### PR TITLE
Upgrade d2 to v29

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "case-sensitive-paths-webpack-plugin": "2.1.1",
         "chalk": "1.1.3",
         "css-loader": "0.28.7",
-        "d2": "^28.3.0",
+        "d2": "^29.0.0",
         "d2-manifest": "^1.0.0",
         "d2-ui": "^29.0.0",
         "d2-utilizr": "^0.2.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1941,9 +1941,9 @@ d2-utilizr@^0.2.15:
     lodash.isset "^4.3.0"
     lodash.isstring "^4.0.1"
 
-d2@^28.3.0:
-  version "28.3.0"
-  resolved "https://registry.yarnpkg.com/d2/-/d2-28.3.0.tgz#7ca7e5369849aa5d8e8e3659c3b46999541508ff"
+d2@^29.0.0:
+  version "29.0.0"
+  resolved "https://registry.yarnpkg.com/d2/-/d2-29.0.0.tgz#c49925be87dee8f7cd950821c01e3d6e4209c268"
   dependencies:
     docdash "^0.4.0"
     jsdoc "^3.5.5"


### PR DESCRIPTION
v29 includes the fix for the bug where starred dashboard status is lost when saving a dashboard