### PR TITLE
Implement the Exit Without Saving button

### DIFF
--- a/src/ControlBarContainer/EditBar.js
+++ b/src/ControlBarContainer/EditBar.js
@@ -1,12 +1,16 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import ControlBar from 'd2-ui/lib/controlbar/ControlBar';
+import Button from 'd2-ui/lib/button/Button';
+
+import { fromSelected, fromEditDashboard } from '../actions';
 
 import {
     CONTROL_BAR_OUTER_HEIGHT_DIFF,
     CONTROL_BAR_ROW_HEIGHT,
 } from './ControlBarContainer';
 
-const EditBar = ({ style, onNewClick }) => {
+const EditBar = ({ style, onSaveChanges, onDiscardChanges }) => {
     const controlBarHeight =
         CONTROL_BAR_OUTER_HEIGHT_DIFF + CONTROL_BAR_ROW_HEIGHT;
 
@@ -18,14 +22,32 @@ const EditBar = ({ style, onNewClick }) => {
         >
             <div style={{ height: CONTROL_BAR_ROW_HEIGHT }}>
                 <div style={style.leftControls}>
-                    <div>Save changes</div>
+                    <Button color="primary" onClick={onSaveChanges}>
+                        Save Changes
+                    </Button>
                 </div>
                 <div style={style.rightControls}>
-                    <div>Exit without saving</div>
+                    <Button color="default" onClick={onDiscardChanges}>
+                        Exit without saving
+                    </Button>
                 </div>
             </div>
         </ControlBar>
     );
 };
 
-export default EditBar;
+const mapDispatchToProps = dispatch => {
+    return {
+        onSaveChanges: () => {
+            console.log('not implemented yet');
+        },
+        onDiscardChanges: () => {
+            dispatch(fromSelected.acSetSelectedEdit(false));
+            dispatch(fromEditDashboard.acSetEditDashboard({}));
+        },
+    };
+};
+
+const EditBarCt = connect(null, mapDispatchToProps)(EditBar);
+
+export default EditBarCt;


### PR DESCRIPTION
The button will set the edit property to false, and reset the editDashboard object to an empty object