### PR TITLE
Simplify store structure by using the editDashboard prop to indicate edit state

### DIFF
--- a/src/ControlBarContainer/ControlBarContainer.js
+++ b/src/ControlBarContainer/ControlBarContainer.js
@@ -4,7 +4,7 @@ import { END_FLAP_HEIGHT } from 'd2-ui/lib/controlbar/ControlBar';
 
 import EditBar from './EditBar';
 import DashboardsBar from './DashboardsBar';
-import { fromSelected } from '../reducers';
+import { fromEditDashboard } from '../reducers';
 
 import './ControlBarContainer.css';
 
@@ -30,7 +30,7 @@ const ControlBar = ({ edit }) => {
 };
 
 const mapStateToProps = state => ({
-    edit: fromSelected.sGetSelectedEdit(state),
+    edit: fromEditDashboard.sGetIsEditing(state),
 });
 
 const ControlBarCt = connect(mapStateToProps, null)(ControlBar);

--- a/src/ControlBarContainer/DashboardsBar.js
+++ b/src/ControlBarContainer/DashboardsBar.js
@@ -182,11 +182,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
             }
         },
         onNewClick: () => {
-            dispatch(
-                fromEditDashboard.acSetEditDashboard(
-                    fromReducers.fromEditDashboard.NEW_DASHBOARD
-                )
-            );
+            dispatch(fromEditDashboard.acSetEditNewDashboard());
         },
         onToggleExpanded: () => {
             dispatch(fromControlBar.acSetControlBarExpanded(!isExpanded));

--- a/src/ControlBarContainer/DashboardsBar.js
+++ b/src/ControlBarContainer/DashboardsBar.js
@@ -154,12 +154,7 @@ const mapStateToProps = state => {
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
     const { dashboards, name, rows, isExpanded } = stateProps;
     const { dispatch } = dispatchProps;
-    const {
-        fromControlBar,
-        fromFilter,
-        fromSelected,
-        fromEditDashboard,
-    } = fromActions;
+    const { fromControlBar, fromFilter, fromEditDashboard } = fromActions;
 
     const filteredDashboards = Object.values(orObject(dashboards)).filter(
         d => d.name.toLowerCase().indexOf(name) !== -1
@@ -187,13 +182,11 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
             }
         },
         onNewClick: () => {
-            const newDashboard = {
-                id: '',
-                name: '',
-                description: '',
-                dashboardItems: [],
-            };
-            dispatch(fromEditDashboard.acSetEditDashboard(newDashboard));
+            dispatch(
+                fromEditDashboard.acSetEditDashboard(
+                    fromReducers.fromEditDashboard.NEW_DASHBOARD
+                )
+            );
         },
         onToggleExpanded: () => {
             dispatch(fromControlBar.acSetControlBarExpanded(!isExpanded));

--- a/src/ControlBarContainer/DashboardsBar.js
+++ b/src/ControlBarContainer/DashboardsBar.js
@@ -188,12 +188,11 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
         },
         onNewClick: () => {
             const newDashboard = {
+                id: '',
                 name: '',
                 description: '',
                 dashboardItems: [],
             };
-            dispatch(fromSelected.acSetSelectedId(''));
-            dispatch(fromSelected.acSetSelectedEdit(true));
             dispatch(fromEditDashboard.acSetEditDashboard(newDashboard));
         },
         onToggleExpanded: () => {

--- a/src/ControlBarContainer/EditBar.js
+++ b/src/ControlBarContainer/EditBar.js
@@ -3,10 +3,7 @@ import { connect } from 'react-redux';
 import ControlBar from 'd2-ui/lib/controlbar/ControlBar';
 import Button from 'd2-ui/lib/button/Button';
 import { colors } from '../colors';
-
-import { tSaveDashboard, acSetEditDashboard } from '../actions/editDashboard';
-import { fromEditDashboard } from '../reducers';
-
+import { tSaveDashboard, acClearEditDashboard } from '../actions/editDashboard';
 import { CONTROL_BAR_ROW_HEIGHT, getOuterHeight } from './ControlBarContainer';
 
 const styles = {
@@ -68,7 +65,7 @@ const mapDispatchToProps = dispatch => {
             dispatch(tSaveDashboard());
         },
         onDiscard: () => {
-            dispatch(acSetEditDashboard(fromEditDashboard.DEFAULT_STATE));
+            dispatch(acClearEditDashboard());
         },
     };
 };

--- a/src/ControlBarContainer/EditBar.js
+++ b/src/ControlBarContainer/EditBar.js
@@ -4,7 +4,8 @@ import ControlBar from 'd2-ui/lib/controlbar/ControlBar';
 import Button from 'd2-ui/lib/button/Button';
 import { colors } from '../colors';
 
-import { fromSelected, fromEditDashboard } from '../actions';
+import { tSaveDashboard, acSetEditDashboard } from '../actions/editDashboard';
+import { fromEditDashboard } from '../reducers';
 
 import { CONTROL_BAR_ROW_HEIGHT, getOuterHeight } from './ControlBarContainer';
 
@@ -64,10 +65,10 @@ const EditBar = ({ style, onSave, onDiscard }) => {
 const mapDispatchToProps = dispatch => {
     return {
         onSave: () => {
-            dispatch(fromEditDashboard.tSaveDashboard());
+            dispatch(tSaveDashboard());
         },
         onDiscard: () => {
-            dispatch(fromEditDashboard.acSetEditDashboard(null));
+            dispatch(acSetEditDashboard(fromEditDashboard.DEFAULT_STATE));
         },
     };
 };

--- a/src/ControlBarContainer/EditBar.js
+++ b/src/ControlBarContainer/EditBar.js
@@ -67,8 +67,7 @@ const mapDispatchToProps = dispatch => {
             dispatch(fromEditDashboard.tSaveDashboard());
         },
         onDiscard: () => {
-            dispatch(fromSelected.acSetSelectedEdit(false));
-            dispatch(fromEditDashboard.acSetEditDashboard({}));
+            dispatch(fromEditDashboard.acSetEditDashboard(null));
         },
     };
 };

--- a/src/ItemGrid/ItemGrid.js
+++ b/src/ItemGrid/ItemGrid.js
@@ -73,7 +73,9 @@ export class ItemGrid extends Component {
     }
 
     onLayoutChange = newLayout => {
-        this.props.acUpdateDashboardLayout(newLayout);
+        if (this.props.edit) {
+            this.props.acUpdateDashboardLayout(newLayout);
+        }
     };
 
     render() {
@@ -158,8 +160,12 @@ const onResizeStop = (layout, oldItem, newItem) => {
 };
 
 const mapStateToProps = state => {
-    const { sGetSelectedDashboard, fromSelected } = fromReducers;
-    const { sGetSelectedIsLoading, sGetSelectedEdit } = fromSelected;
+    const {
+        sGetSelectedDashboard,
+        fromSelected,
+        fromEditDashboard,
+    } = fromReducers;
+    const { sGetSelectedIsLoading } = fromSelected;
 
     const selectedDashboard = sGetSelectedDashboard(state);
 
@@ -168,7 +174,7 @@ const mapStateToProps = state => {
         : null;
 
     return {
-        edit: sGetSelectedEdit(state),
+        edit: fromEditDashboard.sGetIsEditing(state),
         isLoading: sGetSelectedIsLoading(state),
         dashboardItems,
     };

--- a/src/PageContainer/PageContainer.js
+++ b/src/PageContainer/PageContainer.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import { CONTROL_BAR_ROW_HEIGHT } from '../ControlBarContainer/ControlBarContainer';
-import { sGetSelectedEdit } from '../reducers/selected';
+import { sGetIsEditing } from '../reducers/editDashboard';
 import { sGetControlBarRows } from '../reducers/controlBar';
 
 const DEFAULT_TOP_MARGIN = 80;
@@ -15,7 +15,7 @@ const DynamicTopMarginContainer = ({ marginTop, children }) => (
 );
 
 const mapStateToProps = state => {
-    const edit = sGetSelectedEdit(state);
+    const edit = sGetIsEditing(state);
     const rows = sGetControlBarRows(state);
 
     return {

--- a/src/TitleBar/TitleBar.js
+++ b/src/TitleBar/TitleBar.js
@@ -64,7 +64,7 @@ const mapStateToProps = state => {
         id: selectedDashboard.id,
         name: selectedDashboard.name,
         description: selectedDashboard.description,
-        edit: fromReducers.fromSelected.sGetSelectedEdit(state),
+        edit: fromReducers.fromEditDashboard.sGetIsEditing(state),
     };
 };
 

--- a/src/TitleBar/ViewTitleBar.js
+++ b/src/TitleBar/ViewTitleBar.js
@@ -141,7 +141,6 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
         onStarClick: () =>
             dispatch(tStarDashboard(selectedDashboard.id, !stateProps.starred)),
         onEditClick: () => {
-            dispatch(fromSelected.acSetSelectedEdit(true));
             dispatch(fromEditDashboard.acSetEditDashboard(selectedDashboard));
         },
         onInfoClick: () =>

--- a/src/actions/editDashboard.js
+++ b/src/actions/editDashboard.js
@@ -17,6 +17,14 @@ export const acSetEditDashboard = value => ({
     value,
 });
 
+export const acSetEditNewDashboard = () => ({
+    type: actionTypes.START_NEW_DASHBOARD,
+});
+
+export const acClearEditDashboard = () => ({
+    type: actionTypes.RECEIVED_NOT_EDITING,
+});
+
 export const acSetDashboardTitle = value => ({
     type: actionTypes.RECEIVED_TITLE,
     value,
@@ -87,7 +95,7 @@ export const tSaveDashboard = () => async (dispatch, getState) => {
 
         await dispatch(fromSelected.tSetSelectedDashboardById(selectedId));
 
-        return dispatch(acSetEditDashboard({}));
+        return dispatch(acClearEditDashboard());
     } catch (error) {
         onError(error);
     }

--- a/src/actions/editDashboard.js
+++ b/src/actions/editDashboard.js
@@ -86,7 +86,6 @@ export const tSaveDashboard = () => async (dispatch, getState) => {
             : await postDashboard(dashboardToSave);
 
         await dispatch(fromSelected.tSetSelectedDashboardById(selectedId));
-        dispatch(fromSelected.acSetSelectedEdit(false));
 
         return dispatch(acSetEditDashboard({}));
     } catch (error) {

--- a/src/actions/selected.js
+++ b/src/actions/selected.js
@@ -21,11 +21,6 @@ export const acSetSelectedId = value => ({
     value,
 });
 
-export const acSetSelectedEdit = value => ({
-    type: actionTypes.SET_SELECTED_EDIT,
-    value,
-});
-
 export const acSetSelectedIsLoading = value => ({
     type: actionTypes.SET_SELECTED_ISLOADING,
     value,

--- a/src/reducers/__tests__/editDashboard.spec.js
+++ b/src/reducers/__tests__/editDashboard.spec.js
@@ -1,7 +1,11 @@
 import update from 'immutability-helper';
-import reducer, { actionTypes } from '../editDashboard';
+import reducer, {
+    actionTypes,
+    sGetIsEditing,
+    DEFAULT_STATE,
+} from '../editDashboard';
 
-describe('editDashboard reducer', () => {
+describe('editDashboard', () => {
     const initialState = {
         id: 'ponydash',
         name: 'My pony dashboard',
@@ -28,142 +32,178 @@ describe('editDashboard reducer', () => {
         ],
     };
 
-    it('should set the dashboard layout', () => {
-        const shape0 = { w: 7, h: 7, x: 7, y: 7 };
-        const shape1 = { w: 9, h: 9, x: 9, y: 9 };
-        const newLayout = [
-            Object.assign({}, { i: 'd0' }, shape0),
-            Object.assign({}, { i: 'd1' }, shape1),
-        ];
+    describe('reducer', () => {
+        it('should set the dashboard layout', () => {
+            const shape0 = { w: 7, h: 7, x: 7, y: 7 };
+            const shape1 = { w: 9, h: 9, x: 9, y: 9 };
+            const newLayout = [
+                Object.assign({}, { i: 'd0' }, shape0),
+                Object.assign({}, { i: 'd1' }, shape1),
+            ];
 
-        const actualState = reducer(initialState, {
-            type: actionTypes.RECEIVED_DASHBOARD_LAYOUT,
-            value: newLayout,
+            const actualState = reducer(initialState, {
+                type: actionTypes.RECEIVED_DASHBOARD_LAYOUT,
+                value: newLayout,
+            });
+
+            expect(actualState.id).toEqual('ponydash');
+            expect(actualState.name).toEqual('My pony dashboard');
+
+            const expectedItem = update(initialState.dashboardItems[0], {
+                $merge: shape0,
+            });
+
+            expect(actualState.dashboardItems[0]).toMatchObject(expectedItem);
+
+            //check for pure function
+            expect(initialState.dashboardItems[0].w).toEqual(4);
         });
 
-        expect(actualState.id).toEqual('ponydash');
-        expect(actualState.name).toEqual('My pony dashboard');
-
-        const expectedItem = update(initialState.dashboardItems[0], {
-            $merge: shape0,
-        });
-
-        expect(actualState.dashboardItems[0]).toMatchObject(expectedItem);
-
-        //check for pure function
-        expect(initialState.dashboardItems[0].w).toEqual(4);
-    });
-
-    const newState = {
-        id: 'scarydash',
-        name: 'My scary dashboard',
-        dashboardItems: [
-            { id: 'd5', type: 'GHOST' },
-            { id: 'd6', type: 'GHOUL' },
-            { id: 'd7', type: 'POLTERGEIST' },
-        ],
-    };
-
-    it('should return the default state', () => {
-        const actualState = reducer(undefined, { type: 'NO_MATCH' });
-
-        expect(actualState).toEqual({});
-    });
-
-    it('should set the dashboard to be edited', () => {
-        const actualState = reducer(initialState, {
-            type: actionTypes.RECEIVED_EDIT_DASHBOARD,
-            value: newState,
-        });
-
-        expect(actualState.name).toEqual(newState.name);
-        expect(actualState.id).toEqual(newState.id);
-        expect(actualState.dashboardItems.length).toEqual(
-            newState.dashboardItems.length
-        );
-    });
-
-    it('should set the dashboard title', () => {
-        const title = 'moohaha scary dashboard';
-
-        const actualState = reducer(initialState, {
-            type: actionTypes.RECEIVED_TITLE,
-            value: title,
-        });
-
-        expect(actualState.name).toEqual(title);
-        expect(actualState.dashboardItems.length).toEqual(
-            initialState.dashboardItems.length
-        );
-
-        //check for pure function
-        expect(initialState.name).toEqual('My pony dashboard');
-    });
-
-    it('should set the dashboard description', () => {
-        const description = 'moohaha scary dashboard dashboard';
-
-        const actualState = reducer(initialState, {
-            type: actionTypes.RECEIVED_DESCRIPTION,
-            value: description,
-        });
-
-        expect(actualState.description).toEqual(description);
-        expect(actualState.dashboardItems.length).toEqual(
-            initialState.dashboardItems.length
-        );
-
-        //check for pure function
-        expect(initialState.description).toEqual(
-            'My pony dashboard description'
-        );
-    });
-
-    it('should add a dashboard item', () => {
-        const newItem = {
-            id: 'add1',
-            type: 'ROBOT',
+        const newState = {
+            id: 'scarydash',
+            name: 'My scary dashboard',
+            dashboardItems: [
+                { id: 'd5', type: 'GHOST' },
+                { id: 'd6', type: 'GHOUL' },
+                { id: 'd7', type: 'POLTERGEIST' },
+            ],
         };
 
-        const actualState = reducer(initialState, {
-            type: actionTypes.ADD_DASHBOARD_ITEM,
-            value: newItem,
+        it('should return the default state', () => {
+            const actualState = reducer(undefined, {});
+
+            expect(actualState).toEqual(DEFAULT_STATE);
         });
 
-        expect(actualState.dashboardItems.length).toEqual(
-            initialState.dashboardItems.length + 1
-        );
+        it('should set the dashboard to be edited', () => {
+            const actualState = reducer(initialState, {
+                type: actionTypes.RECEIVED_EDIT_DASHBOARD,
+                value: newState,
+            });
 
-        const expectedState = update(initialState, {
-            dashboardItems: { $push: [newItem] },
+            expect(actualState.name).toEqual(newState.name);
+            expect(actualState.id).toEqual(newState.id);
+            expect(actualState.dashboardItems.length).toEqual(
+                newState.dashboardItems.length
+            );
         });
 
-        expect(actualState).toMatchObject(expectedState);
+        it('should set the dashboard title', () => {
+            const title = 'moohaha scary dashboard';
 
-        //check for pure function
-        expect(initialState.dashboardItems.length).toEqual(2);
+            const actualState = reducer(initialState, {
+                type: actionTypes.RECEIVED_TITLE,
+                value: title,
+            });
+
+            expect(actualState.name).toEqual(title);
+            expect(actualState.dashboardItems.length).toEqual(
+                initialState.dashboardItems.length
+            );
+
+            //check for pure function
+            expect(initialState.name).toEqual('My pony dashboard');
+        });
+
+        it('should set the dashboard description', () => {
+            const description = 'moohaha scary dashboard dashboard';
+
+            const actualState = reducer(initialState, {
+                type: actionTypes.RECEIVED_DESCRIPTION,
+                value: description,
+            });
+
+            expect(actualState.description).toEqual(description);
+            expect(actualState.dashboardItems.length).toEqual(
+                initialState.dashboardItems.length
+            );
+
+            //check for pure function
+            expect(initialState.description).toEqual(
+                'My pony dashboard description'
+            );
+        });
+
+        it('should add a dashboard item', () => {
+            const newItem = {
+                id: 'add1',
+                type: 'ROBOT',
+            };
+
+            const actualState = reducer(initialState, {
+                type: actionTypes.ADD_DASHBOARD_ITEM,
+                value: newItem,
+            });
+
+            expect(actualState.dashboardItems.length).toEqual(
+                initialState.dashboardItems.length + 1
+            );
+
+            const expectedState = update(initialState, {
+                dashboardItems: { $push: [newItem] },
+            });
+
+            expect(actualState).toMatchObject(expectedState);
+
+            //check for pure function
+            expect(initialState.dashboardItems.length).toEqual(2);
+        });
+
+        it('should remove a dashboard item', () => {
+            const removeIdx = 1;
+            const itemToRemove = initialState.dashboardItems[removeIdx];
+
+            const actualState = reducer(initialState, {
+                type: actionTypes.REMOVE_DASHBOARD_ITEM,
+                value: itemToRemove.id,
+            });
+
+            expect(actualState.dashboardItems.length).toEqual(
+                initialState.dashboardItems.length - 1
+            );
+
+            const expectedState = update(initialState, {
+                dashboardItems: { $splice: [[removeIdx, 1]] },
+            });
+
+            expect(actualState).toMatchObject(expectedState);
+
+            //check for pure function
+            expect(initialState.dashboardItems.length).toEqual(2);
+        });
     });
 
-    it('should remove a dashboard item', () => {
-        const removeIdx = 1;
-        const itemToRemove = initialState.dashboardItems[removeIdx];
+    describe('sGetIsEditing selector', () => {
+        it('should return "true" when state contains name property', () => {
+            const isEditing = sGetIsEditing({
+                editDashboard: { name: 'tinkywinky' },
+            });
 
-        const actualState = reducer(initialState, {
-            type: actionTypes.REMOVE_DASHBOARD_ITEM,
-            value: itemToRemove.id,
+            expect(isEditing).toBe(true);
         });
 
-        expect(actualState.dashboardItems.length).toEqual(
-            initialState.dashboardItems.length - 1
-        );
+        it('should return "true" when state contains dashboardItems property', () => {
+            const isEditing = sGetIsEditing({
+                editDashboard: { dashboardItems: [] },
+            });
 
-        const expectedState = update(initialState, {
-            dashboardItems: { $splice: [[removeIdx, 1]] },
+            expect(isEditing).toBe(true);
         });
 
-        expect(actualState).toMatchObject(expectedState);
+        it('should return "true" when state contains description property', () => {
+            const isEditing = sGetIsEditing({
+                editDashboard: { description: 'tinkywinky' },
+            });
 
-        //check for pure function
-        expect(initialState.dashboardItems.length).toEqual(2);
+            expect(isEditing).toBe(true);
+        });
+
+        it('should return "false" when state is an empty object', () => {
+            const isEditing = sGetIsEditing({
+                editDashboard: {},
+            });
+
+            expect(isEditing).toBe(false);
+        });
     });
 });

--- a/src/reducers/__tests__/editDashboard.spec.js
+++ b/src/reducers/__tests__/editDashboard.spec.js
@@ -3,6 +3,7 @@ import reducer, {
     actionTypes,
     sGetIsEditing,
     DEFAULT_STATE,
+    NEW_DASHBOARD_STATE,
 } from '../editDashboard';
 
 describe('editDashboard', () => {
@@ -73,6 +74,22 @@ describe('editDashboard', () => {
             const actualState = reducer(undefined, {});
 
             expect(actualState).toEqual(DEFAULT_STATE);
+        });
+
+        it('should handle the action RECEIVED_NOT_EDITING', () => {
+            const actualState = reducer(initialState, {
+                type: actionTypes.RECEIVED_NOT_EDITING,
+            });
+
+            expect(actualState).toEqual(DEFAULT_STATE);
+        });
+
+        it('should return the state for a new dashboard', () => {
+            const actualState = reducer(DEFAULT_STATE, {
+                type: actionTypes.START_NEW_DASHBOARD,
+            });
+
+            expect(actualState).toEqual(NEW_DASHBOARD_STATE);
         });
 
         it('should set the dashboard to be edited', () => {
@@ -147,6 +164,28 @@ describe('editDashboard', () => {
 
             //check for pure function
             expect(initialState.dashboardItems.length).toEqual(2);
+        });
+
+        it('should update a dashboard item', () => {
+            const updatedDashboardItem = {
+                id: 'd1',
+                type: 'APPLEJACK',
+                w: 8,
+                h: 8,
+                x: 4,
+                y: 4,
+                shape: 'sloppy',
+            };
+
+            const actualState = reducer(initialState, {
+                type: actionTypes.UPDATE_DASHBOARD_ITEM,
+                value: updatedDashboardItem,
+            });
+
+            const actualItem = actualState.dashboardItems.find(
+                item => item.id === 'd1'
+            );
+            expect(actualItem).toEqual(updatedDashboardItem);
         });
 
         it('should remove a dashboard item', () => {

--- a/src/reducers/__tests__/selected.spec.js
+++ b/src/reducers/__tests__/selected.spec.js
@@ -3,7 +3,6 @@ import reducer, { actionTypes } from '../selected';
 describe('selected dashboard reducer', () => {
     const defaultState = {
         id: null,
-        edit: false,
         isLoading: false,
         showDescription: false,
     };
@@ -16,18 +15,6 @@ describe('selected dashboard reducer', () => {
             const actualState = reducer(defaultState, {
                 type: actionTypes.SET_SELECTED_ID,
                 value: id,
-            });
-
-            expect(actualState).toEqual(expectedState);
-        });
-
-        it('should set the selected dashboard edit state', () => {
-            const edit = true;
-            const expectedState = Object.assign({}, defaultState, { edit });
-
-            const actualState = reducer(defaultState, {
-                type: actionTypes.SET_SELECTED_EDIT,
-                value: edit,
             });
 
             expect(actualState).toEqual(expectedState);

--- a/src/reducers/editDashboard.js
+++ b/src/reducers/editDashboard.js
@@ -6,6 +6,7 @@ import { orArray } from '../util';
 export const actionTypes = {
     RECEIVED_EDIT_DASHBOARD: 'RECEIVED_EDIT_DASHBOARD',
     RECEIVED_NOT_EDITING: 'RECEIVED_NOT_EDITING',
+    START_NEW_DASHBOARD: 'START_NEW_DASHBOARD',
     RECEIVED_TITLE: 'RECEIVED_TITLE',
     RECEIVED_DESCRIPTION: 'RECEIVED_DESCRIPTION',
     ADD_DASHBOARD_ITEM: 'ADD_DASHBOARD_ITEM',
@@ -15,12 +16,6 @@ export const actionTypes = {
 };
 
 export const DEFAULT_STATE = {};
-export const NEW_DASHBOARD = {
-    id: '',
-    name: '',
-    description: '',
-    dashboardItems: [],
-};
 
 export default (state = DEFAULT_STATE, action) => {
     switch (action.type) {
@@ -28,6 +23,13 @@ export default (state = DEFAULT_STATE, action) => {
             return action.value;
         case actionTypes.RECEIVED_NOT_EDITING:
             return DEFAULT_STATE;
+        case actionTypes.START_NEW_DASHBOARD:
+            return {
+                id: '',
+                name: '',
+                description: '',
+                dashboardItems: [],
+            };
         case actionTypes.RECEIVED_TITLE: {
             return Object.assign({}, state, { name: action.value });
         }

--- a/src/reducers/editDashboard.js
+++ b/src/reducers/editDashboard.js
@@ -15,6 +15,12 @@ export const actionTypes = {
 };
 
 export const DEFAULT_STATE = {};
+export const NEW_DASHBOARD = {
+    id: '',
+    name: '',
+    description: '',
+    dashboardItems: [],
+};
 
 export default (state = DEFAULT_STATE, action) => {
     switch (action.type) {

--- a/src/reducers/editDashboard.js
+++ b/src/reducers/editDashboard.js
@@ -1,9 +1,11 @@
 /** @module reducers/editDashboard */
 import update from 'immutability-helper';
+import isEmpty from 'lodash/isEmpty';
 import { orArray } from '../util';
 
 export const actionTypes = {
     RECEIVED_EDIT_DASHBOARD: 'RECEIVED_EDIT_DASHBOARD',
+    RECEIVED_NOT_EDITING: 'RECEIVED_NOT_EDITING',
     RECEIVED_TITLE: 'RECEIVED_TITLE',
     RECEIVED_DESCRIPTION: 'RECEIVED_DESCRIPTION',
     ADD_DASHBOARD_ITEM: 'ADD_DASHBOARD_ITEM',
@@ -12,10 +14,14 @@ export const actionTypes = {
     RECEIVED_DASHBOARD_LAYOUT: 'RECEIVED_DASHBOARD_LAYOUT',
 };
 
-export default (state = {}, action) => {
+export const DEFAULT_STATE = {};
+
+export default (state = DEFAULT_STATE, action) => {
     switch (action.type) {
         case actionTypes.RECEIVED_EDIT_DASHBOARD:
             return action.value;
+        case actionTypes.RECEIVED_NOT_EDITING:
+            return DEFAULT_STATE;
         case actionTypes.RECEIVED_TITLE: {
             return Object.assign({}, state, { name: action.value });
         }
@@ -83,6 +89,8 @@ export default (state = {}, action) => {
 };
 
 // selectors
-export const sGetEditDashboard = state => {
-    return state.editDashboard;
+export const sGetEditDashboard = state => state.editDashboard;
+
+export const sGetIsEditing = state => {
+    return !isEmpty(state.editDashboard);
 };

--- a/src/reducers/editDashboard.js
+++ b/src/reducers/editDashboard.js
@@ -16,6 +16,12 @@ export const actionTypes = {
 };
 
 export const DEFAULT_STATE = {};
+export const NEW_DASHBOARD_STATE = {
+    id: '',
+    name: '',
+    description: '',
+    dashboardItems: [],
+};
 
 export default (state = DEFAULT_STATE, action) => {
     switch (action.type) {
@@ -24,12 +30,7 @@ export default (state = DEFAULT_STATE, action) => {
         case actionTypes.RECEIVED_NOT_EDITING:
             return DEFAULT_STATE;
         case actionTypes.START_NEW_DASHBOARD:
-            return {
-                id: '',
-                name: '',
-                description: '',
-                dashboardItems: [],
-            };
+            return NEW_DASHBOARD_STATE;
         case actionTypes.RECEIVED_TITLE: {
             return Object.assign({}, state, { name: action.value });
         }

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -69,11 +69,10 @@ export {
 };
 
 // selected dashboard
-export const sGetSelectedDashboard = state => {
-    return fromEditDashboard.sGetIsEditing(state)
+export const sGetSelectedDashboard = state =>
+    fromEditDashboard.sGetIsEditing(state)
         ? fromEditDashboard.sGetEditDashboard(state)
         : fromDashboards.sGetById(state, fromSelected.sGetSelectedId(state));
-};
 
 // filter dashboards by name
 export const sFilterDashboardsByName = (dashboards, filter) =>

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -69,10 +69,11 @@ export {
 };
 
 // selected dashboard
-export const sGetSelectedDashboard = state =>
-    state.selected.edit
+export const sGetSelectedDashboard = state => {
+    return fromEditDashboard.sGetIsEditing(state)
         ? fromEditDashboard.sGetEditDashboard(state)
         : fromDashboards.sGetById(state, fromSelected.sGetSelectedId(state));
+};
 
 // filter dashboards by name
 export const sFilterDashboardsByName = (dashboards, filter) =>

--- a/src/reducers/selected.js
+++ b/src/reducers/selected.js
@@ -5,13 +5,11 @@ import { validateReducer } from '../util';
 
 export const actionTypes = {
     SET_SELECTED_ID: 'SET_SELECTED_ID',
-    SET_SELECTED_EDIT: 'SET_SELECTED_EDIT',
     SET_SELECTED_ISLOADING: 'SET_SELECTED_ISLOADING',
     SET_SELECTED_SHOWDESCRIPTION: 'SET_SELECTED_SHOWDESCRIPTION',
 };
 
 export const DEFAULT_SELECTED_ID = null;
-export const DEFAULT_SELECTED_EDIT = false;
 export const DEFAULT_SELECTED_ISLOADING = false;
 export const DEFAULT_SELECTED_SHOWDESCRIPTION = false;
 
@@ -25,15 +23,6 @@ const id = (state = DEFAULT_SELECTED_ID, action) => {
     switch (action.type) {
         case actionTypes.SET_SELECTED_ID:
             return validateReducer(action.value, DEFAULT_SELECTED_ID);
-        default:
-            return state;
-    }
-};
-
-const edit = (state = DEFAULT_SELECTED_EDIT, action) => {
-    switch (action.type) {
-        case actionTypes.SET_SELECTED_EDIT:
-            return validateReducer(action.value, DEFAULT_SELECTED_EDIT);
         default:
             return state;
     }
@@ -62,7 +51,6 @@ const showDescription = (state = DEFAULT_SELECTED_SHOWDESCRIPTION, action) => {
 
 export default combineReducers({
     id,
-    edit,
     isLoading,
     showDescription,
 });
@@ -73,8 +61,6 @@ export const sGetFromState = state => state.selected;
 // Selector dependency level 2
 
 export const sGetSelectedId = state => sGetFromState(state).id;
-
-export const sGetSelectedEdit = state => sGetFromState(state).edit;
 
 export const sGetSelectedIsLoading = state => sGetFromState(state).isLoading;
 


### PR DESCRIPTION
Unneccessary and even buggy to keep two different properties to indicate the edit state of the dashboard.