### PR TITLE
Create functions only once to reduce re-rendering

### DIFF
--- a/src/ItemGrid/ItemGrid.js
+++ b/src/ItemGrid/ItemGrid.js
@@ -141,6 +141,27 @@ ItemGrid.defaultProps = {
 
 const currentItemTypeMap = {}; //TODO: improve
 
+const onButtonClick = (id, type, targetType) => {
+    const plugin = getPluginByType(targetType);
+
+    apiFetchFavorite(id, type).then(favorite => {
+        const itemConfig = getPluginItemConfig(favorite, true);
+
+        plugin.load(itemConfig);
+
+        currentItemTypeMap[id] = targetType;
+    });
+};
+
+const onItemResize = id => {
+    if (
+        [undefined, 'CHART', 'EVENT_CHART'].indexOf(currentItemTypeMap[id]) !==
+        -1
+    ) {
+        onPluginItemResize(id);
+    }
+};
+
 const mapStateToProps = state => {
     const { sGetSelectedDashboard } = fromReducers;
     const { sGetSelectedIsLoading, sGetSelectedEdit } = fromSelected;
@@ -152,26 +173,8 @@ const mapStateToProps = state => {
         dashboardItems,
         isLoading: sGetSelectedIsLoading(state),
         edit: sGetSelectedEdit(state),
-        onButtonClick: (id, type, targetType) => {
-            const plugin = getPluginByType(targetType);
-
-            apiFetchFavorite(id, type).then(favorite => {
-                const itemConfig = getPluginItemConfig(favorite, true);
-
-                plugin.load(itemConfig);
-
-                currentItemTypeMap[id] = targetType;
-            });
-        },
-        onItemResize: id => {
-            if (
-                [undefined, 'CHART', 'EVENT_CHART'].indexOf(
-                    currentItemTypeMap[id]
-                ) !== -1
-            ) {
-                onPluginItemResize(id);
-            }
-        },
+        onButtonClick,
+        onItemResize,
     };
 };
 


### PR DESCRIPTION
ItemGrid was rerendering with every action because the onButtonClick and onItemResize were new functions in the new props and therefore not equal to the functions in the existing props (shallow compare).

By pulling them out of mapStateToProps and creating them only once on mounting the component, ItemGrid no longer re-renders as much unnecessarily
  