### PR TITLE
Disable or remove active links on items when in edit mode

### DIFF
--- a/src/Item/MessagesItem/Item.js
+++ b/src/Item/MessagesItem/Item.js
@@ -70,9 +70,11 @@ class MessagesItem extends Component {
     }
 
     messageHref = id => {
-        return `${
-            this.context.baseUrl
-        }/dhis-web-messaging/readMessage.action?id=${id}`;
+        return this.props.editMode
+            ? '#'
+            : `${
+                  this.context.baseUrl
+              }/dhis-web-messaging/readMessage.action?id=${id}`;
     };
 
     filterAll = () => {

--- a/src/Item/PluginItem/Item.js
+++ b/src/Item/PluginItem/Item.js
@@ -69,12 +69,14 @@ class Item extends Component {
                 <span title={favorite.getName(item)} style={style.title}>
                     {favorite.getName(item)}
                 </span>
-                <a
-                    href={favorite.getLink(item, this.context.d2)}
-                    style={{ height: 16 }}
-                >
-                    <SvgIcon icon="Launch" style={style.icon} />
-                </a>
+                {!this.props.editMode ? (
+                    <a
+                        href={favorite.getLink(item, this.context.d2)}
+                        style={{ height: 16 }}
+                    >
+                        <SvgIcon icon="Launch" style={style.icon} />
+                    </a>
+                ) : null}
             </div>
         );
 


### PR DESCRIPTION
So that the user doesn't inadvertently click themselves away from editing the dashboard.
- remove the Launch button on the items
- for messages items, set href=# so the messages look the same but don't do anything