### PR TITLE
Add initial style guide

### DIFF
--- a/src/styleGuide.js
+++ b/src/styleGuide.js
@@ -1,0 +1,17 @@
+const accentLightGreen = '#48A999';
+const black = 'rgba(0,0,0,0.87)';
+const charcoalGrey = '#8C8C8C';
+const darkGrey = '#494949';
+const lightGrey = '#ECEFF1';
+const mediumGrey = '#393939';
+const red = '#E53935';
+
+export const colors = {
+    accentLightGreen,
+    black,
+    charcoalGrey,
+    darkGrey,
+    lightGrey,
+    mediumGrey,
+    red,
+};


### PR DESCRIPTION
I was thinking that we can store the color codes in one place. If we agree on this concept, it might be that it gets moved to d2-ui, or its own repo.