### PR TITLE
Configure d2 to use a specific api version

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -9,6 +9,7 @@ const InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
 const WatchMissingNodeModulesPlugin = require('react-dev-utils/WatchMissingNodeModulesPlugin');
 const eslintFormatter = require('react-dev-utils/eslintFormatter');
 const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin');
+const fs = require('fs');
 const getClientEnvironment = require('./env');
 const paths = require('./paths');
 
@@ -37,7 +38,10 @@ try {
     };
 }
 
-const manifest = require(`${paths.appPublic}/manifest`);
+const manifest = JSON.parse(
+    fs.readFileSync(`${paths.appPublic}/manifest.webapp`, 'utf8')
+);
+
 const globals = Object.assign(
     {},
     {

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -37,10 +37,12 @@ try {
     };
 }
 
+const manifest = require(`${paths.appPublic}/manifest`);
 const globals = Object.assign(
     {},
     {
         DHIS_CONFIG: JSON.stringify(dhisConfig),
+        manifest: JSON.stringify(manifest),
     },
     env.stringified
 );

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -27,7 +27,7 @@ const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP !== 'false';
 const publicUrl = publicPath.slice(0, -1);
 // Get environment variables to inject into our app.
 const env = getClientEnvironment(publicUrl);
-const manifest = require(`${paths.appPublic}/manifest`);
+const manifest = require(`${paths.appBuild}/manifest`);
 const globals = Object.assign(
     {},
     {
@@ -35,6 +35,10 @@ const globals = Object.assign(
     },
     env.stringified
 );
+
+console.log('paths', paths);
+
+console.log('manifest', manifest);
 
 // Assert this just to be safe.
 // Development builds of React are slow and not intended for production.

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -10,6 +10,7 @@ const InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
 const SWPrecacheWebpackPlugin = require('sw-precache-webpack-plugin');
 const eslintFormatter = require('react-dev-utils/eslintFormatter');
 const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin');
+const fs = require('fs');
 const paths = require('./paths');
 const getClientEnvironment = require('./env');
 
@@ -27,7 +28,9 @@ const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP !== 'false';
 const publicUrl = publicPath.slice(0, -1);
 // Get environment variables to inject into our app.
 const env = getClientEnvironment(publicUrl);
-const manifest = require(`${paths.appBuild}/manifest`);
+const manifest = JSON.parse(
+    fs.readFileSync(`${paths.appBuild}/manifest.webapp`, 'utf8')
+);
 const globals = Object.assign(
     {},
     {

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -36,10 +36,6 @@ const globals = Object.assign(
     env.stringified
 );
 
-console.log('paths', paths);
-
-console.log('manifest', manifest);
-
 // Assert this just to be safe.
 // Development builds of React are slow and not intended for production.
 if (env.stringified['process.env'].NODE_ENV !== '"production"') {

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -27,6 +27,14 @@ const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP !== 'false';
 const publicUrl = publicPath.slice(0, -1);
 // Get environment variables to inject into our app.
 const env = getClientEnvironment(publicUrl);
+const manifest = require(`${paths.appPublic}/manifest`);
+const globals = Object.assign(
+    {},
+    {
+        manifest: JSON.stringify(manifest),
+    },
+    env.stringified
+);
 
 // Assert this just to be safe.
 // Development builds of React are slow and not intended for production.
@@ -290,7 +298,7 @@ module.exports = {
         // if (process.env.NODE_ENV === 'production') { ... }. See `./env.js`.
         // It is absolutely essential that NODE_ENV was set to production here.
         // Otherwise React will be compiled in the very slow development mode.
-        new webpack.DefinePlugin(env.stringified),
+        new webpack.DefinePlugin(globals),
         // Minify the code.
         new webpack.optimize.UglifyJsPlugin({
             compress: {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
             "url": "",
             "name": "DHIS2"
         },
-        "version": "29",
+        "apiVersion": "29",
         "activities": {
             "dhis": {
                 "href": ".."

--- a/package.json
+++ b/package.json
@@ -91,7 +91,9 @@
             "url": "",
             "name": "DHIS2"
         },
-        "apiVersion": "29",
+        "dhis2": {
+            "apiVersion": "29"
+        },
         "activities": {
             "dhis": {
                 "href": ".."

--- a/package.json
+++ b/package.json
@@ -69,15 +69,16 @@
     },
     "scripts": {
         "documentation": "./node_modules/.bin/jsdoc -c jsdoc.json",
-        "prestart": "d2-manifest package.json ./public/manifest.webapp",
+        "prestart": "d2-manifest package.json ./public/manifest.json",
         "start": "node scripts/start.js",
         "build": "node scripts/build.js",
         "coverage": "npm test -- --coverage",
         "test": "node scripts/test.js --env=jsdom",
         "lint": "eslint -c .eslintrc.json src",
-        "prebuild": "rm -rf build && npm run lint",
-        "postbuild": "cp -r src/i18n build && npm run manifest",
-        "manifest": "d2-manifest package.json build/manifest.webapp",
+        "prebuild":
+            "rm -rf build && npm run lint && mkdir build && npm run manifest",
+        "postbuild": "cp -r src/i18n build",
+        "manifest": "d2-manifest package.json build/manifest.json",
         "deploy": "npm run build && mvn clean deploy",
         "prettify": "prettier \"src/{**/*,*}.js\" --write"
     },

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     },
     "scripts": {
         "documentation": "./node_modules/.bin/jsdoc -c jsdoc.json",
-        "prestart": "d2-manifest package.json ./public/manifest.json",
+        "prestart": "d2-manifest package.json ./public/manifest.webapp",
         "start": "node scripts/start.js",
         "build": "node scripts/build.js",
         "coverage": "npm test -- --coverage",
@@ -78,7 +78,7 @@
         "prebuild":
             "rm -rf build && npm run lint && mkdir build && npm run manifest",
         "postbuild": "cp -r src/i18n build",
-        "manifest": "d2-manifest package.json build/manifest.json",
+        "manifest": "d2-manifest package.json build/manifest.webapp",
         "deploy": "npm run build && mvn clean deploy",
         "prettify": "prettier \"src/{**/*,*}.js\" --write"
     },

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
             "url": "",
             "name": "DHIS2"
         },
+        "version": "29",
         "activities": {
             "dhis": {
                 "href": ".."

--- a/src/index.js
+++ b/src/index.js
@@ -18,8 +18,6 @@ import App from './App';
 // init material-ui
 injectTapEventPlugin();
 
-let baseUrl;
-
 const configI18n = userSettings => {
     const uiLocale = userSettings.keyUiLocale;
 
@@ -31,7 +29,7 @@ const configI18n = userSettings => {
 };
 
 const isProd = process.env.NODE_ENV === 'production';
-baseUrl = isProd ? manifest.activities.dhis.href : DHIS_CONFIG.baseUrl;
+const baseUrl = isProd ? manifest.activities.dhis.href : DHIS_CONFIG.baseUrl;
 config.baseUrl = `${baseUrl}/api/${manifest.dhis2.apiVersion}`;
 config.headers = isProd ? null : { Authorization: DHIS_CONFIG.authorization };
 

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ const configI18n = userSettings => {
 
 const isProd = process.env.NODE_ENV === 'production';
 baseUrl = isProd ? manifest.activities.dhis.href : DHIS_CONFIG.baseUrl;
-config.baseUrl = `${baseUrl}/api/${manifest.version}`;
+config.baseUrl = `${baseUrl}/api/${manifest.apiVersion}`;
 config.headers = isProd ? null : { Authorization: DHIS_CONFIG.authorization };
 
 getUserSettings()

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-/* global DHIS_CONFIG */
+/* global DHIS_CONFIG, manifest */
 
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -7,7 +7,7 @@ import { Provider } from 'react-redux';
 import injectTapEventPlugin from 'react-tap-event-plugin';
 import D2UIApp from 'd2-ui/lib/app/D2UIApp';
 
-import { config, getManifest, getUserSettings } from 'd2/lib/d2';
+import { config, getUserSettings } from 'd2/lib/d2';
 
 import './index.css';
 
@@ -30,18 +30,12 @@ const configI18n = userSettings => {
     config.i18n.sources.add('./i18n/i18n_module_en.properties');
 };
 
-// init d2
-getManifest('manifest.webapp')
-    .then(manifest => {
-        const isProd = process.env.NODE_ENV === 'production';
-        baseUrl = isProd ? manifest.getBaseUrl() : DHIS_CONFIG.baseUrl;
+const isProd = process.env.NODE_ENV === 'production';
+baseUrl = isProd ? manifest.getBaseUrl() : DHIS_CONFIG.baseUrl;
+config.baseUrl = `${baseUrl}/api/${manifest.version}`;
+config.headers = isProd ? null : { Authorization: DHIS_CONFIG.authorization };
 
-        config.baseUrl = `${baseUrl}/api/${manifest.version}`;
-        config.headers = isProd
-            ? null
-            : { Authorization: DHIS_CONFIG.authorization };
-    })
-    .then(getUserSettings)
+getUserSettings()
     .then(configI18n)
     .then(() => {
         config.schemas = ['dashboard'];

--- a/src/index.js
+++ b/src/index.js
@@ -18,8 +18,6 @@ import App from './App';
 // init material-ui
 injectTapEventPlugin();
 
-const API_VERSION = '29';
-
 let baseUrl;
 
 const configI18n = userSettings => {
@@ -38,7 +36,7 @@ getManifest('manifest.webapp')
         const isProd = process.env.NODE_ENV === 'production';
         baseUrl = isProd ? manifest.getBaseUrl() : DHIS_CONFIG.baseUrl;
 
-        config.baseUrl = `${baseUrl}/api/${API_VERSION}`;
+        config.baseUrl = `${baseUrl}/api/${manifest.version}`;
         config.headers = isProd
             ? null
             : { Authorization: DHIS_CONFIG.authorization };

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,8 @@ import App from './App';
 // init material-ui
 injectTapEventPlugin();
 
+const API_VERSION = '29';
+
 let baseUrl;
 
 const configI18n = userSettings => {
@@ -36,7 +38,7 @@ getManifest('manifest.webapp')
         const isProd = process.env.NODE_ENV === 'production';
         baseUrl = isProd ? manifest.getBaseUrl() : DHIS_CONFIG.baseUrl;
 
-        config.baseUrl = `${baseUrl}/api`;
+        config.baseUrl = `${baseUrl}/api/${API_VERSION}`;
         config.headers = isProd
             ? null
             : { Authorization: DHIS_CONFIG.authorization };

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ const configI18n = userSettings => {
 };
 
 const isProd = process.env.NODE_ENV === 'production';
-baseUrl = isProd ? manifest.getBaseUrl() : DHIS_CONFIG.baseUrl;
+baseUrl = isProd ? manifest.activities.dhis.href : DHIS_CONFIG.baseUrl;
 config.baseUrl = `${baseUrl}/api/${manifest.version}`;
 config.headers = isProd ? null : { Authorization: DHIS_CONFIG.authorization };
 

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ const configI18n = userSettings => {
 
 const isProd = process.env.NODE_ENV === 'production';
 baseUrl = isProd ? manifest.activities.dhis.href : DHIS_CONFIG.baseUrl;
-config.baseUrl = `${baseUrl}/api/${manifest.apiVersion}`;
+config.baseUrl = `${baseUrl}/api/${manifest.dhis2.apiVersion}`;
 config.headers = isProd ? null : { Authorization: DHIS_CONFIG.authorization };
 
 getUserSettings()


### PR DESCRIPTION
Set the version in the manifest, which is configured in package.json. Webpack then builds the manifest information into the bundle. Then, instead of asking d2 to read the manifest, the app will read the manifest itself and then configure d2 with the correct api url.