### PR TITLE
Render a placeholder Item component for not supported types

### DIFF
--- a/src/Item/Item.js
+++ b/src/Item/Item.js
@@ -2,10 +2,12 @@ import React from 'react';
 
 import PluginItem from './PluginItem/Item';
 import MessagesItem from './MessagesItem/Item';
+import NotSupportedItem from './NotSupportedItem/Item';
 
 const Items = {
     PluginItem,
     MessagesItem,
+    NotSupportedItem,
 };
 
 export const Item = props => {
@@ -13,12 +15,16 @@ export const Item = props => {
     switch (props.item.type) {
         case 'CHART':
         case 'REPORT_TABLE':
+        case 'MAP':
+        case 'EVENT_CHART':
+        case 'EVENT_REPORT':
             GridItem = Items.PluginItem;
             break;
         case 'MESSAGES':
             GridItem = Items.MessagesItem;
             break;
         default:
+            GridItem = Items.NotSupportedItem;
             break;
     }
 

--- a/src/Item/Item.js
+++ b/src/Item/Item.js
@@ -4,12 +4,6 @@ import PluginItem from './PluginItem/Item';
 import MessagesItem from './MessagesItem/Item';
 import NotSupportedItem from './NotSupportedItem/Item';
 
-const Items = {
-    PluginItem,
-    MessagesItem,
-    NotSupportedItem,
-};
-
 export const Item = props => {
     let GridItem = null;
     switch (props.item.type) {
@@ -18,13 +12,13 @@ export const Item = props => {
         case 'MAP':
         case 'EVENT_CHART':
         case 'EVENT_REPORT':
-            GridItem = Items.PluginItem;
+            GridItem = PluginItem;
             break;
         case 'MESSAGES':
-            GridItem = Items.MessagesItem;
+            GridItem = MessagesItem;
             break;
         default:
-            GridItem = Items.NotSupportedItem;
+            GridItem = NotSupportedItem;
             break;
     }
 

--- a/src/Item/NotSupportedItem/Item.js
+++ b/src/Item/NotSupportedItem/Item.js
@@ -4,7 +4,7 @@ import SvgIcon from 'd2-ui/lib/svg-icon/SvgIcon';
 
 const NotSupportedItem = props => (
     <Fragment>
-        <ItemHeader title={`Not supported item type: ${props.item.type}`} />
+        <ItemHeader title={`Item type not supported: ${props.item.type}`} />
         <div
             style={{
                 display: 'flex',

--- a/src/Item/NotSupportedItem/Item.js
+++ b/src/Item/NotSupportedItem/Item.js
@@ -1,0 +1,25 @@
+import React, { Fragment } from 'react';
+import ItemHeader from '../ItemHeader';
+import SvgIcon from 'd2-ui/lib/svg-icon/SvgIcon';
+
+const NotSupportedItem = props => (
+    <Fragment>
+        <ItemHeader title={`Not supported item type: ${props.item.type}`} />
+        <div
+            style={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                height: '90%',
+            }}
+        >
+            <SvgIcon
+                icon="NotInterested"
+                style={{ width: 100, height: 100, align: 'center' }}
+                disabled
+            />
+        </div>
+    </Fragment>
+);
+
+export default NotSupportedItem;


### PR DESCRIPTION
This is mostly useful during development to avoid the app to break when
some unsupported item type is returned in the API response.