### PR TITLE
Move List item content delete icon next to resource name

### DIFF
--- a/src/Item/ListItem/Item.js
+++ b/src/Item/ListItem/Item.js
@@ -5,6 +5,7 @@ import { List, ListItem as MUIListItem } from 'material-ui/List';
 import IconButton from 'material-ui/IconButton';
 import SvgIcon from 'd2-ui/lib/svg-icon/SvgIcon';
 import ItemHeader from '../ItemHeader';
+import Line from '../../widgets/Line';
 import { REPORTS, RESOURCES, USERS, itemTypeMap, orArray } from '../../util';
 import { tRemoveListItemContent } from './actions';
 import { colors } from '../../colors';
@@ -50,8 +51,6 @@ const ListItem = (props, context) => {
     const contentItems = getContentItems(item);
 
     const primaryText = contentItem => {
-        console.log('contentItem', contentItem);
-
         const deleteButton = (
             <IconButton
                 style={{
@@ -89,6 +88,7 @@ const ListItem = (props, context) => {
     return (
         <Fragment>
             <ItemHeader title={getItemTitle(item)} />
+            <Line />
             <List className="dashboard-item-content">
                 {contentItems.map(contentItem => (
                     <MUIListItem

--- a/src/Item/ListItem/Item.js
+++ b/src/Item/ListItem/Item.js
@@ -2,11 +2,13 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { List, ListItem as MUIListItem } from 'material-ui/List';
-import Button from 'd2-ui/lib/button/Button';
+// import Button from 'd2-ui/lib/button/Button';
+import IconButton from 'material-ui/IconButton';
 import SvgIcon from 'd2-ui/lib/svg-icon/SvgIcon';
 import ItemHeader from '../ItemHeader';
 import { REPORTS, RESOURCES, USERS, itemTypeMap, orArray } from '../../util';
 import { tRemoveListItemContent } from './actions';
+import { colors } from '../../colors';
 
 const getItemTitle = item => {
     return itemTypeMap[item.type].pluralTitle;
@@ -39,6 +41,8 @@ const getLink = (item, id, context) => {
 };
 
 const removeContent = (handler, item, contentToRemove) => () => {
+    console.log('removeContent', item, contentToRemove);
+
     handler(item, contentToRemove);
 };
 
@@ -48,6 +52,41 @@ const ListItem = (props, context) => {
     // avoid showing duplicates
     const contentItems = getContentItems(item);
 
+    const primaryText = contentItem => {
+        const deleteButton = (
+            <IconButton
+                style={{
+                    verticalAlign: 'text-bottom',
+                    height: '32px',
+                }}
+                iconStyle={{
+                    width: 20,
+                    height: 20,
+                    fill: colors.red,
+                }}
+                onClick={removeContent(
+                    tRemoveListItemContent,
+                    item,
+                    contentItem
+                )}
+            >
+                <SvgIcon icon="Delete" />
+            </IconButton>
+        );
+
+        return (
+            <div>
+                <a
+                    style={{ textDecoration: 'none' }}
+                    href={getLink(item, contentItem.id, context)}
+                >
+                    {contentItem.name}
+                </a>
+                {editMode ? deleteButton : null}
+            </div>
+        );
+    };
+
     return (
         <Fragment>
             <ItemHeader title={getItemTitle(item)} />
@@ -55,27 +94,7 @@ const ListItem = (props, context) => {
                 {contentItems.map(contentItem => (
                     <MUIListItem
                         key={contentItem.id}
-                        primaryText={
-                            <a
-                                style={{ textDecoration: 'none' }}
-                                href={getLink(item, contentItem.id, context)}
-                            >
-                                {contentItem.name}
-                            </a>
-                        }
-                        rightIconButton={
-                            editMode ? (
-                                <Button
-                                    onClick={removeContent(
-                                        tRemoveListItemContent,
-                                        item,
-                                        contentItem
-                                    )}
-                                >
-                                    <SvgIcon icon="Delete" />
-                                </Button>
-                            ) : null
-                        }
+                        primaryText={primaryText(contentItem)}
                     />
                 ))}
             </List>

--- a/src/Item/ListItem/Item.js
+++ b/src/Item/ListItem/Item.js
@@ -2,7 +2,6 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { List, ListItem as MUIListItem } from 'material-ui/List';
-// import Button from 'd2-ui/lib/button/Button';
 import IconButton from 'material-ui/IconButton';
 import SvgIcon from 'd2-ui/lib/svg-icon/SvgIcon';
 import ItemHeader from '../ItemHeader';
@@ -41,8 +40,6 @@ const getLink = (item, id, context) => {
 };
 
 const removeContent = (handler, item, contentToRemove) => () => {
-    console.log('removeContent', item, contentToRemove);
-
     handler(item, contentToRemove);
 };
 
@@ -53,6 +50,8 @@ const ListItem = (props, context) => {
     const contentItems = getContentItems(item);
 
     const primaryText = contentItem => {
+        console.log('contentItem', contentItem);
+
         const deleteButton = (
             <IconButton
                 style={{

--- a/src/Item/MessagesItem/Item.js
+++ b/src/Item/MessagesItem/Item.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 
 import ItemHeader from '../ItemHeader';
 import { fromMessages } from '../../reducers';
+import Line from '../../widgets/Line';
 import { colors } from '../../colors';
 import { formatDate, sortByDate } from '../../util';
 
@@ -37,12 +38,6 @@ const style = {
         fontSize: '12px',
         lineHeight: '14px',
         textAlign: 'right',
-    },
-    line: {
-        backgroundColor: `${colors.lightGrey}`,
-        border: 'none',
-        height: '1px',
-        margin: '0px 0px 5px 0px',
     },
     list: {
         listStyleType: 'none',
@@ -155,7 +150,7 @@ class MessagesItem extends Component {
         return (
             <Fragment>
                 <ItemHeader title="Messages" actionButtons={actionButtons} />
-                <hr style={style.line} />
+                <Line />
                 <div className="dashboard-item-content">
                     <ul style={style.list}>{messageItems}</ul>
                 </div>

--- a/src/widgets/Line.js
+++ b/src/widgets/Line.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { colors } from '../colors';
+
+const style = {
+    backgroundColor: `${colors.lightGrey}`,
+    border: 'none',
+    height: '1px',
+    margin: '0px 0px 5px 0px',
+};
+
+const Line = props => <hr style={style} />;
+
+export default Line;


### PR DESCRIPTION
The reason for moving the icon to be just to the right of the resource name is so that it isn't so close to the delete icon for the entire item. Also, made it smaller to further distinguish it from the Item delete button. A horizontal line was also added to separate the header from the content area of the item, similar to the messages type.

Some refactoring of all the different ways we are currently doing icon "buttons" is needed.