### PR TITLE
Set the control bar height to be same in edit and view mode

### DIFF
--- a/src/ControlBarContainer/ControlBarContainer.js
+++ b/src/ControlBarContainer/ControlBarContainer.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import { END_FLAP_HEIGHT } from 'd2-ui/lib/controlbar/ControlBar';
 
 import EditBar from './EditBar';
 import DashboardsBar from './DashboardsBar';
@@ -38,3 +39,13 @@ export default ControlBarCt;
 
 export const CONTROL_BAR_ROW_HEIGHT = 36;
 export const CONTROL_BAR_OUTER_HEIGHT_DIFF = 24;
+
+export const getInnerHeight = rows => {
+    return rows * CONTROL_BAR_ROW_HEIGHT;
+};
+
+export const getOuterHeight = (rows, includeFlapHeight = false) => {
+    const flapHeight = includeFlapHeight ? END_FLAP_HEIGHT : 0;
+
+    return getInnerHeight(rows) + CONTROL_BAR_OUTER_HEIGHT_DIFF + flapHeight;
+};

--- a/src/ControlBarContainer/ControlBarContainer.js
+++ b/src/ControlBarContainer/ControlBarContainer.js
@@ -44,8 +44,8 @@ export const getInnerHeight = rows => {
     return rows * CONTROL_BAR_ROW_HEIGHT;
 };
 
-export const getOuterHeight = (rows, includeFlapHeight = false) => {
-    const flapHeight = includeFlapHeight ? END_FLAP_HEIGHT : 0;
+export const getOuterHeight = (rows, expandable) => {
+    const flapHeight = !expandable ? END_FLAP_HEIGHT : 0;
 
     return getInnerHeight(rows) + CONTROL_BAR_OUTER_HEIGHT_DIFF + flapHeight;
 };

--- a/src/ControlBarContainer/DashboardsBar.js
+++ b/src/ControlBarContainer/DashboardsBar.js
@@ -8,8 +8,9 @@ import Chip from 'd2-ui/lib/chip/Chip';
 import D2IconButton from '../widgets/D2IconButton';
 import Filter from './Filter';
 import {
-    CONTROL_BAR_OUTER_HEIGHT_DIFF,
     CONTROL_BAR_ROW_HEIGHT,
+    getInnerHeight,
+    getOuterHeight,
 } from './ControlBarContainer';
 
 import * as fromActions from '../actions';
@@ -29,12 +30,6 @@ const dashboardBarStyles = {
 
 const EXPANDED_ROW_COUNT = 10;
 
-const getInnerHeight = (isExpanded, rows) =>
-    (isExpanded ? EXPANDED_ROW_COUNT : rows) * CONTROL_BAR_ROW_HEIGHT;
-
-const getOuterHeight = (isExpanded, rows) =>
-    getInnerHeight(isExpanded, rows) + CONTROL_BAR_OUTER_HEIGHT_DIFF;
-
 const onDashboardSelectWrapper = (id, onClick) => () => id && onClick(id);
 
 const DashboardsBar = ({
@@ -51,14 +46,15 @@ const DashboardsBar = ({
     onDashboardSelect,
 }) => {
     const style = Object.assign({}, controlsStyle, dashboardBarStyles);
+    const rowCount = isExpanded ? EXPANDED_ROW_COUNT : rows;
     const contentWrapperStyle = Object.assign(
         {},
         dashboardBarStyles.scrollWrapper,
         { overflowY: isExpanded ? 'auto' : 'hidden' },
-        { height: getInnerHeight(isExpanded, rows) }
+        { height: getInnerHeight(rowCount) }
     );
 
-    const controlBarHeight = getOuterHeight(isExpanded, rows);
+    const controlBarHeight = getOuterHeight(rowCount);
 
     return (
         <ControlBar

--- a/src/ControlBarContainer/DashboardsBar.js
+++ b/src/ControlBarContainer/DashboardsBar.js
@@ -54,7 +54,7 @@ const DashboardsBar = ({
         { height: getInnerHeight(rowCount) }
     );
 
-    const controlBarHeight = getOuterHeight(rowCount);
+    const controlBarHeight = getOuterHeight(rowCount, true);
 
     return (
         <ControlBar

--- a/src/ControlBarContainer/EditBar.js
+++ b/src/ControlBarContainer/EditBar.js
@@ -5,14 +5,10 @@ import Button from 'd2-ui/lib/button/Button';
 
 import { fromSelected, fromEditDashboard } from '../actions';
 
-import {
-    CONTROL_BAR_OUTER_HEIGHT_DIFF,
-    CONTROL_BAR_ROW_HEIGHT,
-} from './ControlBarContainer';
+import { CONTROL_BAR_ROW_HEIGHT, getOuterHeight } from './ControlBarContainer';
 
 const EditBar = ({ style, onSaveChanges, onDiscardChanges }) => {
-    const controlBarHeight =
-        CONTROL_BAR_OUTER_HEIGHT_DIFF + CONTROL_BAR_ROW_HEIGHT;
+    const controlBarHeight = getOuterHeight(1, true);
 
     return (
         <ControlBar

--- a/src/ControlBarContainer/EditBar.js
+++ b/src/ControlBarContainer/EditBar.js
@@ -8,7 +8,7 @@ import { fromSelected, fromEditDashboard } from '../actions';
 import { CONTROL_BAR_ROW_HEIGHT, getOuterHeight } from './ControlBarContainer';
 
 const EditBar = ({ style, onSaveChanges, onDiscardChanges }) => {
-    const controlBarHeight = getOuterHeight(1, true);
+    const controlBarHeight = getOuterHeight(1, false);
 
     return (
         <ControlBar


### PR DESCRIPTION
When the controlbar is expandable, some padding is added to the height to allow for the "pull-down flap". If the controlbar is not expandable, as in edit mode, then that extra padding needs to be manually added to the controlbar height.