### PR TITLE
Rename ItemGrid method for toggling griditem height

### DIFF
--- a/src/Item/Item.js
+++ b/src/Item/Item.js
@@ -26,7 +26,7 @@ export const Item = props => {
         <GridItem
             item={props.item}
             editMode={props.editMode}
-            onToggleItemFooter={props.onToggleItemFooter}
+            onToggleItemExpanded={props.onToggleItemExpanded}
         />
     );
 };

--- a/src/Item/PluginItem/Item.js
+++ b/src/Item/PluginItem/Item.js
@@ -70,7 +70,7 @@ class Item extends Component {
 
     onToggleInterpretations = () => {
         this.setState({ showInterpretations: !this.state.showInterpretations });
-        this.props.onToggleItemFooter(this.props.item.id);
+        this.props.onToggleItemExpanded(this.props.item.id);
     };
 
     render() {

--- a/src/ItemGrid/ItemGrid.js
+++ b/src/ItemGrid/ItemGrid.js
@@ -43,7 +43,7 @@ export class ItemGrid extends Component {
 
     NO_ITEMS_MESSAGE = 'You have not added any items';
 
-    onToggleItemFooter = clickedId => {
+    onToggleItemExpanded = clickedId => {
         const isExpanded =
             typeof this.state.expandedItems[clickedId] === 'boolean'
                 ? this.state.expandedItems[clickedId]
@@ -106,7 +106,9 @@ export class ItemGrid extends Component {
                                 <Item
                                     item={item}
                                     editMode={edit}
-                                    onToggleItemFooter={this.onToggleItemFooter}
+                                    onToggleItemExpanded={
+                                        this.onToggleItemExpanded
+                                    }
                                 />
                             </div>
                         );


### PR DESCRIPTION
The item grid doesn't care what an "ItemFooter" is. It does care about when grid items are vertically expanded.