### PR TITLE
Add new dashboard items to top of dashboard when in edit mode

### DIFF
--- a/src/ItemGrid/gridUtil.js
+++ b/src/ItemGrid/gridUtil.js
@@ -8,6 +8,8 @@ export const GRID_ROW_HEIGHT = 10;
 const GRID_COLUMN_WIDTH_PX = 20;
 const GRID_LAYOUT = 'FLEXIBLE'; // FIXED | FLEXIBLE
 
+export const NEW_ITEM_SHAPE = { x: 0, y: 0, w: 20, h: 29 };
+
 // Dimensions for getShape
 
 const NUMBER_OF_ITEM_COLS = 2;

--- a/src/ItemGrid/gridUtil.js
+++ b/src/ItemGrid/gridUtil.js
@@ -71,15 +71,6 @@ export const withShape = items =>
             hasShape(item) ? item : Object.assign({}, item, getShape(index))
     );
 
-export const getYMax = (items = []) => {
-    return !items.length
-        ? 0
-        : items.reduce(
-              (tot, item) => (item.y + item.h > tot ? item.y + item.h : tot),
-              0
-          );
-};
-
 export const getGridItemDomId = id => `item-${id}`;
 
 export function onItemResize(id) {

--- a/src/ItemSelect/ItemSelectList.js
+++ b/src/ItemSelect/ItemSelectList.js
@@ -9,7 +9,6 @@ import SvgIcon from 'd2-ui/lib/svg-icon/SvgIcon';
 import { acAddDashboardItem } from '../actions/editDashboard';
 import { tAddListItemContent } from './actions';
 import { sGetEditDashboard } from '../reducers/editDashboard';
-import { getYMax } from '../ItemGrid/gridUtil';
 import {
     itemTypeMap,
     getItemUrl,
@@ -37,11 +36,9 @@ class ItemSelectList extends Component {
         const {
             type,
             dashboardId,
-            dashboardItems,
             acAddDashboardItem,
             tAddListItemContent,
         } = this.props;
-        const yValue = getYMax(dashboardItems);
 
         const newItem = {
             id: item.id,
@@ -54,9 +51,9 @@ class ItemSelectList extends Component {
         } else if (type === APP) {
             newItem.id = newItem.appKey = item.key;
 
-            acAddDashboardItem({ type, content: newItem }, yValue);
+            acAddDashboardItem({ type, content: newItem });
         } else {
-            acAddDashboardItem({ type, content: newItem }, yValue);
+            acAddDashboardItem({ type, content: newItem });
         }
     };
 
@@ -167,7 +164,6 @@ ItemSelectList.contextTypes = {
 export default connect(
     state => ({
         dashboardId: sGetEditDashboard(state).id,
-        dashboardItems: sGetEditDashboard(state).dashboardItems,
     }),
     {
         acAddDashboardItem,

--- a/src/ItemSelect/ItemSelectSingle.js
+++ b/src/ItemSelect/ItemSelectSingle.js
@@ -6,8 +6,6 @@ import { List, ListItem } from 'material-ui/List';
 import Button from 'd2-ui/lib/button/Button';
 import SvgIcon from 'd2-ui/lib/svg-icon/SvgIcon';
 import { acAddDashboardItem } from '../actions/editDashboard';
-import { sGetEditDashboard } from '../reducers/editDashboard';
-import { getYMax } from '../ItemGrid/gridUtil';
 
 const SingleItem = ({ item, onAddToDashboard }) => {
     return (
@@ -35,11 +33,9 @@ const SingleItem = ({ item, onAddToDashboard }) => {
     );
 };
 
-const ItemSelectSingle = ({ dashboardItems, acAddDashboardItem, category }) => {
+const ItemSelectSingle = ({ acAddDashboardItem, category }) => {
     const addToDashboard = ({ type, content }) => () => {
-        const yValue = getYMax(dashboardItems);
-
-        acAddDashboardItem({ type, content }, yValue);
+        acAddDashboardItem({ type, content });
     };
 
     return (
@@ -68,9 +64,7 @@ const ItemSelectSingle = ({ dashboardItems, acAddDashboardItem, category }) => {
 };
 
 export default connect(
-    state => ({
-        dashboardItems: sGetEditDashboard(state).dashboardItems,
-    }),
+    null,
     {
         acAddDashboardItem,
     },

--- a/src/ItemSelect/actions.js
+++ b/src/ItemSelect/actions.js
@@ -1,5 +1,4 @@
 import { sGetEditDashboard } from '../reducers/editDashboard';
-import { getYMax } from '../ItemGrid/gridUtil';
 import { itemTypeMap } from '../itemTypes';
 import {
     acAddDashboardItem,
@@ -30,6 +29,6 @@ export const tAddListItemContent = (dashboardId, type, content) => (
             content: [content],
         };
 
-        dispatch(acAddDashboardItem(dashboardItem, getYMax(dashboardItems)));
+        dispatch(acAddDashboardItem(dashboardItem));
     }
 };

--- a/src/actions/editDashboard.js
+++ b/src/actions/editDashboard.js
@@ -3,6 +3,7 @@ import { actionTypes } from '../reducers';
 import { fromEditDashboard } from '../reducers';
 import { updateDashboard, postDashboard } from '../api/editDashboard';
 import { fromSelected } from '.';
+import { NEW_ITEM_SHAPE } from '../ItemGrid/gridUtil';
 import {
     itemTypeMap,
     isSpacerType,
@@ -46,7 +47,7 @@ export const acUpdateDashboardLayout = value => ({
     value,
 });
 
-export const acAddDashboardItem = (item, yValue) => {
+export const acAddDashboardItem = item => {
     const type = item.type;
     delete item.type;
     const itemPropName = itemTypeMap[type].propName;
@@ -57,11 +58,7 @@ export const acAddDashboardItem = (item, yValue) => {
             id: generateUid(),
             type,
             [itemPropName]: item.content,
-            // TODO pass these as arguments
-            x: 0,
-            y: yValue,
-            h: 20,
-            w: 29,
+            ...NEW_ITEM_SHAPE,
         },
     };
 };

--- a/src/reducers/__tests__/editDashboard.spec.js
+++ b/src/reducers/__tests__/editDashboard.spec.js
@@ -157,7 +157,7 @@ describe('editDashboard', () => {
             );
 
             const expectedState = update(initialState, {
-                dashboardItems: { $push: [newItem] },
+                dashboardItems: { $unshift: [newItem] },
             });
 
             expect(actualState).toMatchObject(expectedState);

--- a/src/reducers/editDashboard.js
+++ b/src/reducers/editDashboard.js
@@ -41,7 +41,7 @@ export default (state = DEFAULT_STATE, action) => {
         }
         case actionTypes.ADD_DASHBOARD_ITEM:
             return update(state, {
-                dashboardItems: { $push: [action.value] },
+                dashboardItems: { $unshift: [action.value] },
             });
         case actionTypes.REMOVE_DASHBOARD_ITEM: {
             const idToRemove = action.value;


### PR DESCRIPTION
To put a new dashboard at the top left position, the y value of the shape needs to be 0, and the new item needs to be added to the beginning of the array of dashboard items ($unshift fn) instead of the end of the array.