### PR TITLE
Render the previously selected vis when exiting without save

### DIFF
--- a/src/Item/PluginItem/Item.js
+++ b/src/Item/PluginItem/Item.js
@@ -108,14 +108,13 @@ class Item extends Component {
     componentDidMount() {
         this.pluginCredentials = pluginCredentials(this.context.d2);
 
-        const itemType =
-            this.props.visualization.activeType || this.props.item.type;
-
         if (this.pluginIsAvailable()) {
             pluginManager.load(
                 this.props.item,
                 this.pluginCredentials,
-                !this.props.editMode ? itemType : null,
+                !this.props.editMode
+                    ? orObject(this.props.visualization).activeType
+                    : null,
                 this.props.itemFilter
             );
         }

--- a/src/Item/PluginItem/plugin.js
+++ b/src/Item/PluginItem/plugin.js
@@ -75,12 +75,16 @@ const getUserOrgUnitIds = (ouPaths = []) => {
 // if original visualisation, set id and let the plugin handle it
 // otherwise fetch and pass the correct config to the plugin
 const configureFavorite = async (item, activeType) => {
-    const isOriginalVisualisation = item.type === activeType;
+    const isOriginalVisualisation = activeType
+        ? item.type === activeType
+        : true;
     let favorite;
 
     if (isOriginalVisualisation) {
+        const fullFavorite = extractFavorite(item);
         favorite = {
-            id: getId(item),
+            id: fullFavorite.id,
+            hideTitle: !fullFavorite.title,
         };
     } else {
         const fetchedFavorite = await apiFetchFavorite(getId(item), item.type, {
@@ -108,31 +112,17 @@ const configureFilter = (filter = {}) => {
     return Object.assign({}, ...filter, userOrgUnitFilter);
 };
 
-export const reload = async (item, activeType, credentials, filter) => {
+export const load = async (item, credentials, activeType, filter = {}) => {
     const config = {
         ...(await configureFavorite(item, activeType)),
         ...configureFilter(filter),
         el: getGridItemDomId(item.id),
     };
 
-    const plugin = itemTypeMap[activeType].plugin;
+    const type = activeType || item.type;
+    const plugin = itemTypeMap[type].plugin;
 
     loadPlugin(plugin, config, credentials);
-};
-
-export const load = (item, credentials, filter) => {
-    let plugin = itemTypeMap[item.type].plugin;
-
-    const configuredFilter = configureFilter(filter);
-    const favorite = extractFavorite(item);
-    const itemConfig = {
-        id: favorite.id,
-        el: getGridItemDomId(item.id),
-        hideTitle: !favorite.title,
-        ...configuredFilter,
-    };
-
-    loadPlugin(plugin, itemConfig, credentials);
 };
 
 export const resize = item => {


### PR DESCRIPTION
- Removed this.state.activeVisualization since it was never used and potentially wrong
- pluginIsAvailable now checks which plugin is about to be used
- when in Edit mode, the original visualization will be displayed
- after exiting without save, use the activeType to decide which visualization to load.