### PR TITLE
Pass empty value to onChangeName when clearing dashboard filter

### DIFF
--- a/src/ControlBarContainer/Filter.js
+++ b/src/ControlBarContainer/Filter.js
@@ -110,13 +110,15 @@ Filter.defaultProps = {
 const ClearButton = ({ name, onChangeName }) => {
     const disabled = isEmpty(name);
 
+    const clearFilter = () => onChangeName();
+
     return (
         <IconButton
             style={Object.assign({}, styles.clearButton, {
                 opacity: disabled ? 0 : 1,
             })}
             iconStyle={styles.clearButtonIcon}
-            onClick={onChangeName}
+            onClick={clearFilter}
             disabled={disabled}
         >
             <IconClear color={grey700} />


### PR DESCRIPTION
By default, React passes a Synthetic Event object in the event handler. When attempting to read that value in DashboardsBar, things break.

https://stackoverflow.com/questions/38923917/accessing-onchange-event-from-child-component-react-redux