### PR TITLE
feature/control-bar-height

### DIFF
--- a/src/ControlBarContainer/ControlBarContainer.js
+++ b/src/ControlBarContainer/ControlBarContainer.js
@@ -65,11 +65,17 @@ const ControlBarComponent = ({
         { height: getInnerHeight(isExpanded, rows) }
     );
 
+    const controlBarHeight = getOuterHeight(
+        edit ? false : isExpanded,
+        edit ? 1 : rows
+    );
+
     return (
         <ControlBar
-            height={getOuterHeight(isExpanded, rows)}
+            height={controlBarHeight}
             onChangeHeight={onChangeHeight}
             editMode={edit}
+            expandable={!edit}
         >
             <div style={contentWrapperStyle}>
                 <div style={styles.leftControls}>
@@ -132,6 +138,7 @@ const ControlBarComponent = ({
                         color: blue800,
                         textTransform: 'uppercase',
                         cursor: 'pointer',
+                        visibility: edit ? 'hidden' : 'visible',
                     }}
                 >
                     {isExpanded ? 'Show less' : 'Show more'}

--- a/src/PageContainer/PageContainer.js
+++ b/src/PageContainer/PageContainer.js
@@ -3,8 +3,10 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import { CONTROL_BAR_ROW_HEIGHT } from '../ControlBarContainer/ControlBarContainer';
+import { sGetSelectedEdit } from '../reducers/selected';
+import { sGetControlBarRows } from '../reducers/controlBar';
 
-const TOP_MARGIN = 80;
+const DEFAULT_TOP_MARGIN = 80;
 
 const DynamicTopMarginContainer = ({ marginTop, children }) => (
     <div className="dashboard-wrapper" style={{ marginTop }}>
@@ -12,8 +14,14 @@ const DynamicTopMarginContainer = ({ marginTop, children }) => (
     </div>
 );
 
-const mapStateToProps = state => ({
-    marginTop: state.controlBar.rows * CONTROL_BAR_ROW_HEIGHT + TOP_MARGIN,
-});
+const mapStateToProps = state => {
+    const edit = sGetSelectedEdit(state);
+    const rows = sGetControlBarRows(state);
+
+    return {
+        marginTop:
+            DEFAULT_TOP_MARGIN + CONTROL_BAR_ROW_HEIGHT * (edit ? 1 : rows),
+    };
+};
 
 export default connect(mapStateToProps)(DynamicTopMarginContainer);

--- a/src/reducers/controlBar.js
+++ b/src/reducers/controlBar.js
@@ -49,5 +49,5 @@ export const sGetFromState = state => state.controlBar;
 
 // Selector dependency level 2
 
-export const sGetRows = state => sGetFromState(state).rows;
-export const sGetExpanded = state => sGetFromState(state).expanded;
+export const sGetControlBarRows = state => sGetFromState(state).rows;
+export const sGetControlBarExpanded = state => sGetFromState(state).expanded;


### PR DESCRIPTION
- Makes sure the height of the control-bar and the top-margin of the dashboard-wrapper are set correctly when toggling edit mode.

- The height prop in the store is not touched, so if the user has set it to e.g. 3 rows by default it will render as 1 row in edit mode but go back to 3 rows when exiting.

- Control-bar draggability is switched off in edit mode.