### PR TITLE
Fix crash if user has no permission to see analytics apps

### DIFF
--- a/src/Item/PluginItem/Item.js
+++ b/src/Item/PluginItem/Item.js
@@ -43,9 +43,7 @@ class Item extends Component {
     state = {
         showFooter: false,
         activeVisualization: this.props.item.type,
-        pluginIsAvailable: itemTypeMap[this.props.item.type].plugin
-            ? true
-            : false,
+        pluginIsAvailable: !!itemTypeMap[this.props.item.type].plugin,
     };
 
     pluginCredentials = null;

--- a/src/Item/PluginItem/plugin.js
+++ b/src/Item/PluginItem/plugin.js
@@ -113,22 +113,26 @@ export const reload = async (item, targetType, credentials, filter) => {
 
     const plugin = itemTypeMap[targetType].plugin;
 
-    loadPlugin(plugin, config, credentials);
+    if (plugin && plugin.load) {
+        loadPlugin(plugin, config, credentials);
+    }
 };
 
 export const load = (item, credentials, filter) => {
     let plugin = itemTypeMap[item.type].plugin;
 
-    const configuredFilter = configureFilter(filter);
-    const favorite = extractFavorite(item);
-    const itemConfig = {
-        id: favorite.id,
-        el: getGridItemDomId(item.id),
-        hideTitle: !favorite.title,
-        ...configuredFilter,
-    };
+    if (plugin && plugin.load) {
+        const configuredFilter = configureFilter(filter);
+        const favorite = extractFavorite(item);
+        const itemConfig = {
+            id: favorite.id,
+            el: getGridItemDomId(item.id),
+            hideTitle: !favorite.title,
+            ...configuredFilter,
+        };
 
-    loadPlugin(plugin, itemConfig, credentials);
+        loadPlugin(plugin, itemConfig, credentials);
+    }
 };
 
 export const resize = item => {


### PR DESCRIPTION
If a user does not have permission to see an analytics app (in user
roles) access to the whole app folder is denied, which causes the plugin
request to fail, causing errors when trying to call a function on it (like
load/reload).
Instead, show a message informing the user about the unavailable plugin.
We could improve the message suggesting the likely reason for it:
missing permission.
The whole header is also removed, to avoid other errors when clicking
the buttons (ie. launch).
Switching between different visualisation types could work if a user can
see other visualisation apps, but it's inconsistent when trying to go
back to the original visualisation.
Even better would be to hide only the button related to the type of
visualisation that does not work.
Another solution, depending on what the "See app" permission really
means, is to make all the plugins always available, the user then can
see the dashboard item, but won't be able to use the associated app (no
launch button).