### PR TITLE
Fix launch button for Apps in item selector

### DIFF
--- a/src/ItemSelect/ItemSelectList.js
+++ b/src/ItemSelect/ItemSelectList.js
@@ -122,7 +122,7 @@ class ItemSelectList extends Component {
                                     <a
                                         href={getItemUrl(
                                             this.props.type,
-                                            item.id,
+                                            item,
                                             this.context.d2
                                         )}
                                         style={{ display: 'flex' }}

--- a/src/ItemSelect/ItemSelectList.js
+++ b/src/ItemSelect/ItemSelectList.js
@@ -87,58 +87,64 @@ class ItemSelectList extends Component {
                 </div>
                 <Divider />
                 <List>
-                    {this.props.items.map(item => (
-                        <ListItem
-                            // apps don't have item.id
-                            key={item.id || item.key}
-                            leftIcon={
-                                <SvgIcon
-                                    icon={itemTypeMap[this.props.type].icon}
-                                    style={{ margin: '6px' }}
-                                />
-                            }
-                            innerDivStyle={{ padding: '0px 0px 0px 42px' }}
-                            hoverColor="transparent"
-                            primaryText={
-                                <p
-                                    style={{
-                                        display: 'flex',
-                                        alignItems: 'center',
-                                        justifyContent: 'flex-start',
-                                        margin: 0,
-                                    }}
-                                >
-                                    {item.displayName || item.name}
-                                    <Button
-                                        color="primary"
-                                        onClick={this.addItem(item)}
+                    {this.props.items.map(item => {
+                        const itemUrl = getItemUrl(
+                            this.props.type,
+                            item,
+                            this.context.d2
+                        );
+
+                        return (
+                            <ListItem
+                                // apps don't have item.id
+                                key={item.id || item.key}
+                                leftIcon={
+                                    <SvgIcon
+                                        icon={itemTypeMap[this.props.type].icon}
+                                        style={{ margin: '6px' }}
+                                    />
+                                }
+                                innerDivStyle={{ padding: '0px 0px 0px 42px' }}
+                                hoverColor="transparent"
+                                primaryText={
+                                    <p
                                         style={{
-                                            marginLeft: '5px',
-                                            marginRight: '5px',
+                                            display: 'flex',
+                                            alignItems: 'center',
+                                            justifyContent: 'flex-start',
+                                            margin: 0,
                                         }}
                                     >
-                                        + ADD
-                                    </Button>
-                                    <a
-                                        href={getItemUrl(
-                                            this.props.type,
-                                            item,
-                                            this.context.d2
-                                        )}
-                                        style={{ display: 'flex' }}
-                                    >
-                                        <SvgIcon
-                                            icon="Launch"
+                                        {item.displayName || item.name}
+                                        <Button
+                                            color="primary"
+                                            onClick={this.addItem(item)}
                                             style={{
-                                                width: '16px',
-                                                height: '16px',
+                                                marginLeft: '5px',
+                                                marginRight: '5px',
                                             }}
-                                        />
-                                    </a>
-                                </p>
-                            }
-                        />
-                    ))}
+                                        >
+                                            + ADD
+                                        </Button>
+                                        {itemUrl ? (
+                                            <a
+                                                href={itemUrl}
+                                                style={{ display: 'flex' }}
+                                            >
+                                                <SvgIcon
+                                                    icon="Launch"
+                                                    style={{
+                                                        width: '16px',
+                                                        height: '16px',
+                                                    }}
+                                                />
+                                            </a>
+                                        ) : null}
+                                    </p>
+                                }
+                            />
+                        );
+                    })}
                 </List>
             </Fragment>
         );

--- a/src/itemTypes.js
+++ b/src/itemTypes.js
@@ -146,11 +146,15 @@ export const itemTypeMap = {
 };
 
 export const getItemUrl = (type, item, d2) => {
+    let url;
+
     if (type === APP) {
-        return item.launchUrl;
+        url = item.launchUrl;
     }
 
     if (itemTypeMap[type] && itemTypeMap[type].appUrl) {
-        return `${getBaseUrl(d2)}/${itemTypeMap[type].appUrl(item.id)}`;
+        url = `${getBaseUrl(d2)}/${itemTypeMap[type].appUrl(item.id)}`;
     }
+
+    return url;
 };

--- a/src/itemTypes.js
+++ b/src/itemTypes.js
@@ -145,8 +145,12 @@ export const itemTypeMap = {
     },
 };
 
-export const getItemUrl = (type, id, d2) => {
+export const getItemUrl = (type, item, d2) => {
+    if (type === APP) {
+        return item.launchUrl;
+    }
+
     if (itemTypeMap[type] && itemTypeMap[type].appUrl) {
-        return `${getBaseUrl(d2)}/${itemTypeMap[type].appUrl(id)}`;
+        return `${getBaseUrl(d2)}/${itemTypeMap[type].appUrl(item.id)}`;
     }
 };


### PR DESCRIPTION
The launch button (link) for Apps did not have any URL.
Apps are different from the other ListItem types in that each item has its own launchUrl, while for the other types, the URL is built using the item id which is typically passed as query parameter.