### PR TITLE
Move grid-specific functionality to grid folder and add tests

### DIFF
--- a/public/manifest.webapp
+++ b/public/manifest.webapp
@@ -16,5 +16,5 @@
   "developer": {
     "name": "DHIS2"
   },
-  "manifest_generated_at": "Thu Oct 05 2017 12:10:04 GMT+0200 (CEST)"
+  "manifest_generated_at": "Wed Nov 08 2017 11:07:53 GMT+0100 (CET)"
 }

--- a/src/DashboardItemGrid/DashboardItemGrid.js
+++ b/src/DashboardItemGrid/DashboardItemGrid.js
@@ -70,9 +70,6 @@ export class DashboardItemGrid extends Component {
 
         const pluginItems = dashboardItems.map((item, index) => Object.assign({}, item, { i: `${index}` }));
 
-        console.log('jj pluginItems', pluginItems);
-        
-
         return (
             <div style={{ margin: '10px' }}>
                 <ReactGridLayout

--- a/src/DashboardItemGrid/DashboardItemGrid.js
+++ b/src/DashboardItemGrid/DashboardItemGrid.js
@@ -7,6 +7,8 @@ import 'react-grid-layout/css/styles.css';
 
 import './DashboardItemGrid.css';
 
+import { gridColumns, gridRowHeight } from './gridUtil';
+
 import * as fromReducers from '../reducers';
 
 const { fromSelectedDashboard } = fromReducers;
@@ -62,12 +64,14 @@ export class DashboardItemGrid extends Component {
 
     render() {
         const { dashboardItems } = this.props;
-console.log("dashboardItems", dashboardItems);
         if (!dashboardItems.length) {
             return (<div style={{ padding: 50 }}>No items</div>);
         }
 
         const pluginItems = dashboardItems.map((item, index) => Object.assign({}, item, { i: `${index}` }));
+
+        console.log('jj pluginItems', pluginItems);
+        
 
         return (
             <div style={{ margin: '10px' }}>
@@ -75,8 +79,8 @@ console.log("dashboardItems", dashboardItems);
                     onLayoutChange={(a, b, c) => console.log(a, b, c)}
                     className="layout"
                     layout={pluginItems}
-                    cols={30}
-                    rowHeight={30}
+                    cols={gridColumns}
+                    rowHeight={gridRowHeight}
                     width={window.innerWidth}
                 >
                     {pluginItems.map((item => (

--- a/src/DashboardItemGrid/__tests__/gridUtil.spec.js
+++ b/src/DashboardItemGrid/__tests__/gridUtil.spec.js
@@ -1,0 +1,33 @@
+import { hasShape, getShape } from '../gridUtil';
+
+describe('gridUtil', () => {
+    describe('getShape', () => {
+        it('should get the position and size properties of the first grid block', () => {
+            expect(getShape(0)).toEqual({x: 0, y: 0, w: 9, h: 10});
+        });
+
+        it('should get the position and size properties of the eighth grid block', () => {
+            expect(getShape(7)).toEqual({ x: 9, y: 20, w: 9, h: 10 });
+        });
+
+        it('should throw an error when the grid block number is invalid', () => {
+            expect(() => {
+                getShape('octopus');
+            }).toThrow('Invalid grid block number');
+        });
+    });
+
+    describe('hasShape', () => {
+        it('should return true if grid block object has correct properties', () => {
+            expect(hasShape({ x: 9, y: 20, w: 9, h: 10 })).toBeTruthy();
+        });
+
+        it('should return false if grid block object is missing properties', () => {
+            expect(hasShape({ x: 9, y: 20, w: 9 })).toBeFalsy();
+        });
+
+        it('should return false if grid block object has invalid properties', () => {
+            expect(hasShape({ x: 9, y: 20, w: 9, h: 'octopus' })).toBeFalsy();
+        });
+    });
+});

--- a/src/DashboardItemGrid/gridUtil.js
+++ b/src/DashboardItemGrid/gridUtil.js
@@ -1,0 +1,34 @@
+const isNonNegativeInteger = x => Number.isInteger(x) && x >= 0;
+
+// Does the item have all the shape properties?
+export const hasShape = item => 
+    isNonNegativeInteger(item.x) && 
+    isNonNegativeInteger(item.y) &&
+    isNonNegativeInteger(item.w) && 
+    isNonNegativeInteger(item.h);
+
+//Dimensions for the react-grid-layout
+export const gridColumns = 30;
+export const gridRowHeight = 30;
+
+// returns a rectangular grid block dimensioned with x, y, w, h in grid units.
+// based on a grid with 3 items across
+export const getShape = (i) => {
+    if (!isNonNegativeInteger(i)) {
+        throw new Error('Invalid grid block number');
+    }
+
+    const numberOfCols = 3;
+    const itemWidth = (gridColumns / numberOfCols) - 1;
+    const itemHeight = gridRowHeight / 3;
+
+    const col = i % numberOfCols;
+    const row = Math.floor(i / numberOfCols);
+
+    return {
+        x: col * itemWidth,
+        y: row * itemHeight,
+        w: itemWidth,
+        h: itemHeight,
+    };
+};

--- a/src/DashboardItemGrid/gridUtil.js
+++ b/src/DashboardItemGrid/gridUtil.js
@@ -19,11 +19,11 @@ export const getShape = (i) => {
     }
 
     const numberOfCols = 3;
-    const itemWidth = (gridColumns / numberOfCols) - 1;
-    const itemHeight = gridRowHeight / 3;
-
+    
     const col = i % numberOfCols;
     const row = Math.floor(i / numberOfCols);
+    const itemWidth = Math.floor((gridColumns - 1) / numberOfCols);
+    const itemHeight = gridRowHeight / 3;
 
     return {
         x: col * itemWidth,

--- a/src/__tests__/util.spec.js
+++ b/src/__tests__/util.spec.js
@@ -1,0 +1,22 @@
+import { arrayGetById, validateReducer } from '../util';
+
+describe('util', () => {
+    describe('validateReducer', () => {
+        it('should return the given value when it is defined and not null', () => {
+            const result = validateReducer('42', 'default val');
+            expect(result).toEqual('42');
+        });
+
+        it('should return the default value if the given value is undefined', () => {
+            let undefVal;
+            const result = validateReducer(undefVal, 'default val');
+            expect(result).toEqual('default val');
+        });
+
+        it('should return the default value if the given value is null', () => {
+            const nullVal = null;
+            const result = validateReducer(nullVal, 'default val');
+            expect(result).toEqual('default val');
+        });
+    });
+});

--- a/src/__tests__/util.spec.js
+++ b/src/__tests__/util.spec.js
@@ -3,8 +3,9 @@ import { validateReducer } from '../util';
 describe('util', () => {
     describe('validateReducer', () => {
         it('should return the given value when it is defined and not null', () => {
-            const result = validateReducer('42', 'default val');
-            expect(result).toEqual('42');
+            const givenVal = '42';
+            const result = validateReducer(givenVal, 'default val');
+            expect(result).toEqual(givenVal);
         });
 
         it('should return the default value if the given value is undefined', () => {

--- a/src/__tests__/util.spec.js
+++ b/src/__tests__/util.spec.js
@@ -1,4 +1,4 @@
-import { arrayGetById, validateReducer } from '../util';
+import { validateReducer } from '../util';
 
 describe('util', () => {
     describe('validateReducer', () => {

--- a/src/reducers/__tests__/selectedDashboard.spec.js
+++ b/src/reducers/__tests__/selectedDashboard.spec.js
@@ -50,16 +50,5 @@ describe('selected dashboard reducer', () => {
             const actual = sGetSelectedDashboardItems(state);
             expect(actual).toEqual([]);
         });
-
-        // export const uGetTransformedItems = items => items.map((item, index) => (hasShape(item) ? item : Object.assign({}, item, getShape(index))));
-        // it('should get the selected dashboard items', () => {
-        //     const items = {
-        //         'item0': {x: 1, y: 1, w: 4, h: 4},
-        //         'item2': {x: 6, y: 6, w: 5, h: 5},
-        //     };
-
-        //     const actual = uGetTransformedItems(items);
-        //     expect(actual).toEqual(dash.dashboardItems);
-        // });
     });
 });

--- a/src/reducers/selectedDashboard.js
+++ b/src/reducers/selectedDashboard.js
@@ -1,4 +1,5 @@
-import { validateReducer, hasShape, getShape } from '../util';
+import { validateReducer } from '../util';
+import { hasShape, getShape } from '../DashboardItemGrid/gridUtil';
 
 export const actionTypes = {
     SET_SELECTEDDASHBOARD: 'SET_SELECTEDDASHBOARD',

--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,3 @@
-import isNumber from 'd2-utilizr/lib/isNumber';
-
 // array
 export function arrayGetById(array, id) {
     return array.find(item => item.id === id);
@@ -19,22 +17,3 @@ export function getDate() {
 
 // reducer validator
 export const validateReducer = (value, defaultValue) => (value === undefined || value === null ? defaultValue : value);
-
-// shape
-export const hasShape = item => isNumber(item.x) && isNumber(item.y) && isNumber(item.w) && isNumber(item.h);
-
-export const getShape = (i) => {
-    const numberOfCols = 3;
-    const itemWidth = 9;
-    const itemHeight = 10;
-
-    const col = i % numberOfCols;
-    const row = Math.floor(i / numberOfCols);
-
-    return {
-        x: col * itemWidth,
-        y: row * itemHeight,
-        w: itemWidth,
-        h: itemHeight,
-    };
-};


### PR DESCRIPTION
"Magic" numbers related to the grid have all been moved into gridUtil, instead of being split between the GridItem component and the old util module.