### PR TITLE
Add snackbar that shows message about loading dashboard

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -40,6 +40,12 @@ class App extends Component {
     };
 
     render() {
+        console.log(
+            'render App, with snackbar prop',
+            this.props.snackbarMessage,
+            !!this.props.snackbarMessage
+        );
+
         return (
             <div className="app-wrapper">
                 <HeaderBar />
@@ -49,7 +55,7 @@ class App extends Component {
                     <ItemGridCt />
                 </PageContainer>
                 <Snackbar
-                    open={!!this.props.snackbarMessage}
+                    open={this.props.snackbarOpen}
                     message={
                         <SnackbarMessage message={this.props.snackbarMessage} />
                     }
@@ -62,8 +68,9 @@ class App extends Component {
 }
 
 const mapStateToProps = state => {
-    const { message, duration } = fromSnackbar.sGetSnackbar(state);
+    const { message, duration, open } = fromSnackbar.sGetSnackbar(state);
     return {
+        snackbarOpen: open,
         snackbarMessage: message,
         snackbarDuration: duration,
     };

--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ import PageContainer from './PageContainer/PageContainer';
 import ControlBarContainer from './ControlBarContainer/ControlBarContainer';
 import TitleBarCt from './TitleBar/TitleBar';
 import ItemGridCt from './ItemGrid/ItemGrid';
+import SnackbarMessage from './SnackbarMessage';
 
 import { fromDashboards, fromUser } from './actions';
 import { acSnackbarClosed } from './actions/snackbar';
@@ -49,7 +50,9 @@ class App extends Component {
                 </PageContainer>
                 <Snackbar
                     open={!!this.props.snackbarMessage}
-                    message={this.props.snackbarMessage}
+                    message={
+                        <SnackbarMessage message={this.props.snackbarMessage} />
+                    }
                     autoHideDuration={this.props.snackbarDuration}
                     onRequestClose={this.props.onCloseSnackbar}
                 />
@@ -60,7 +63,6 @@ class App extends Component {
 
 const mapStateToProps = state => {
     const { message, duration } = fromSnackbar.sGetSnackbar(state);
-
     return {
         snackbarMessage: message,
         snackbarDuration: duration,

--- a/src/App.js
+++ b/src/App.js
@@ -67,10 +67,6 @@ const mapStateToProps = state => {
     };
 };
 
-const mapDispatchToProps = {
-    acSnackbarClosed,
-};
-
 App.contextTypes = {
     d2: PropTypes.object,
     store: PropTypes.object,
@@ -80,6 +76,8 @@ App.childContextTypes = {
     baseUrl: PropTypes.string,
 };
 
-const AppCt = connect(mapStateToProps, mapDispatchToProps)(App);
+const AppCt = connect(mapStateToProps, {
+    acSnackbarClosed,
+})(App);
 
 export default AppCt;

--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,11 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import HeaderBarComponent from 'd2-ui/lib/app-header/HeaderBar';
 import headerBarStore$ from 'd2-ui/lib/app-header/headerBar.store';
 import withStateFrom from 'd2-ui/lib/component-helpers/withStateFrom';
+import Snackbar from 'material-ui/Snackbar';
 
 import PageContainer from './PageContainer/PageContainer';
 import ControlBarContainer from './ControlBarContainer/ControlBarContainer';
@@ -11,6 +13,8 @@ import TitleBarCt from './TitleBar/TitleBar';
 import ItemGridCt from './ItemGrid/ItemGrid';
 
 import { fromDashboards, fromUser } from './actions';
+import { acSnackbarClosed } from './actions/snackbar';
+import { fromSnackbar } from './reducers';
 
 import './App.css';
 
@@ -30,6 +34,10 @@ class App extends Component {
         };
     }
 
+    onCloseSnackbar = () => {
+        this.props.acSnackbarClosed();
+    };
+
     render() {
         return (
             <div className="app-wrapper">
@@ -39,10 +47,29 @@ class App extends Component {
                     <TitleBarCt />
                     <ItemGridCt />
                 </PageContainer>
+                <Snackbar
+                    open={!!this.props.snackbarMessage}
+                    message={this.props.snackbarMessage}
+                    autoHideDuration={this.props.snackbarDuration}
+                    onRequestClose={this.props.onCloseSnackbar}
+                />
             </div>
         );
     }
 }
+
+const mapStateToProps = state => {
+    const { message, duration } = fromSnackbar.sGetSnackbar(state);
+
+    return {
+        snackbarMessage: message,
+        snackbarDuration: duration,
+    };
+};
+
+const mapDispatchToProps = {
+    acSnackbarClosed,
+};
 
 App.contextTypes = {
     d2: PropTypes.object,
@@ -53,4 +80,6 @@ App.childContextTypes = {
     baseUrl: PropTypes.string,
 };
 
-export default App;
+const AppCt = connect(mapStateToProps, mapDispatchToProps)(App);
+
+export default AppCt;

--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,7 @@ import ItemGridCt from './ItemGrid/ItemGrid';
 import SnackbarMessage from './SnackbarMessage';
 
 import { fromDashboards, fromUser } from './actions';
-import { acSnackbarClosed } from './actions/snackbar';
+import { acCloseSnackbar } from './actions/snackbar';
 import { fromSnackbar } from './reducers';
 
 import './App.css';
@@ -36,7 +36,7 @@ class App extends Component {
     }
 
     onCloseSnackbar = () => {
-        this.props.acSnackbarClosed();
+        this.props.acCloseSnackbar();
     };
 
     render() {
@@ -79,7 +79,7 @@ App.childContextTypes = {
 };
 
 const AppCt = connect(mapStateToProps, {
-    acSnackbarClosed,
+    acCloseSnackbar,
 })(App);
 
 export default AppCt;

--- a/src/App.js
+++ b/src/App.js
@@ -40,12 +40,6 @@ class App extends Component {
     };
 
     render() {
-        console.log(
-            'render App, with snackbar prop',
-            this.props.snackbarMessage,
-            !!this.props.snackbarMessage
-        );
-
         return (
             <div className="app-wrapper">
                 <HeaderBar />

--- a/src/ControlBarContainer/DashboardsBar.js
+++ b/src/ControlBarContainer/DashboardsBar.js
@@ -33,7 +33,8 @@ const dashboardBarStyles = {
 
 const EXPANDED_ROW_COUNT = 10;
 
-const onDashboardSelectWrapper = (id, onClick) => () => id && onClick(id);
+const onDashboardSelectWrapper = (id, name, onClick) => () =>
+    id && onClick(id, name);
 
 // FIXME: TO BE USED IN 2.30
 // const ListViewButton = () => (
@@ -99,6 +100,7 @@ const DashboardsBar = ({
                             onChangeName={onChangeFilterName}
                             onKeypressEnter={onDashboardSelectWrapper(
                                 orObject(orArray(dashboards)[0]).id,
+                                orObject(orArray(dashboards)[0]).displayName,
                                 onSelectDashboard
                             )}
                         />
@@ -112,6 +114,7 @@ const DashboardsBar = ({
                         selected={dashboard.id === selectedId}
                         onClick={onDashboardSelectWrapper(
                             dashboard.id,
+                            dashboard.displayName,
                             onSelectDashboard
                         )}
                     />
@@ -199,7 +202,8 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
         },
         onChangeFilterName: name =>
             dispatch(fromDashboardsFilter.acSetFilterName(name)),
-        onSelectDashboard: id => dispatch(fromActions.tSelectDashboardById(id)),
+        onSelectDashboard: (id, name) =>
+            dispatch(fromActions.tSelectDashboardById(id, name)),
     };
 };
 

--- a/src/SnackbarMessage.js
+++ b/src/SnackbarMessage.js
@@ -4,14 +4,16 @@ const LOADING_DASHBOARD = 'LOADING_DASHBOARD';
 export const loadingDashboardMsg = { name: '', type: LOADING_DASHBOARD };
 
 const SnackbarMessage = ({ message }) => {
-    // if (message.type === LOADING_DASHBOARD) {
-    return (
-        <span>
-            Loading <span style={{ fontWeight: 800 }}>{message.name}</span>{' '}
-            dashboard
-        </span>
-    );
-    // }
+    if (typeof message === 'object') {
+        //future message types:  switch(message.type)
+        return (
+            <span>
+                Loading <span style={{ fontWeight: 800 }}>{message.name}</span>{' '}
+                dashboard
+            </span>
+        );
+    }
+    return message;
 };
 
 export default SnackbarMessage;

--- a/src/SnackbarMessage.js
+++ b/src/SnackbarMessage.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
-export const LOADING_DASHBOARD = 'LOADING_DASHBOARD';
+const LOADING_DASHBOARD = 'LOADING_DASHBOARD';
+export const loadingDashboardMsg = { name: '', type: LOADING_DASHBOARD };
 
 const SnackbarMessage = ({ message }) => {
     // if (message.type === LOADING_DASHBOARD) {

--- a/src/SnackbarMessage.js
+++ b/src/SnackbarMessage.js
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export const LOADING_DASHBOARD = 'LOADING_DASHBOARD';
+
+const SnackbarMessage = ({ message }) => {
+    // if (message.type === LOADING_DASHBOARD) {
+    return (
+        <span>
+            Loading <span style={{ fontWeight: 800 }}>{message.name}</span>{' '}
+            dashboard
+        </span>
+    );
+    // }
+};
+
+export default SnackbarMessage;

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -17,9 +17,9 @@ export {
 };
 
 // depends on: fromSelected, fromDashboardsFilter, fromControlBar
-export const tSelectDashboardById = id => dispatch => {
+export const tSelectDashboardById = (id, name) => dispatch => {
     // select dashboard by id
-    dispatch(fromSelected.tSetSelectedDashboardById(id));
+    dispatch(fromSelected.tSetSelectedDashboardById(id, name));
 
     // reset filter
     dispatch(fromDashboardsFilter.acSetFilterName());

--- a/src/actions/selected.js
+++ b/src/actions/selected.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import { actionTypes } from '../reducers';
 import { apiFetchSelected } from '../api/dashboards';
 import { acSetDashboards } from './dashboards';
@@ -6,6 +7,7 @@ import { tGetMessages } from '../Item/MessagesItem/actions';
 import { acReceivedSnackbarMessage, acSnackbarClosed } from './snackbar';
 import { storePreferredDashboardId } from '../api/localStorage';
 import { fromUser, fromSelected } from '../reducers';
+import { LOADING_DASHBOARD } from '../SnackbarMessage';
 import {
     REPORT_TABLE,
     CHART,
@@ -41,8 +43,10 @@ export const receivedVisualization = value => ({
     value,
 });
 
+// const LoadingMesage = name => <span>Loading {name} dashboard</span>;
+
 // thunks
-export const tSetSelectedDashboardById = (id, name) => async (
+export const tSetSelectedDashboardById = (id, name = '') => async (
     dispatch,
     getState
 ) => {
@@ -51,7 +55,7 @@ export const tSetSelectedDashboardById = (id, name) => async (
         if (fromSelected.sGetSelectedIsLoading(getState())) {
             dispatch(
                 acReceivedSnackbarMessage({
-                    message: `Loading "${name}" dashboard`,
+                    message: { name, type: LOADING_DASHBOARD },
                     open: true,
                 })
             );
@@ -90,7 +94,7 @@ export const tSetSelectedDashboardById = (id, name) => async (
             acSetDashboards(
                 {
                     ...selected,
-                    dashboardItems: withShape(selected.dashboardItems), // TODO get shape from backend instead
+                    dashboardItems: withShape(selected.dashboardItems),
                 },
                 true
             )

--- a/src/actions/selected.js
+++ b/src/actions/selected.js
@@ -6,7 +6,7 @@ import { tGetMessages } from '../Item/MessagesItem/actions';
 import { acReceivedSnackbarMessage, acCloseSnackbar } from './snackbar';
 import { storePreferredDashboardId } from '../api/localStorage';
 import { fromUser, fromSelected } from '../reducers';
-import { LOADING_DASHBOARD } from '../SnackbarMessage';
+import { loadingDashboardMsg } from '../SnackbarMessage';
 import {
     REPORT_TABLE,
     CHART,
@@ -48,11 +48,17 @@ export const tSetSelectedDashboardById = (id, name = '') => async (
     getState
 ) => {
     dispatch(acSetSelectedIsLoading(true));
+    console.log('create timeout');
+
     const snackbarTimeout = setTimeout(() => {
-        if (fromSelected.sGetSelectedIsLoading(getState())) {
+        if (fromSelected.sGetSelectedIsLoading(getState()) && name) {
+            console.log('dispatch loading msg for ', name);
+
+            loadingDashboardMsg.name = name;
+
             dispatch(
                 acReceivedSnackbarMessage({
-                    message: { name, type: LOADING_DASHBOARD },
+                    message: loadingDashboardMsg,
                     open: true,
                 })
             );
@@ -99,7 +105,11 @@ export const tSetSelectedDashboardById = (id, name = '') => async (
 
         dispatch(acSetSelectedId(id));
         dispatch(acSetSelectedIsLoading(false));
+        console.log('clear timeout');
+
         clearTimeout(snackbarTimeout);
+        console.log('close snackbar');
+
         dispatch(acCloseSnackbar());
         return selected;
     };

--- a/src/actions/selected.js
+++ b/src/actions/selected.js
@@ -48,12 +48,9 @@ export const tSetSelectedDashboardById = (id, name = '') => async (
     getState
 ) => {
     dispatch(acSetSelectedIsLoading(true));
-    console.log('create timeout');
 
     const snackbarTimeout = setTimeout(() => {
         if (fromSelected.sGetSelectedIsLoading(getState()) && name) {
-            console.log('dispatch loading msg for ', name);
-
             loadingDashboardMsg.name = name;
 
             dispatch(
@@ -105,12 +102,9 @@ export const tSetSelectedDashboardById = (id, name = '') => async (
 
         dispatch(acSetSelectedId(id));
         dispatch(acSetSelectedIsLoading(false));
-        console.log('clear timeout');
-
         clearTimeout(snackbarTimeout);
-        console.log('close snackbar');
-
         dispatch(acCloseSnackbar());
+
         return selected;
     };
 

--- a/src/actions/selected.js
+++ b/src/actions/selected.js
@@ -3,8 +3,9 @@ import { apiFetchSelected } from '../api/dashboards';
 import { acSetDashboards } from './dashboards';
 import { withShape } from '../ItemGrid/gridUtil';
 import { tGetMessages } from '../Item/MessagesItem/actions';
+import { acReceivedSnackbarMessage, acSnackbarClosed } from './snackbar';
 import { storePreferredDashboardId } from '../api/localStorage';
-import { fromUser } from '../reducers';
+import { fromUser, fromSelected } from '../reducers';
 import {
     REPORT_TABLE,
     CHART,
@@ -41,9 +42,21 @@ export const receivedVisualization = value => ({
 });
 
 // thunks
-
-export const tSetSelectedDashboardById = id => async (dispatch, getState) => {
+export const tSetSelectedDashboardById = (id, name) => async (
+    dispatch,
+    getState
+) => {
     dispatch(acSetSelectedIsLoading(true));
+    const snackbarTimeout = setTimeout(() => {
+        if (fromSelected.sGetSelectedIsLoading(getState())) {
+            dispatch(
+                acReceivedSnackbarMessage({
+                    message: `Loading "${name}" dashboard`,
+                    open: true,
+                })
+            );
+        }
+    }, 500);
 
     const onSuccess = selected => {
         selected.dashboardItems.forEach(item => {
@@ -85,6 +98,8 @@ export const tSetSelectedDashboardById = id => async (dispatch, getState) => {
 
         dispatch(acSetSelectedId(id));
         dispatch(acSetSelectedIsLoading(false));
+        clearTimeout(snackbarTimeout);
+        dispatch(acSnackbarClosed());
         return selected;
     };
 

--- a/src/actions/selected.js
+++ b/src/actions/selected.js
@@ -1,10 +1,9 @@
-import React from 'react';
 import { actionTypes } from '../reducers';
 import { apiFetchSelected } from '../api/dashboards';
 import { acSetDashboards } from './dashboards';
 import { withShape } from '../ItemGrid/gridUtil';
 import { tGetMessages } from '../Item/MessagesItem/actions';
-import { acReceivedSnackbarMessage, acSnackbarClosed } from './snackbar';
+import { acReceivedSnackbarMessage, acCloseSnackbar } from './snackbar';
 import { storePreferredDashboardId } from '../api/localStorage';
 import { fromUser, fromSelected } from '../reducers';
 import { LOADING_DASHBOARD } from '../SnackbarMessage';
@@ -42,8 +41,6 @@ export const receivedVisualization = value => ({
     type: actionTypes.RECEIVED_VISUALIZATION,
     value,
 });
-
-// const LoadingMesage = name => <span>Loading {name} dashboard</span>;
 
 // thunks
 export const tSetSelectedDashboardById = (id, name = '') => async (
@@ -103,7 +100,7 @@ export const tSetSelectedDashboardById = (id, name = '') => async (
         dispatch(acSetSelectedId(id));
         dispatch(acSetSelectedIsLoading(false));
         clearTimeout(snackbarTimeout);
-        dispatch(acSnackbarClosed());
+        dispatch(acCloseSnackbar());
         return selected;
     };
 

--- a/src/actions/snackbar.js
+++ b/src/actions/snackbar.js
@@ -5,6 +5,6 @@ export const acReceivedSnackbarMessage = value => ({
     value,
 });
 
-export const acSnackbarClosed = () => ({
+export const acCloseSnackbar = () => ({
     type: actionTypes.SNACKBAR_CLOSED,
 });

--- a/src/actions/snackbar.js
+++ b/src/actions/snackbar.js
@@ -1,10 +1,10 @@
 import { actionTypes } from '../reducers';
 
 export const acReceivedSnackbarMessage = value => ({
-    type: actionTypes.RECEIVED_MESSAGE,
+    type: actionTypes.RECEIVED_SNACKBAR_MESSAGE,
     value,
 });
 
 export const acCloseSnackbar = () => ({
-    type: actionTypes.SNACKBAR_CLOSED,
+    type: actionTypes.CLOSE_SNACKBAR,
 });

--- a/src/actions/snackbar.js
+++ b/src/actions/snackbar.js
@@ -1,0 +1,10 @@
+import { actionTypes } from '../reducers';
+
+export const acReceivedSnackbarMessage = value => ({
+    type: actionTypes.RECEIVED_MESSAGE,
+    value,
+});
+
+export const acSnackbarClosed = () => ({
+    type: actionTypes.SNACKBAR_CLOSED,
+});

--- a/src/reducers/__tests__/snackbar.spec.js
+++ b/src/reducers/__tests__/snackbar.spec.js
@@ -1,0 +1,89 @@
+import reducer, { actionTypes, DEFAULT_STATE } from '../snackbar';
+
+describe('snackbar reducer', () => {
+    it('should return the default state', () => {
+        const actualState = reducer(undefined, {});
+
+        expect(actualState).toEqual(DEFAULT_STATE);
+    });
+
+    it('should handle RECEIVED_MESSAGE action with only message', () => {
+        const message = 'Loading "tinkywinky" dashboard';
+
+        const action = {
+            type: actionTypes.RECEIVED_MESSAGE,
+            value: {
+                message,
+            },
+        };
+
+        const expectedState = {
+            message,
+            duration: null,
+        };
+
+        const actualState = reducer(DEFAULT_STATE, action);
+        expect(actualState).toEqual(expectedState);
+    });
+
+    it('should handle RECEIVED_MESSAGE action with only message with duration previously set', () => {
+        const message = 'Loading "tinkywinky" dashboard';
+        const duration = 3000;
+
+        const action = {
+            type: actionTypes.RECEIVED_MESSAGE,
+            value: {
+                message,
+            },
+        };
+
+        const expectedState = {
+            message,
+            duration,
+        };
+
+        const currentState = {
+            message: 'You just won 1000 dollars',
+            duration,
+        };
+
+        const actualState = reducer(currentState, action);
+        expect(actualState).toEqual(expectedState);
+    });
+
+    it('should handle RECEIVED_MESSAGE action with message and duration', () => {
+        const message = 'Loading "tinkywinky" dashboard';
+        const duration = 3000;
+
+        const action = {
+            type: actionTypes.RECEIVED_MESSAGE,
+            value: {
+                message,
+                duration,
+            },
+        };
+
+        const expectedState = {
+            message,
+            duration,
+        };
+
+        const actualState = reducer(DEFAULT_STATE, action);
+        expect(actualState).toEqual(expectedState);
+    });
+
+    it('should handle the SNACKBAR_CLOSED action', () => {
+        const action = {
+            type: actionTypes.SNACKBAR_CLOSED,
+        };
+
+        const currentState = {
+            message: 'You just won 1000 dollars',
+            duration: 3000,
+        };
+
+        const actualState = reducer(currentState, action);
+
+        expect(actualState).toEqual(DEFAULT_STATE);
+    });
+});

--- a/src/reducers/__tests__/snackbar.spec.js
+++ b/src/reducers/__tests__/snackbar.spec.js
@@ -20,6 +20,7 @@ describe('snackbar reducer', () => {
         const expectedState = {
             message,
             duration: null,
+            open: false,
         };
 
         const actualState = reducer(DEFAULT_STATE, action);
@@ -40,11 +41,13 @@ describe('snackbar reducer', () => {
         const expectedState = {
             message,
             duration,
+            open: true,
         };
 
         const currentState = {
             message: 'You just won 1000 dollars',
             duration,
+            open: true,
         };
 
         const actualState = reducer(currentState, action);
@@ -54,18 +57,21 @@ describe('snackbar reducer', () => {
     it('should handle RECEIVED_MESSAGE action with message and duration', () => {
         const message = 'Loading "tinkywinky" dashboard';
         const duration = 3000;
+        const open = true;
 
         const action = {
             type: actionTypes.RECEIVED_MESSAGE,
             value: {
                 message,
                 duration,
+                open,
             },
         };
 
         const expectedState = {
             message,
             duration,
+            open,
         };
 
         const actualState = reducer(DEFAULT_STATE, action);
@@ -80,6 +86,7 @@ describe('snackbar reducer', () => {
         const currentState = {
             message: 'You just won 1000 dollars',
             duration: 3000,
+            open: true,
         };
 
         const actualState = reducer(currentState, action);

--- a/src/reducers/__tests__/snackbar.spec.js
+++ b/src/reducers/__tests__/snackbar.spec.js
@@ -7,11 +7,11 @@ describe('snackbar reducer', () => {
         expect(actualState).toEqual(DEFAULT_STATE);
     });
 
-    it('should handle RECEIVED_MESSAGE action with only message', () => {
+    it('should handle RECEIVED_SNACKBAR_MESSAGE action with only message', () => {
         const message = 'Loading "tinkywinky" dashboard';
 
         const action = {
-            type: actionTypes.RECEIVED_MESSAGE,
+            type: actionTypes.RECEIVED_SNACKBAR_MESSAGE,
             value: {
                 message,
             },
@@ -27,12 +27,12 @@ describe('snackbar reducer', () => {
         expect(actualState).toEqual(expectedState);
     });
 
-    it('should handle RECEIVED_MESSAGE action with only message with duration previously set', () => {
+    it('should handle RECEIVED_SNACKBAR_MESSAGE action with only message with duration previously set', () => {
         const message = 'Loading "tinkywinky" dashboard';
         const duration = 3000;
 
         const action = {
-            type: actionTypes.RECEIVED_MESSAGE,
+            type: actionTypes.RECEIVED_SNACKBAR_MESSAGE,
             value: {
                 message,
             },
@@ -54,13 +54,13 @@ describe('snackbar reducer', () => {
         expect(actualState).toEqual(expectedState);
     });
 
-    it('should handle RECEIVED_MESSAGE action with message and duration', () => {
+    it('should handle RECEIVED_SNACKBAR_MESSAGE action with message and duration', () => {
         const message = 'Loading "tinkywinky" dashboard';
         const duration = 3000;
         const open = true;
 
         const action = {
-            type: actionTypes.RECEIVED_MESSAGE,
+            type: actionTypes.RECEIVED_SNACKBAR_MESSAGE,
             value: {
                 message,
                 duration,
@@ -78,9 +78,9 @@ describe('snackbar reducer', () => {
         expect(actualState).toEqual(expectedState);
     });
 
-    it('should handle the SNACKBAR_CLOSED action', () => {
+    it('should handle the CLOSE_SNACKBAR action', () => {
         const action = {
-            type: actionTypes.SNACKBAR_CLOSED,
+            type: actionTypes.CLOSE_SNACKBAR,
         };
 
         const currentState = {

--- a/src/reducers/__tests__/snackbar.spec.js
+++ b/src/reducers/__tests__/snackbar.spec.js
@@ -7,8 +7,11 @@ describe('snackbar reducer', () => {
         expect(actualState).toEqual(DEFAULT_STATE);
     });
 
-    it('should handle RECEIVED_SNACKBAR_MESSAGE action with only message', () => {
-        const message = 'Loading "tinkywinky" dashboard';
+    it('should handle RECEIVED_SNACKBAR_MESSAGE action with message object containing only message text', () => {
+        const message = {
+            name: 'Loading "tinkywinky" dashboard',
+            type: 'LOADING_TINKYWINKY',
+        };
 
         const action = {
             type: actionTypes.RECEIVED_SNACKBAR_MESSAGE,
@@ -27,8 +30,11 @@ describe('snackbar reducer', () => {
         expect(actualState).toEqual(expectedState);
     });
 
-    it('should handle RECEIVED_SNACKBAR_MESSAGE action with only message with duration previously set', () => {
-        const message = 'Loading "tinkywinky" dashboard';
+    it('should handle RECEIVED_SNACKBAR_MESSAGE action with message object with duration previously set', () => {
+        const message = {
+            name: 'Loading "tinkywinky" dashboard',
+            type: 'LOADING_TINKYWINKY',
+        };
         const duration = 3000;
 
         const action = {
@@ -54,7 +60,34 @@ describe('snackbar reducer', () => {
         expect(actualState).toEqual(expectedState);
     });
 
-    it('should handle RECEIVED_SNACKBAR_MESSAGE action with message and duration', () => {
+    it('should handle RECEIVED_SNACKBAR_MESSAGE action with message object containing text and duration', () => {
+        const message = {
+            name: 'Loading "tinkywinky" dashboard',
+            type: 'LOADING_TINKYWINKY',
+        };
+        const duration = 3000;
+        const open = true;
+
+        const action = {
+            type: actionTypes.RECEIVED_SNACKBAR_MESSAGE,
+            value: {
+                message,
+                duration,
+                open,
+            },
+        };
+
+        const expectedState = {
+            message,
+            duration,
+            open,
+        };
+
+        const actualState = reducer(DEFAULT_STATE, action);
+        expect(actualState).toEqual(expectedState);
+    });
+
+    it('should handle RECEIVED_SNACKBAR_MESSAGE action with message string', () => {
         const message = 'Loading "tinkywinky" dashboard';
         const duration = 3000;
         const open = true;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -9,6 +9,7 @@ import visualizations, * as fromVisualizations from './visualizations';
 import editDashboard, * as fromEditDashboard from './editDashboard';
 import messages, * as fromMessages from './messages';
 import user, * as fromUser from './user';
+import snackbar, * as fromSnackbar from './snackbar';
 import itemFilter, * as fromItemFilter from './itemFilter';
 import style, * as fromStyle from './style';
 
@@ -28,6 +29,7 @@ export const actionTypes = {
     ...fromEditDashboard.actionTypes,
     ...fromItemFilter.actionTypes,
     ...fromStyle.actionTypes,
+    ...fromSnackbar.actionTypes,
 };
 
 // reducers
@@ -44,6 +46,7 @@ export default combineReducers({
     editDashboard,
     itemFilter,
     style,
+    snackbar,
 });
 
 // map constants to data
@@ -69,6 +72,7 @@ export {
     fromUser,
     fromItemFilter,
     fromStyle,
+    fromSnackbar,
 };
 
 // selected dashboard

--- a/src/reducers/snackbar.js
+++ b/src/reducers/snackbar.js
@@ -1,0 +1,26 @@
+export const actionTypes = {
+    RECEIVED_MESSAGE: 'RECEIVED_MESSAGE',
+    SNACKBAR_CLOSED: 'SNACKBAR_CLOSED',
+};
+
+export const DEFAULT_STATE = {
+    message: '',
+    duration: null,
+};
+
+export default (state = DEFAULT_STATE, action) => {
+    switch (action.type) {
+        case actionTypes.RECEIVED_MESSAGE: {
+            return { ...state, ...action.value };
+        }
+        case actionTypes.SNACKBAR_CLOSED: {
+            return DEFAULT_STATE;
+        }
+        default:
+            return state;
+    }
+};
+
+// selectors
+
+export const sGetSnackbar = state => state.snackbar || DEFAULT_STATE;

--- a/src/reducers/snackbar.js
+++ b/src/reducers/snackbar.js
@@ -6,6 +6,7 @@ export const actionTypes = {
 export const DEFAULT_STATE = {
     message: {},
     duration: null,
+    open: false,
 };
 
 export default (state = DEFAULT_STATE, action) => {

--- a/src/reducers/snackbar.js
+++ b/src/reducers/snackbar.js
@@ -1,6 +1,6 @@
 export const actionTypes = {
-    RECEIVED_MESSAGE: 'RECEIVED_MESSAGE',
-    SNACKBAR_CLOSED: 'SNACKBAR_CLOSED',
+    RECEIVED_SNACKBAR_MESSAGE: 'RECEIVED_SNACKBAR_MESSAGE',
+    CLOSE_SNACKBAR: 'CLOSE_SNACKBAR',
 };
 
 export const DEFAULT_STATE = {
@@ -11,10 +11,10 @@ export const DEFAULT_STATE = {
 
 export default (state = DEFAULT_STATE, action) => {
     switch (action.type) {
-        case actionTypes.RECEIVED_MESSAGE: {
+        case actionTypes.RECEIVED_SNACKBAR_MESSAGE: {
             return { ...state, ...action.value };
         }
-        case actionTypes.SNACKBAR_CLOSED: {
+        case actionTypes.CLOSE_SNACKBAR: {
             return DEFAULT_STATE;
         }
         default:

--- a/src/reducers/snackbar.js
+++ b/src/reducers/snackbar.js
@@ -4,7 +4,7 @@ export const actionTypes = {
 };
 
 export const DEFAULT_STATE = {
-    message: '',
+    message: {},
     duration: null,
 };
 


### PR DESCRIPTION
If loading the dashboard takes more than 500ms, then show a snackbar message indicating that loading is happening.

The snackbar can be reused for communicating other messages as well. Because of this, I left in the commented out line checking for message type in SnackbarMessage.js, even though there is currently only one message type. Future message types will be: Dashboard item added/removed. Possibly also error messages.

You might notice that I am reusing the loadingDashboardMsg object rather than creating a new object for each message. This is because of some buggy behaviour that is described in the MUI snackbar documentation.