### PR TITLE
Do not show the NO ITEMS message until it is known whether there are any items

### DIFF
--- a/src/ItemGrid/ItemGrid.js
+++ b/src/ItemGrid/ItemGrid.js
@@ -53,7 +53,7 @@ export class ItemGrid extends Component {
         expandedItems: {},
     };
 
-    NO_ITEMS_MESSAGE = i18n.t('You have not added any items');
+    NO_ITEMS_MESSAGE = i18n.t('There are no items on this dashboard');
 
     onToggleItemExpanded = clickedId => {
         const isExpanded =
@@ -100,7 +100,7 @@ export class ItemGrid extends Component {
     render() {
         const { edit, isLoading, dashboardItems } = this.props;
 
-        if (!dashboardItems.length) {
+        if (!isLoading && !dashboardItems.length) {
             return <NoItemsMessage text={this.NO_ITEMS_MESSAGE} />;
         }
 
@@ -190,7 +190,8 @@ const mapStateToProps = state => {
 
     return {
         edit: fromEditDashboard.sGetIsEditing(state),
-        isLoading: fromSelected.sGetSelectedIsLoading(state),
+        isLoading:
+            fromSelected.sGetSelectedIsLoading(state) || !selectedDashboard,
         dashboardItems,
     };
 };


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-2982

Also, NO_ITEMS_MESSAGE was changes to be geared towards both viewers and editors of the dashboard, instead of just editors.

It would perhaps be better to set the isLoading flag in the selector, rather than ItemGrid.js. Want to discuss?