### PR TITLE
Use css height instead of display flex for items when in view mode

### DIFF
--- a/src/Item/ItemHeader.js
+++ b/src/Item/ItemHeader.js
@@ -1,10 +1,15 @@
 import React from 'react';
 
+export const HEADER_HEIGHT = 45;
+
 const ItemHeader = props => {
     const { title, actionButtons, editMode } = props;
 
     return (
-        <div className="dashboard-item-header">
+        <div
+            className="dashboard-item-header"
+            style={{ height: HEADER_HEIGHT }}
+        >
             <div
                 className="dashboard-item-header-title"
                 style={{ userSelect: editMode ? 'none' : 'text' }}

--- a/src/Item/PluginItem/Item.js
+++ b/src/Item/PluginItem/Item.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import SvgIcon from 'd2-ui/lib/svg-icon/SvgIcon';
-import ItemHeader from '../ItemHeader';
+import ItemHeader, { HEADER_HEIGHT } from '../ItemHeader';
 import ItemFooter from './ItemFooter';
 import PluginItemHeaderButtons from './ItemHeaderButtons';
 
@@ -178,6 +178,13 @@ class Item extends Component {
                 />
             ) : null;
 
+        const PADDING_BOTTOM = 4;
+        const contentStyle = !this.props.editMode
+            ? {
+                  height: item.originalHeight - HEADER_HEIGHT - PADDING_BOTTOM,
+              }
+            : null;
+
         return (
             <Fragment>
                 <ItemHeader
@@ -185,7 +192,11 @@ class Item extends Component {
                     actionButtons={actionButtons}
                     editMode={this.props.editMode}
                 />
-                <div id={elementId} className="dashboard-item-content">
+                <div
+                    id={elementId}
+                    className="dashboard-item-content"
+                    style={contentStyle}
+                >
                     {!pluginIsAvailable ? (
                         <div style={style.textDiv}>
                             Unable to load the plugin for this item

--- a/src/Item/PluginItem/ItemFooter.js
+++ b/src/Item/PluginItem/ItemFooter.js
@@ -5,7 +5,7 @@ import { getId, getDescription } from './plugin';
 
 const style = {
     scrollContainer: {
-        overflowY: 'scroll',
+        overflowY: 'auto',
         height: '370px',
         marginTop: '5px',
         marginBottom: '5px',

--- a/src/ItemGrid/ItemGrid.css
+++ b/src/ItemGrid/ItemGrid.css
@@ -9,7 +9,11 @@
     min-width: 70px;
 }
 
-.react-grid-item.edit {
+.react-grid-item.edit,
+.react-grid-item.RESOURCES,
+.react-grid-item.TEXT,
+.react-grid-item.MESSAGES,
+.react-grid-item.APP {
     display: flex;
     flex-direction: column;
 }
@@ -64,7 +68,11 @@
     overflow: auto;
 }
 
-.react-grid-item.edit .dashboard-item-content {
+.react-grid-item.edit .dashboard-item-content,
+.react-grid-item.RESOURCES .dashboard-item-content,
+.react-grid-item.TEXT .dashboard-item-content,
+.react-grid-item.MESSAGES .dashboard-item-content,
+.react-grid-item.APP .dashboard-item-content {
     flex: 1;
 }
 

--- a/src/ItemGrid/ItemGrid.css
+++ b/src/ItemGrid/ItemGrid.css
@@ -1,14 +1,17 @@
 /* react-grid-layout style */
 
 .react-grid-item {
-    display: flex;
-    flex-direction: column;
     overflow: hidden !important;
     box-shadow: 0px 0px 3px 0px #999999;
     background-color: #ffffff;
     border-radius: 3px;
     min-height: 70px;
     min-width: 70px;
+}
+
+.react-grid-item.edit {
+    display: flex;
+    flex-direction: column;
 }
 
 .react-grid-item.edit:hover {
@@ -38,7 +41,6 @@
 /* dashboard item - header */
 
 .dashboard-item-header {
-    height: 45px;
     font-size: 15px;
     font-weight: 700;
     color: #3a3a3a;
@@ -58,9 +60,12 @@
 /* dashboard item - content */
 
 .dashboard-item-content {
-    flex: 1;
     padding: 0 4px 4px;
     overflow: auto;
+}
+
+.react-grid-item.edit .dashboard-item-content {
+    flex: 1;
 }
 
 .CHART.resizing .dashboard-item-content,

--- a/src/ItemGrid/ItemGrid.js
+++ b/src/ItemGrid/ItemGrid.js
@@ -20,6 +20,7 @@ import DeleteItemButton from './DeleteItemButton';
 import {
     GRID_ROW_HEIGHT,
     GRID_COMPACT_TYPE,
+    MARGIN,
     getGridColumns,
     hasShape,
     onItemResize,
@@ -124,6 +125,7 @@ export class ItemGrid extends Component {
                     onResizeStop={this.onResizeStop}
                     className="layout"
                     layout={items}
+                    margin={MARGIN}
                     cols={getGridColumns()}
                     rowHeight={GRID_ROW_HEIGHT}
                     width={window.innerWidth}

--- a/src/ItemGrid/gridUtil.js
+++ b/src/ItemGrid/gridUtil.js
@@ -7,6 +7,7 @@ export const GRID_COMPACT_TYPE = 'vertical'; // vertical | horizonal | null
 export const GRID_ROW_HEIGHT = 10;
 const GRID_COLUMN_WIDTH_PX = 20;
 const GRID_LAYOUT = 'FLEXIBLE'; // FIXED | FLEXIBLE
+export const MARGIN = [10, 10];
 
 export const NEW_ITEM_SHAPE = { x: 0, y: 0, w: 20, h: 29 };
 
@@ -59,17 +60,40 @@ export const getShape = i => {
 };
 
 /**
- * Returns an array of items that each contain its grid block shape object
+ * Calculates the grid item's original height in pixels based
+ * on the height in grid units. This calculation
+ * is copied directly from react-grid-layout GridItem.js (calcPosition)
+ *
+ * @param {Object} item item containing shape (x, y, w, h)
+ */
+const getOriginalHeight = item => {
+    const originalHeight = Math.round(
+        GRID_ROW_HEIGHT * item.h + Math.max(0, item.h - 1) * MARGIN[1]
+    );
+
+    return { originalHeight };
+};
+
+/**
+ * Returns an array of items containing the x, y, w, h dimensions
+ * and the item's originalheight in pixels
  * @function
  * @param {Array} items
  * @returns {Array}
  */
 
 export const withShape = items =>
-    items.map(
-        (item, index) =>
-            hasShape(item) ? item : Object.assign({}, item, getShape(index))
-    );
+    items.map((item, index) => {
+        const itemWithShape = hasShape(item)
+            ? item
+            : Object.assign({}, item, getShape(index));
+
+        return Object.assign(
+            {},
+            itemWithShape,
+            getOriginalHeight(itemWithShape)
+        );
+    });
 
 export const getGridItemDomId = id => `item-${id}`;
 

--- a/src/actions/selected.js
+++ b/src/actions/selected.js
@@ -77,21 +77,13 @@ export const tSetSelectedDashboardById = (id, name = '') => async (
     }, 500);
 
     const onSuccess = selected => {
-        // update store with selected dashboard
-        // withShape adds shape info to items lacking it
-        // only works properly when all items in a dashboard are missing it
-        // ensures that upgraded dasbboards work before they are re-saved
-        dispatch(
-            acSetDashboards(
-                {
-                    ...selected,
-                    dashboardItems: withShape(selected.dashboardItems),
-                },
-                true
-            )
-        );
+        const dashboard = {
+            ...selected,
+            dashboardItems: withShape(selected.dashboardItems),
+        };
 
-        // store preferred dashboard
+        dispatch(acSetDashboards(dashboard, true));
+
         storePreferredDashboardId(fromUser.sGetUsername(getState()), id);
 
         // add visualizations to store


### PR DESCRIPTION
Fix for the issue where vertical scrollbar appears on the plugin item after expanding then hiding the interpretations while also changing vis types. The display: flex was adjusting the height, but it should stay fixed while in view mode. When in edit mode, it should still use display:flex as the items might get dragged to a different size.