### PR TITLE
feature/star-dashboard

### DIFF
--- a/src/Item/PluginItem/plugin.js
+++ b/src/Item/PluginItem/plugin.js
@@ -1,6 +1,6 @@
-import { apiFetchFavorite } from '../../api';
-import { getGridItemDomId } from '../../ItemGrid/gridUtil';
 import isObject from 'd2-utilizr/lib/isObject';
+import { apiFetchFavorite } from '../../api/dashboards';
+import { getGridItemDomId } from '../../ItemGrid/gridUtil';
 import {
     REPORT_TABLE,
     CHART,

--- a/src/TitleBar/Info.js
+++ b/src/TitleBar/Info.js
@@ -1,12 +1,6 @@
 import React, { Component } from 'react';
 import SvgIcon from 'd2-ui/lib/svg-icon/SvgIcon';
 
-const styles = {
-    info: {
-        cursor: 'pointer',
-    },
-};
-
 class Info extends Component {
     show = false;
 
@@ -17,10 +11,7 @@ class Info extends Component {
 
     render() {
         return (
-            <div
-                style={styles.info}
-                onClick={() => this.props.onClick(this.toggle())}
-            >
+            <div onClick={() => this.props.onClick(this.toggle())}>
                 <SvgIcon icon={'InfoOutline'} />
             </div>
         );

--- a/src/TitleBar/ViewTitleBar.js
+++ b/src/TitleBar/ViewTitleBar.js
@@ -121,12 +121,12 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
             dispatch(fromSelected.acSetSelectedEdit(true));
             dispatch(fromEditDashboard.acSetEditDashboard(selectedDashboard));
         },
-        onInfoClick: () =>
-            dispatch(
-                fromSelected.acSetSelectedShowDescription(
-                    !stateProps.showDescription
-                )
-            ),
+        onInfoClick: eventHandlerWrapper(
+            dispatch,
+            fromSelected.acSetSelectedShowDescription(
+                !stateProps.showDescription
+            )
+        ),
     };
 };
 

--- a/src/TitleBar/ViewTitleBar.js
+++ b/src/TitleBar/ViewTitleBar.js
@@ -7,7 +7,8 @@ import Info from './Info';
 import D2TextLink from '../widgets/D2TextLink';
 import * as fromReducers from '../reducers';
 import { fromEditDashboard, fromSelected } from '../actions';
-import { orObject } from '../util';
+import { orObject, eventHandlerWrapper } from '../util';
+import { tStarDashboard } from '../actions/dashboards';
 
 const NO_DESCRIPTION = 'No description';
 
@@ -24,6 +25,7 @@ const viewStyle = {
         marginLeft: 5,
         position: 'relative',
         top: 1,
+        cursor: 'pointer',
     },
     titleBarLink: {
         marginLeft: 20,
@@ -39,6 +41,7 @@ const ViewTitleBar = ({
     style,
     showDescription,
     starred,
+    onStarClick,
     onEditClick,
     onInfoClick,
 }) => {
@@ -51,7 +54,7 @@ const ViewTitleBar = ({
                     <div style={{ userSelect: 'text' }}>{name}</div>
                 </div>
                 <div style={{ display: 'flex', alignItems: 'center' }}>
-                    <div style={styles.titleBarIcon}>
+                    <div style={styles.titleBarIcon} onClick={onStarClick}>
                         <SvgIcon icon={starred ? 'Star' : 'StarBorder'} />
                     </div>
                     <div style={styles.titleBarIcon}>
@@ -110,6 +113,10 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     return {
         ...stateProps,
         ...ownProps,
+        onStarClick: eventHandlerWrapper(
+            dispatch,
+            tStarDashboard(selectedDashboard.id, !stateProps.starred)
+        ),
         onEditClick: () => {
             dispatch(fromSelected.acSetSelectedEdit(true));
             dispatch(fromEditDashboard.acSetEditDashboard(selectedDashboard));

--- a/src/actions/dashboards.js
+++ b/src/actions/dashboards.js
@@ -1,6 +1,6 @@
 import { actionTypes } from '../reducers';
 import { getCustomDashboards } from '../reducers/dashboards';
-import { apiFetchDashboards } from '../api';
+import { apiFetchDashboards, apiStarDashboard } from '../api/dashboards';
 import { arrayToIdMap } from '../util';
 
 // actions
@@ -9,6 +9,12 @@ export const acSetDashboards = (dashboards, append) => ({
     type: actionTypes.SET_DASHBOARDS,
     append: !!append,
     value: arrayToIdMap(getCustomDashboards(dashboards)),
+});
+
+export const acStarDashboard = (dashboardId, isStarred) => ({
+    type: actionTypes.STAR_DASHBOARD,
+    dashboardId: dashboardId,
+    value: isStarred,
 });
 
 // thunks
@@ -27,6 +33,27 @@ export const tSetDashboards = () => async (dispatch, getState) => {
     try {
         const collection = await apiFetchDashboards();
         return onSuccess(collection);
+    } catch (err) {
+        return onError(err);
+    }
+};
+
+export const tStarDashboard = (id, isStarred) => async (dispatch, getState) => {
+    const onSuccess = id => {
+        // dispatch(tSetDashboards());
+        // dispatch(tSetSelectedDashboardById(id));
+        dispatch(acStarDashboard(id, isStarred));
+
+        return;
+    };
+
+    const onError = error => {
+        console.log('Error (apiStarDashboard): ', error);
+        return error;
+    };
+    try {
+        await apiStarDashboard(id, isStarred);
+        return onSuccess(id);
     } catch (err) {
         return onError(err);
     }

--- a/src/actions/dashboards.js
+++ b/src/actions/dashboards.js
@@ -40,11 +40,8 @@ export const tSetDashboards = () => async (dispatch, getState) => {
 
 export const tStarDashboard = (id, isStarred) => async (dispatch, getState) => {
     const onSuccess = id => {
-        // dispatch(tSetDashboards());
-        // dispatch(tSetSelectedDashboardById(id));
         dispatch(acStarDashboard(id, isStarred));
-
-        return;
+        return id;
     };
 
     const onError = error => {

--- a/src/actions/selected.js
+++ b/src/actions/selected.js
@@ -1,5 +1,5 @@
 import { actionTypes } from '../reducers';
-import { apiFetchSelected } from '../api';
+import { apiFetchSelected } from '../api/dashboards';
 import { acSetDashboards } from './dashboards';
 import { withShape } from '../ItemGrid/gridUtil';
 import { tGetMessages } from '../Item/MessagesItem/actions';

--- a/src/api/dashboards.js
+++ b/src/api/dashboards.js
@@ -1,0 +1,61 @@
+import { getInstance } from 'd2/lib/d2';
+import arrayClean from 'd2-utilizr/lib/arrayClean';
+import {
+    onError,
+    getEndPointName,
+    getDashboardFields,
+    getFavoriteFields,
+} from './index';
+
+// Get "all" dashboards on startup
+export const apiFetchDashboards = () =>
+    getInstance()
+        .then(d2 =>
+            d2.models.dashboard.list({
+                fields: [
+                    getDashboardFields().join(','),
+                    'dashboardItems[id]',
+                ].join(','),
+                paging: 'false',
+            })
+        )
+        .catch(onError);
+
+// Get more info about selected dashboard
+export const apiFetchSelected = id =>
+    getInstance()
+        .then(d2 =>
+            d2.models.dashboard.get(id, {
+                fields: arrayClean(
+                    getDashboardFields({
+                        withItems: true,
+                        withFavorite: { withDimensions: false },
+                    })
+                ).join(','),
+            })
+        )
+        .catch(onError);
+
+// Get more info about the favorite of a dashboard item
+export const apiFetchFavorite = (id, type) =>
+    getInstance().then(d2 =>
+        d2.Api.getApi().get(
+            `${getEndPointName(type)}/${id}?fields=${getFavoriteFields({
+                withDimensions: true,
+                withOptions: true,
+            })}`
+        )
+    );
+
+// Star dashboard
+export const apiStarDashboard = (id, isStarred) => {
+    const url = `dashboards/${id}/favorite`;
+
+    getInstance().then(d2 => {
+        if (isStarred) {
+            d2.Api.getApi().post(url);
+        } else {
+            d2.Api.getApi().delete(url);
+        }
+    });
+};

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,35 +1,37 @@
-import { getInstance } from 'd2/lib/d2';
 import arrayClean from 'd2-utilizr/lib/arrayClean';
-
 import { itemTypeMap } from '../itemTypes';
 
-export const getUrlByFavoriteType = type => itemTypeMap[type].endPointName;
+// Helper functions
+export const onError = error => console.log('Error: ', error);
 
-const getIdNameFields = ({ rename } = {}) => [
+export const getEndPointName = type => itemTypeMap[type].endPointName;
+
+// Fields
+export const getIdNameFields = ({ rename } = {}) => [
     'id',
     `${rename ? 'displayName~rename(name)' : 'name'}`,
 ];
 
-const getItemFields = () => ['dimensionItem~rename(id)'];
+export const getItemFields = () => ['dimensionItem~rename(id)'];
 
-const getDimensionFields = ({ withItems }) =>
+export const getDimensionFields = ({ withItems }) =>
     arrayClean([
         'dimension',
         withItems ? `items[${getItemFields().join(',')}]` : ``,
     ]);
 
-const getAxesFields = ({ withItems }) => [
+export const getAxesFields = ({ withItems }) => [
     `columns[${getDimensionFields({ withItems }).join(',')}]`,
     `rows[${getDimensionFields({ withItems }).join(',')}]`,
     `filters[${getDimensionFields({ withItems }).join(',')}]`,
 ];
 
-const interpretationFields = () => {
+export const interpretationFields = () => {
     return 'interpretations[id]';
     // return 'interpretations[id,text,created,user[id,displayName],likedBy,comments[id,text,created,user[id,displayName]]]';
 };
 
-const getFavoriteFields = ({ withDimensions, withOptions }) => {
+export const getFavoriteFields = ({ withDimensions, withOptions }) => {
     return arrayClean([
         `${getIdNameFields({ rename: true }).join(',')}`,
         interpretationFields(),
@@ -66,7 +68,7 @@ const getFavoriteFields = ({ withDimensions, withOptions }) => {
     ]);
 };
 
-const getFavoritesFields = ({ withDimensions, withOptions }) => [
+export const getFavoritesFields = ({ withDimensions, withOptions }) => [
     `reportTable[${getFavoriteFields({ withDimensions }).join(',')}]`,
     `chart[${getFavoriteFields({ withDimensions }).join(',')}]`,
     `map[${getFavoriteFields({ withDimensions }).join(',')}]`,
@@ -74,13 +76,13 @@ const getFavoritesFields = ({ withDimensions, withOptions }) => [
     `eventChart[${getFavoriteFields({ withDimensions }).join(',')}]`,
 ];
 
-const getListItemFields = () => [
+export const getListItemFields = () => [
     `reports[${getIdNameFields({ rename: true }).join(',')}]`,
     `resources[${getIdNameFields({ rename: true }).join(',')}]`,
     `users[${getIdNameFields({ rename: true }).join(',')}]`,
 ];
 
-const getDashboardItemsFields = ({ withFavorite } = {}) =>
+export const getDashboardItemsFields = ({ withFavorite } = {}) =>
     arrayClean([
         'id',
         'type',
@@ -99,10 +101,11 @@ const getDashboardItemsFields = ({ withFavorite } = {}) =>
             : ``,
     ]);
 
-const getDashboardFields = ({ withItems, withFavorite } = {}) =>
+export const getDashboardFields = ({ withItems, withFavorite } = {}) =>
     arrayClean([
         `${getIdNameFields({ rename: true }).join(',')}`,
         'description',
+        'favorite',
         `user[${getIdNameFields({ rename: true }).join(',')}]`,
         'created',
         'lastUpdated',
@@ -112,45 +115,3 @@ const getDashboardFields = ({ withItems, withFavorite } = {}) =>
               }).join(',')}]`
             : ``,
     ]);
-
-const onError = error => console.log('Error: ', error);
-
-// Get "all" dashboards on startup
-export const apiFetchDashboards = () =>
-    getInstance()
-        .then(d2 =>
-            d2.models.dashboard.list({
-                fields: [
-                    getDashboardFields().join(','),
-                    'dashboardItems[id]',
-                ].join(','),
-                paging: 'false',
-            })
-        )
-        .catch(onError);
-
-// Get more info about selected dashboard
-export const apiFetchSelected = id =>
-    getInstance()
-        .then(d2 =>
-            d2.models.dashboard.get(id, {
-                fields: arrayClean(
-                    getDashboardFields({
-                        withItems: true,
-                        withFavorite: { withDimensions: false },
-                    })
-                ).join(','),
-            })
-        )
-        .catch(onError);
-
-// Get more info about selected dashboard
-export const apiFetchFavorite = (id, type) =>
-    getInstance().then(d2 =>
-        d2.Api.getApi().get(
-            `${getUrlByFavoriteType(type)}/${id}?fields=${getFavoriteFields({
-                withDimensions: true,
-                withOptions: true,
-            })}`
-        )
-    );

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -5,9 +5,6 @@ import { itemTypeMap } from '../itemTypes';
 
 export const getUrlByFavoriteType = type => itemTypeMap[type].endPointName;
 
-export const delay = (ms = 500) =>
-    new Promise(resolve => setTimeout(resolve, ms));
-
 const getIdNameFields = ({ rename } = {}) => [
     'id',
     `${rename ? 'displayName~rename(name)' : 'name'}`,

--- a/src/reducers/dashboards.js
+++ b/src/reducers/dashboards.js
@@ -10,6 +10,7 @@ import { orArray, orNull, orObject } from '../util';
  */
 export const actionTypes = {
     SET_DASHBOARDS: 'SET_DASHBOARDS',
+    STAR_DASHBOARD: 'STAR_DASHBOARD',
 };
 
 /**
@@ -32,6 +33,15 @@ export default (state = DEFAULT_DASHBOARDS, action) => {
             return {
                 ...(action.append ? orObject(state) : {}),
                 ...action.value,
+            };
+        }
+        case actionTypes.STAR_DASHBOARD: {
+            return {
+                ...state,
+                [action.dashboardId]: {
+                    ...state[action.dashboardId],
+                    starred: action.value,
+                },
             };
         }
         default:
@@ -71,7 +81,7 @@ export const getCustomDashboards = data =>
         id: d.id,
         name: d.name,
         description: d.description,
-        starred: Math.random() > 0.7,
+        starred: d.favorite,
         owner: d.user.name,
         created: d.created
             .split('T')


### PR DESCRIPTION
Implements star/unstar dashboard. Waiting for the post/delete to return - if success, update the "favorite" prop in store.dashboards.

Waiting for success and then updating the store seems to be a better choice than re-running the whole process of getting all dashboards and selecting the one that was starred.
