### PR TITLE
Improve look of Text item in edit and view mode

### DIFF
--- a/src/Item/TextItem/Item.js
+++ b/src/Item/TextItem/Item.js
@@ -1,21 +1,28 @@
 import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 
+import ItemHeader from '../ItemHeader';
+import Line from '../../widgets/Line';
 import TextField from 'd2-ui/lib/text-field/TextField';
 import { acUpdateDashboardItem } from '../../actions/editDashboard';
 import { sGetSelectedDashboard } from '../../reducers';
 
 const style = {
-    text: {
-        fontSize: '13px',
-        lineHeight: '17px',
+    textDiv: {
+        padding: '10px',
         whiteSpace: 'pre-line',
     },
     textField: {
-        width: '80%',
-        display: 'inline-block',
         fontSize: '14px',
+        lineHeight: '18px',
         fontStretch: 'normal',
+        width: '90%',
+        margin: '0 auto',
+        display: 'block',
+    },
+    container: {
+        marginBottom: '20px',
+        marginTop: '20px',
     },
 };
 
@@ -31,26 +38,37 @@ const TextItem = props => {
         acUpdateDashboardItem(updatedItem);
     };
 
-    return (
-        <Fragment>
-            <div className="dashboard-item-content">
-                {editMode ? (
+    const viewItem = () => {
+        const textDivStyle = Object.assign({}, style.textField, style.textDiv);
+        return (
+            <div className="dashboard-item-content" style={style.container}>
+                <div style={textDivStyle}>{text}</div>
+            </div>
+        );
+    };
+
+    const editItem = () => {
+        return (
+            <Fragment>
+                <ItemHeader title="Text item" />
+                <Line />
+                <div className="dashboard-item-content">
                     <TextField
                         value={text}
                         multiline
                         rows={1}
-                        rowsMax={6}
+                        rowsMax={8}
                         fullWidth
                         style={style.textField}
                         placeholder={'Add text here'}
                         onChange={onChangeText}
                     />
-                ) : (
-                    <div style={style.text}>{text}</div>
-                )}
-            </div>
-        </Fragment>
-    );
+                </div>
+            </Fragment>
+        );
+    };
+
+    return <Fragment>{editMode ? editItem() : viewItem()}</Fragment>;
 };
 
 export default connect(

--- a/src/Item/TextItem/Item.js
+++ b/src/Item/TextItem/Item.js
@@ -11,10 +11,10 @@ const style = {
     textDiv: {
         padding: '10px',
         whiteSpace: 'pre-line',
+        lineHeight: '20px',
     },
     textField: {
         fontSize: '14px',
-        lineHeight: '18px',
         fontStretch: 'normal',
         width: '90%',
         margin: '0 auto',

--- a/src/ItemSelect/selectableItems.js
+++ b/src/ItemSelect/selectableItems.js
@@ -24,7 +24,7 @@ export const singleItems = [
                 type: TEXT,
                 icon: itemTypeMap[TEXT].icon,
                 name: 'Text box',
-                content: 'No content',
+                content: '',
             },
             {
                 type: MESSAGES,

--- a/src/actions/editDashboard.js
+++ b/src/actions/editDashboard.js
@@ -3,7 +3,13 @@ import { actionTypes } from '../reducers';
 import { fromEditDashboard } from '../reducers';
 import { updateDashboard, postDashboard } from '../api/editDashboard';
 import { fromSelected } from '.';
-import { itemTypeMap, isSpacerType, TEXT } from '../itemTypes';
+import {
+    itemTypeMap,
+    isSpacerType,
+    TEXT,
+    emptyTextItemContent,
+    isTextType,
+} from '../itemTypes';
 
 const onError = error => {
     console.log('Error (Saving Dashboard): ', error);
@@ -76,9 +82,15 @@ export const tSaveDashboard = () => async (dispatch, getState) => {
     const dashboard = fromEditDashboard.sGetEditDashboard(getState());
 
     const dashboardItems = dashboard.dashboardItems.map(item => {
+        const text = isTextType(item)
+            ? item.text || emptyTextItemContent
+            : null;
+
         const type = isSpacerType(item) ? TEXT : item.type;
+
         return {
             ...item,
+            ...(text ? { text } : {}),
             type,
         };
     });

--- a/src/itemTypes.js
+++ b/src/itemTypes.js
@@ -24,8 +24,11 @@ export const VISUALIZATION_TYPE_CHART = 'CHART';
 export const VISUALIZATION_TYPE_MAP = 'MAP';
 
 export const spacerContent = 'SPACER_ITEM_FOR_DASHBOARD_LAYOUT_CONVENIENCE';
+export const emptyTextItemContent = 'TEXT_ITEM_WITH_NO_CONTENT';
 export const isSpacerType = item =>
     item.type === TEXT && item.text === spacerContent;
+export const isTextType = item =>
+    item.type === TEXT && item.text !== spacerContent;
 
 // Item type map
 export const itemTypeMap = {

--- a/src/reducers/dashboards.js
+++ b/src/reducers/dashboards.js
@@ -2,7 +2,12 @@
 
 import arrayFrom from 'd2-utilizr/lib/arrayFrom';
 import { orArray, orNull, orObject } from '../util';
-import { SPACER, isSpacerType } from '../itemTypes';
+import {
+    SPACER,
+    isSpacerType,
+    isTextType,
+    emptyTextItemContent,
+} from '../itemTypes';
 
 /**
  * Action types for the dashboard reducer
@@ -88,8 +93,13 @@ export const getCustomDashboards = data => {
     const uiItems = items =>
         items.map(item => {
             const type = isSpacerType(item) ? SPACER : item.type;
+            const text = isTextType(item)
+                ? item.text === emptyTextItemContent ? '' : item.text
+                : null;
+
             return {
                 ...item,
+                ...(text !== null ? { text } : {}),
                 type,
             };
         });


### PR DESCRIPTION
- Make the view and edit mode look more alike with margins, padding, centering, font size, line height, so the user gets a better idea of how it will look in view mode.
- Add ItemHeader in Edit mode
- If the user saves a text item that has no content, then we need to save some placeholder text, because the backend requires the text property to have content. Convert this "empty string" content to "" for the UI
