### PR TITLE
Use only row count to determine if dashboards bar is expanded

### DIFF
--- a/src/actions/controlBar.js
+++ b/src/actions/controlBar.js
@@ -3,15 +3,14 @@ import { apiGetControlBarRows } from '../api/controlBar';
 
 // actions
 
-export const acSetControlBarRows = rows => ({
-    type: actionTypes.SET_CONTROLBAR_ROWS,
-    value: rows,
-});
+export const acSetControlBarRows = rows => {
+    console.log('acSetControlBarRows', rows);
 
-export const acSetControlBarExpanded = expanded => ({
-    type: actionTypes.SET_CONTROLBAR_EXPANDED,
-    value: !!expanded,
-});
+    return {
+        type: actionTypes.SET_CONTROLBAR_ROWS,
+        value: rows,
+    };
+};
 
 // thunks
 

--- a/src/actions/controlBar.js
+++ b/src/actions/controlBar.js
@@ -3,14 +3,10 @@ import { apiGetControlBarRows } from '../api/controlBar';
 
 // actions
 
-export const acSetControlBarRows = rows => {
-    console.log('acSetControlBarRows', rows);
-
-    return {
-        type: actionTypes.SET_CONTROLBAR_ROWS,
-        value: rows,
-    };
-};
+export const acSetControlBarRows = rows => ({
+    type: actionTypes.SET_CONTROLBAR_ROWS,
+    value: rows,
+});
 
 // thunks
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -25,5 +25,5 @@ export const tSelectDashboardById = (id, name) => dispatch => {
     dispatch(fromDashboardsFilter.acSetFilterName());
 
     // collapse controlbar
-    dispatch(fromControlBar.acSetControlBarExpanded(false));
+    dispatch(fromControlBar.acSetControlBarRows(1));
 };

--- a/src/reducers/controlBar.js
+++ b/src/reducers/controlBar.js
@@ -4,11 +4,9 @@ import { validateReducer } from '../util';
 
 export const actionTypes = {
     SET_CONTROLBAR_ROWS: 'SET_CONTROLBAR_ROWS',
-    SET_CONTROLBAR_EXPANDED: 'SET_CONTROLBAR_EXPANDED',
 };
 
 export const DEFAULT_ROWS = 1;
-export const DEFAULT_EXPANDED = false;
 
 /**
  * Reducer functions that computes and returns the new state based on the given action
@@ -25,18 +23,8 @@ const rows = (state = DEFAULT_ROWS, action) => {
     }
 };
 
-const expanded = (state = DEFAULT_EXPANDED, action) => {
-    switch (action.type) {
-        case actionTypes.SET_CONTROLBAR_EXPANDED:
-            return validateReducer(action.value, DEFAULT_EXPANDED);
-        default:
-            return state;
-    }
-};
-
 export default combineReducers({
     rows,
-    expanded,
 });
 
 /**
@@ -50,4 +38,3 @@ export const sGetFromState = state => state.controlBar;
 // Selector dependency level 2
 
 export const sGetControlBarRows = state => sGetFromState(state).rows;
-export const sGetControlBarExpanded = state => sGetFromState(state).expanded;


### PR DESCRIPTION
These changes fix https://jira.dhis2.org/browse/RP229-54

Changes included:
- follow the design and change the button titles to "View all dashboards" and "close".
- clicking on the view-all and close buttons will completely expand or contract the dashboards bar, not set it to something in between.
- the number of rows decides if the bar is at max height or not. No need for the "expanded" property.
- when dashboard bar is only partly expanded, then the button will say "view all dashboards" and clicking will expand to full height.