### PR TITLE
Fix RP229-34: don't use selected dashboard directly

### DIFF
--- a/src/TitleBar/TitleBar.js
+++ b/src/TitleBar/TitleBar.js
@@ -60,16 +60,13 @@ const mapStateToProps = state => {
         fromReducers.sGetSelectedDashboard(state)
     );
     const dashboard = orObject(
-        fromReducers.fromDashboards.sGetById(
-            state,
-            fromReducers.fromSelected.sGetSelectedId(state)
-        )
+        fromReducers.fromDashboards.sGetById(state, selectedDashboard.id)
     );
 
     return {
         id: selectedDashboard.id,
         name: selectedDashboard.name,
-        displayName: dashboard.displayName,
+        displayName: dashboard && dashboard.displayName,
         description: selectedDashboard.description,
         edit: fromReducers.fromEditDashboard.sGetIsEditing(state),
     };


### PR DESCRIPTION
In the new dashboard scenario, selected dashboard is still initialised
with the last dashboard, to be able to show it again in case the "Exit withou saving" is used.
Use dashboard.id instead, which in this case will be empty as well as
the displayName.