### PR TITLE
Rename the dashboard 'starred' property to 'favorite' when saving dashboard

### DIFF
--- a/src/actions/editDashboard.js
+++ b/src/actions/editDashboard.js
@@ -95,8 +95,12 @@ export const tSaveDashboard = () => async (dispatch, getState) => {
         };
     });
 
+    const { id, name, description, starred: favorite } = dashboard;
     const dashboardToSave = {
-        ...dashboard,
+        id,
+        name,
+        description,
+        favorite,
         dashboardItems,
     };
 


### PR DESCRIPTION
The api expects a property named 'favorite', but in the frontend, 'starred' is a more meaningful and less dubious name (so keep the name 'starred' for frontend). This change also restricts the properties sent to the ones that the user may have changed. (except for the 'id' property, which is obviously needed for identification).