### PR TITLE
Add delete dashboard functionality

### DIFF
--- a/src/ControlBarContainer/ConfirmDeleteDialog.js
+++ b/src/ControlBarContainer/ConfirmDeleteDialog.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import Dialog from 'material-ui/Dialog';
+import Button from 'd2-ui/lib/button/Button';
+import { colors } from '../colors';
+
+const style = {
+    button: {
+        color: colors.royalBlue,
+        backgroundColor: 'transparent',
+        border: 'none',
+        fontSize: '14px',
+        fontWeight: 500,
+        textTransform: 'uppercase',
+        padding: '5px',
+        height: '36px',
+        cursor: 'pointer',
+    },
+};
+
+const ConfirmDeleteDialog = ({
+    dashboardName,
+    onDeleteConfirmed,
+    onContinueEditing,
+    open,
+}) => {
+    const actions = [
+        <Button onClick={onDeleteConfirmed} style={style.button}>
+            Delete
+        </Button>,
+        <Button onClick={onContinueEditing} style={style.button}>
+            Continue editing
+        </Button>,
+    ];
+
+    return (
+        <Dialog
+            title="Confirm delete dashboard"
+            actions={actions}
+            modal={true}
+            open={open}
+        >
+            {`Are you sure you want to delete dashboard "${dashboardName}"?`}
+        </Dialog>
+    );
+};
+
+export default ConfirmDeleteDialog;

--- a/src/ControlBarContainer/EditBar.js
+++ b/src/ControlBarContainer/EditBar.js
@@ -61,8 +61,6 @@ class EditBar extends Component {
     };
 
     componentDidMount() {
-        console.log('CDM', this.props.dashboardId);
-
         apiFetchSelected(this.props.dashboardId).then(dashboardModel =>
             this.setState({ dashboardModel })
         );
@@ -110,8 +108,6 @@ class EditBar extends Component {
             deleteAccess,
         } = this.props;
         const controlBarHeight = getOuterHeight(1, false);
-
-        console.log('dashboardId', dashboardId);
 
         return (
             <Fragment>
@@ -161,10 +157,9 @@ const mapStateToProps = state => {
     const dashboard = sGetEditDashboard(state);
 
     return {
-        dashboardId: dashboard.id || '',
-        dashboardName: dashboard.name || '',
-        deleteAccess:
-            dashboard && dashboard.access ? dashboard.access.delete : false,
+        dashboardId: dashboard.id,
+        dashboardName: dashboard.name,
+        deleteAccess: dashboard.access ? dashboard.access.delete : false,
     };
 };
 

--- a/src/ControlBarContainer/EditBar.js
+++ b/src/ControlBarContainer/EditBar.js
@@ -3,8 +3,10 @@ import { connect } from 'react-redux';
 import ControlBar from 'd2-ui/lib/controlbar/ControlBar';
 import Button from 'd2-ui/lib/button/Button';
 import TranslationDialog from 'd2-ui/lib/i18n/TranslationDialog.component';
+import ConfirmDeleteDialog from './ConfirmDeleteDialog';
 import { colors } from '../colors';
 import { tSaveDashboard, acClearEditDashboard } from '../actions/editDashboard';
+import { tDeleteDashboard } from '../actions/dashboards';
 import { sGetEditDashboard } from '../reducers/editDashboard';
 import { CONTROL_BAR_ROW_HEIGHT, getOuterHeight } from './ControlBarContainer';
 import { apiFetchSelected } from '../api/dashboards';
@@ -18,7 +20,7 @@ const styles = {
         boxShadow:
             '0 0 2px 0 rgba(0,0,0,0.12), 0 2px 2px 0 rgba(0,0,0,0.24), 0 0 8px 0 rgba(0,0,0,0.12), 0 0 8px 0 rgba(0,0,0,0.24)',
     },
-    discard: {
+    secondary: {
         color: colors.royalBlue,
         backgroundColor: 'transparent',
         border: 'none',
@@ -28,6 +30,7 @@ const styles = {
         padding: '5px',
         height: '36px',
         cursor: 'pointer',
+        marginLeft: '10px',
     },
     buttonBar: {
         height: CONTROL_BAR_ROW_HEIGHT,
@@ -41,9 +44,25 @@ class EditBar extends Component {
     state = {
         translationDialogIsOpen: false,
         dashboardModel: undefined,
+        confirmDeleteDialogOpen: false,
+    };
+
+    onConfirmDelete = () => {
+        this.setState({ confirmDeleteDialogOpen: true });
+    };
+
+    onContinueEditing = () => {
+        this.setState({ confirmDeleteDialogOpen: false });
+    };
+
+    onDeleteConfirmed = () => {
+        this.setState({ confirmDeleteDialogOpen: false });
+        this.props.onDelete(this.props.dashboardId);
     };
 
     componentDidMount() {
+        console.log('CDM', this.props.dashboardId);
+
         apiFetchSelected(this.props.dashboardId).then(dashboardModel =>
             this.setState({ dashboardModel })
         );
@@ -54,6 +73,16 @@ class EditBar extends Component {
             translationDialogIsOpen: !this.state.translationDialogIsOpen,
         });
     };
+
+    confirmDeleteDialog = () =>
+        this.props.deleteAccess && this.props.dashboardId ? (
+            <ConfirmDeleteDialog
+                dashboardName={this.props.dashboardName}
+                onDeleteConfirmed={this.onDeleteConfirmed}
+                onContinueEditing={this.onContinueEditing}
+                open={this.state.confirmDeleteDialogOpen}
+            />
+        ) : null;
 
     translationDialog = () =>
         this.state.dashboardModel ? (
@@ -73,8 +102,16 @@ class EditBar extends Component {
         ) : null;
 
     render() {
-        const { style, onSave, onDiscard } = this.props;
+        const {
+            style,
+            onSave,
+            onDiscard,
+            dashboardId,
+            deleteAccess,
+        } = this.props;
         const controlBarHeight = getOuterHeight(1, false);
+
+        console.log('dashboardId', dashboardId);
 
         return (
             <Fragment>
@@ -88,26 +125,48 @@ class EditBar extends Component {
                             <Button style={styles.save} onClick={onSave}>
                                 Save Changes
                             </Button>
-                            <Button onClick={this.toggleTranslationDialog}>
+                            {dashboardId && deleteAccess ? (
+                                <button
+                                    style={styles.secondary}
+                                    onClick={this.onConfirmDelete}
+                                >
+                                    Delete dashboard
+                                </button>
+                            ) : null}
+                            <Button
+                                style={styles.secondary}
+                                onClick={this.toggleTranslationDialog}
+                            >
                                 Translate
                             </Button>
                         </div>
                         <div style={style.rightControls}>
-                            <button style={styles.discard} onClick={onDiscard}>
+                            <button
+                                style={styles.secondary}
+                                onClick={onDiscard}
+                            >
                                 Exit without saving
                             </button>
                         </div>
                     </div>
                 </ControlBar>
                 {this.translationDialog()}
+                {this.confirmDeleteDialog()}
             </Fragment>
         );
     }
 }
 
-const mapStateToProps = state => ({
-    dashboardId: sGetEditDashboard(state).id,
-});
+const mapStateToProps = state => {
+    const dashboard = sGetEditDashboard(state);
+
+    return {
+        dashboardId: dashboard.id || '',
+        dashboardName: dashboard.name || '',
+        deleteAccess:
+            dashboard && dashboard.access ? dashboard.access.delete : false,
+    };
+};
 
 const mapDispatchToProps = dispatch => {
     return {
@@ -116,6 +175,9 @@ const mapDispatchToProps = dispatch => {
         },
         onDiscard: () => {
             dispatch(acClearEditDashboard());
+        },
+        onDelete: id => {
+            dispatch(tDeleteDashboard(id));
         },
     };
 };

--- a/src/actions/dashboards.js
+++ b/src/actions/dashboards.js
@@ -12,7 +12,10 @@ import {
     apiStarDashboard,
     apiDeleteDashboard,
 } from '../api/dashboards';
-import { getPreferredDashboard } from '../api/localStorage';
+import {
+    getPreferredDashboard,
+    deletePreferredDashboard,
+} from '../api/localStorage';
 import { arrayToIdMap } from '../util';
 
 // actions
@@ -81,7 +84,7 @@ export const tStarDashboard = (id, isStarred) => async (dispatch, getState) => {
     }
 };
 
-export const tDeleteDashboard = id => async dispatch => {
+export const tDeleteDashboard = id => async (dispatch, getState) => {
     const onSuccess = () => {
         dispatch(acClearEditDashboard());
 
@@ -90,6 +93,7 @@ export const tDeleteDashboard = id => async dispatch => {
 
     try {
         await apiDeleteDashboard(id);
+        deletePreferredDashboard(sGetUsername(getState()));
 
         return onSuccess();
     } catch (err) {

--- a/src/actions/dashboards.js
+++ b/src/actions/dashboards.js
@@ -93,7 +93,6 @@ export const tDeleteDashboard = id => async (dispatch, getState) => {
 
     try {
         await apiDeleteDashboard(id);
-        deletePreferredDashboard(sGetUsername(getState()));
 
         return onSuccess();
     } catch (err) {

--- a/src/actions/dashboards.js
+++ b/src/actions/dashboards.js
@@ -89,9 +89,7 @@ export const tDeleteDashboard = id => async dispatch => {
     };
 
     try {
-        const response = await apiDeleteDashboard(id);
-
-        console.log('delete response', response);
+        await apiDeleteDashboard(id);
 
         return onSuccess();
     } catch (err) {

--- a/src/actions/dashboards.js
+++ b/src/actions/dashboards.js
@@ -12,10 +12,7 @@ import {
     apiStarDashboard,
     apiDeleteDashboard,
 } from '../api/dashboards';
-import {
-    getPreferredDashboard,
-    deletePreferredDashboard,
-} from '../api/localStorage';
+import { getPreferredDashboard } from '../api/localStorage';
 import { arrayToIdMap } from '../util';
 
 // actions

--- a/src/api/dashboards.js
+++ b/src/api/dashboards.js
@@ -59,3 +59,13 @@ export const apiStarDashboard = (id, isStarred) => {
         }
     });
 };
+
+export const apiDeleteDashboard = id => {
+    return getInstance()
+        .then(d2 => {
+            return d2.models.dashboards
+                .get(id)
+                .then(dashboard => dashboard.delete());
+        })
+        .catch(onError);
+};

--- a/src/api/localStorage.js
+++ b/src/api/localStorage.js
@@ -4,3 +4,7 @@ export const getPreferredDashboard = username =>
 export const storePreferredDashboard = (username, dashboardId) => {
     localStorage.setItem(`dhis2.dashboard.current.${username}`, dashboardId);
 };
+
+export const deletePreferredDashboard = username => {
+    localStorage.setItem(`dhis2.dashboard.current.${username}`, null);
+};

--- a/src/api/localStorage.js
+++ b/src/api/localStorage.js
@@ -4,7 +4,3 @@ export const getPreferredDashboard = username =>
 export const storePreferredDashboard = (username, dashboardId) => {
     localStorage.setItem(`dhis2.dashboard.current.${username}`, dashboardId);
 };
-
-export const deletePreferredDashboard = username => {
-    localStorage.setItem(`dhis2.dashboard.current.${username}`, null);
-};


### PR DESCRIPTION
The delete dashboard button is available in edit mode on pre-existing dashboards, if the user has delete access. For new dashboards, the button is not needed since the user can just exit without saving.