### PR TITLE
Get user's preferred dashboard from local storage

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,7 +10,7 @@ import ControlBarContainer from './ControlBarContainer/ControlBarContainer';
 import TitleBarCt from './TitleBar/TitleBar';
 import ItemGridCt from './ItemGrid/ItemGrid';
 
-import { fromDashboards, fromSelected } from './actions';
+import { fromDashboards, fromUser } from './actions';
 
 import './App.css';
 
@@ -19,12 +19,9 @@ const HeaderBar = withStateFrom(headerBarStore$, HeaderBarComponent);
 // App
 class App extends Component {
     componentDidMount() {
-        const { store } = this.context;
-        store.dispatch(fromDashboards.tSetDashboards()).then(() => {
-            store.dispatch(
-                fromSelected.tSetSelectedDashboardById('xP1jtPjus1c')
-            );
-        });
+        const { store, d2 } = this.context;
+        store.dispatch(fromUser.acReceivedUser(d2.currentUser));
+        store.dispatch(fromDashboards.tSetDashboards());
     }
 
     getChildContext() {

--- a/src/actions/dashboards.js
+++ b/src/actions/dashboards.js
@@ -1,6 +1,9 @@
 import { actionTypes } from '../reducers';
 import { getCustomDashboards } from '../reducers/dashboards';
+import { sGetUsername } from '../reducers/user';
+import { tSetSelectedDashboardById } from './selected';
 import { apiFetchDashboards, apiStarDashboard } from '../api/dashboards';
+import { getPreferredDashboard } from '../api/localStorage';
 import { arrayToIdMap } from '../util';
 
 // actions
@@ -21,7 +24,13 @@ export const acStarDashboard = (dashboardId, isStarred) => ({
 
 export const tSetDashboards = () => async (dispatch, getState) => {
     const onSuccess = data => {
-        dispatch(acSetDashboards(data.toArray()));
+        const dashboards = data.toArray();
+        dispatch(acSetDashboards(dashboards));
+
+        const dashboardId =
+            getPreferredDashboard(sGetUsername(getState())) || dashboards[0].id;
+        dispatch(tSetSelectedDashboardById(dashboardId));
+
         return data;
     };
 

--- a/src/actions/dashboards.js
+++ b/src/actions/dashboards.js
@@ -1,5 +1,8 @@
 import { actionTypes } from '../reducers';
-import { getCustomDashboards } from '../reducers/dashboards';
+import {
+    getCustomDashboards,
+    sGetStarredDashboardIds,
+} from '../reducers/dashboards';
 import { sGetUsername } from '../reducers/user';
 import { tSetSelectedDashboardById } from './selected';
 import { apiFetchDashboards, apiStarDashboard } from '../api/dashboards';
@@ -26,9 +29,13 @@ export const tSetDashboards = () => async (dispatch, getState) => {
     const onSuccess = data => {
         const dashboards = data.toArray();
         dispatch(acSetDashboards(dashboards));
+        const state = getState();
 
         const dashboardId =
-            getPreferredDashboard(sGetUsername(getState())) || dashboards[0].id;
+            getPreferredDashboard(sGetUsername(state)) ||
+            sGetStarredDashboardIds(state)[0] ||
+            dashboards[0].id;
+
         dispatch(tSetSelectedDashboardById(dashboardId));
 
         return data;

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -3,6 +3,7 @@ import * as fromSelected from './selected';
 import * as fromFilter from './filter';
 import * as fromControlBar from './controlBar';
 import * as fromEditDashboard from './editDashboard';
+import * as fromUser from './user';
 
 export {
     fromDashboards,
@@ -10,6 +11,7 @@ export {
     fromFilter,
     fromControlBar,
     fromEditDashboard,
+    fromUser,
 };
 
 // depends on: fromSelected, fromFilter, fromControlBar

--- a/src/actions/selected.js
+++ b/src/actions/selected.js
@@ -3,6 +3,8 @@ import { apiFetchSelected } from '../api/dashboards';
 import { acSetDashboards } from './dashboards';
 import { withShape } from '../ItemGrid/gridUtil';
 import { tGetMessages } from '../Item/MessagesItem/actions';
+import { putPreferredDashboard } from '../api/localStorage';
+import { fromUser } from '../reducers';
 import {
     REPORT_TABLE,
     CHART,
@@ -45,7 +47,7 @@ export const receivedVisualization = value => ({
 
 // thunks
 
-export const tSetSelectedDashboardById = id => async dispatch => {
+export const tSetSelectedDashboardById = id => async (dispatch, getState) => {
     dispatch(acSetSelectedIsLoading(true));
 
     const onSuccess = selected => {
@@ -73,6 +75,8 @@ export const tSetSelectedDashboardById = id => async dispatch => {
                     break;
             }
         });
+
+        putPreferredDashboard(fromUser.sGetUsername(getState()), id);
 
         dispatch(
             acSetDashboards(

--- a/src/actions/selected.js
+++ b/src/actions/selected.js
@@ -3,7 +3,7 @@ import { apiFetchSelected } from '../api/dashboards';
 import { acSetDashboards } from './dashboards';
 import { withShape } from '../ItemGrid/gridUtil';
 import { tGetMessages } from '../Item/MessagesItem/actions';
-import { putPreferredDashboard } from '../api/localStorage';
+import { storePreferredDashboard } from '../api/localStorage';
 import { fromUser } from '../reducers';
 import {
     REPORT_TABLE,
@@ -76,7 +76,7 @@ export const tSetSelectedDashboardById = id => async (dispatch, getState) => {
             }
         });
 
-        putPreferredDashboard(fromUser.sGetUsername(getState()), id);
+        storePreferredDashboard(fromUser.sGetUsername(getState()), id);
 
         dispatch(
             acSetDashboards(

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -1,0 +1,6 @@
+import { actionTypes } from '../reducers';
+
+export const acReceivedUser = value => ({
+    type: actionTypes.RECEIVED_USER,
+    value,
+});

--- a/src/api/localStorage.js
+++ b/src/api/localStorage.js
@@ -4,6 +4,6 @@ export const getPreferredDashboard = username => {
     );
 };
 
-export const putPreferredDashboard = (username, dashboardId) => {
+export const storePreferredDashboard = (username, dashboardId) => {
     localStorage.setItem(`dhis2.dashboard.current.${username}`, dashboardId);
 };

--- a/src/api/localStorage.js
+++ b/src/api/localStorage.js
@@ -1,0 +1,9 @@
+export const getPreferredDashboard = username => {
+    return (
+        localStorage.getItem(`dhis2.dashboard.current.${username}`) || undefined
+    );
+};
+
+export const putPreferredDashboard = (username, dashboardId) => {
+    localStorage.setItem(`dhis2.dashboard.current.${username}`, dashboardId);
+};

--- a/src/api/localStorage.js
+++ b/src/api/localStorage.js
@@ -1,8 +1,5 @@
-export const getPreferredDashboard = username => {
-    return (
-        localStorage.getItem(`dhis2.dashboard.current.${username}`) || undefined
-    );
-};
+export const getPreferredDashboard = username =>
+    localStorage.getItem(`dhis2.dashboard.current.${username}`) || undefined;
 
 export const storePreferredDashboard = (username, dashboardId) => {
     localStorage.setItem(`dhis2.dashboard.current.${username}`, dashboardId);

--- a/src/reducers/__tests__/user.spec.js
+++ b/src/reducers/__tests__/user.spec.js
@@ -1,0 +1,26 @@
+import reducer, { actionTypes, defaultState } from '../user';
+
+describe('user reducer', () => {
+    it('should return the default state', () => {
+        const actualState = reducer(undefined, {});
+
+        expect(actualState).toEqual(defaultState);
+    });
+
+    it('should handle RECEIVED_USER action', () => {
+        const username = 'jen123';
+        const action = {
+            type: actionTypes.RECEIVED_USER,
+            value: {
+                username,
+            },
+        };
+
+        const expectedState = {
+            username,
+        };
+
+        const actualState = reducer(defaultState, action);
+        expect(actualState).toEqual(expectedState);
+    });
+});

--- a/src/reducers/dashboards.js
+++ b/src/reducers/dashboards.js
@@ -71,6 +71,13 @@ export const sGetFromState = state => state.dashboards;
 export const sGetById = (state, id) =>
     orNull(orObject(sGetFromState(state))[id]);
 
+export const sGetStarredDashboardIds = state => {
+    const dashboards = Object.values(state.dashboards);
+    return dashboards
+        .filter(dashboard => dashboard.starred === true)
+        .map(starred => starred.id);
+};
+
 /**
  * Returns the array of dashboards, customized for ui
  * @function

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -8,6 +8,7 @@ import interpretations, * as fromInterpretations from './interpretations';
 import visualizations, * as fromVisualizations from './visualizations';
 import editDashboard, * as fromEditDashboard from './editDashboard';
 import messages, * as fromMessages from './messages';
+import user, * as fromUser from './user';
 import style, * as fromStyle from './style';
 
 const USER = 'system';
@@ -23,6 +24,7 @@ export const actionTypes = Object.assign(
     fromInterpretations.actionTypes,
     fromVisualizations.actionTypes,
     fromMessages.actionTypes,
+    fromUser.actionTypes,
     fromEditDashboard.actionTypes,
     fromStyle.actionTypes
 );
@@ -37,6 +39,7 @@ export default combineReducers({
     interpretations,
     visualizations,
     messages,
+    user,
     editDashboard,
     style,
 });
@@ -61,6 +64,7 @@ export {
     fromVisualizations,
     fromMessages,
     fromEditDashboard,
+    fromUser,
     fromStyle,
 };
 

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -1,0 +1,22 @@
+export const actionTypes = {
+    RECEIVED_USER: 'RECEIVED_USER',
+};
+
+export const defaultState = {
+    username: '',
+};
+
+export default (state = defaultState, action) => {
+    switch (action.type) {
+        case actionTypes.RECEIVED_USER: {
+            const { username } = action.value;
+            return { username };
+        }
+        default:
+            return state;
+    }
+};
+
+// selectors
+
+export const sGetUsername = state => state.user.username;


### PR DESCRIPTION
Use local storage to store/retrieve the user's preferred dashboard. A "user" reducer was added to simplify the code so that it isn't necessary to pass username all over the place.