### PR TITLE
Respect user setting for control bar height when clicking on the CLOSE button

### DIFF
--- a/src/ControlBarContainer/DashboardsBar.js
+++ b/src/ControlBarContainer/DashboardsBar.js
@@ -42,9 +42,17 @@ class DashboardsBar extends Component {
         rows: MIN_ROW_COUNT,
     };
 
+    setInitialDashboardState = rows => {
+        this.setState({ rows });
+        this.setState({ isMaxHeight: rows === MAX_ROW_COUNT });
+    };
+
+    componentDidMount() {
+        this.setInitialDashboardState(this.props.userRows);
+    }
+
     componentWillReceiveProps(nextProps) {
-        this.setState({ rows: nextProps.userRows });
-        this.setState({ isMaxHeight: nextProps.userRows === MAX_ROW_COUNT });
+        this.setInitialDashboardState(nextProps.userRows);
     }
 
     onChangeHeight = (newHeight, onEndDrag) => {

--- a/src/ControlBarContainer/DashboardsBar.js
+++ b/src/ControlBarContainer/DashboardsBar.js
@@ -44,6 +44,7 @@ class DashboardsBar extends Component {
 
     componentWillReceiveProps(nextProps) {
         this.setState({ rows: nextProps.userRows });
+        this.setState({ isMaxHeight: nextProps.userRows === MAX_ROW_COUNT });
     }
 
     onChangeHeight = (newHeight, onEndDrag) => {
@@ -71,7 +72,7 @@ class DashboardsBar extends Component {
                 ? this.props.userRows
                 : MAX_ROW_COUNT;
 
-        this.setState({ rows });
+        this.setState({ rows, isMaxHeight: !this.state.isMaxHeight });
     };
 
     render() {
@@ -85,7 +86,7 @@ class DashboardsBar extends Component {
             onSelectDashboard,
         } = this.props;
 
-        const isMaxHeight = this.state.rows === MAX_ROW_COUNT;
+        const isMaxHeight = this.state.isMaxHeight;
         const style = Object.assign({}, controlsStyle, dashboardBarStyles);
         const rowCount = isMaxHeight ? MAX_ROW_COUNT : this.state.rows;
         const contentWrapperStyle = Object.assign(

--- a/src/PageContainer/PageContainer.js
+++ b/src/PageContainer/PageContainer.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 
 import { CONTROL_BAR_ROW_HEIGHT } from '../ControlBarContainer/ControlBarContainer';
 import { sGetIsEditing } from '../reducers/editDashboard';
-import { sGetControlBarRows } from '../reducers/controlBar';
+import { sGetControlBarUserRows } from '../reducers/controlBar';
 
 const DEFAULT_TOP_MARGIN = 80;
 
@@ -16,7 +16,7 @@ const DynamicTopMarginContainer = ({ marginTop, children }) => (
 
 const mapStateToProps = state => {
     const edit = sGetIsEditing(state);
-    const rows = sGetControlBarRows(state);
+    const rows = sGetControlBarUserRows(state);
 
     return {
         marginTop:

--- a/src/actions/controlBar.js
+++ b/src/actions/controlBar.js
@@ -3,11 +3,6 @@ import { apiGetControlBarRows } from '../api/controlBar';
 
 // actions
 
-export const acSetControlBarRows = rows => ({
-    type: actionTypes.SET_CONTROLBAR_ROWS,
-    value: rows,
-});
-
 export const acSetControlBarUserRows = rows => ({
     type: actionTypes.SET_CONTROLBAR_USER_ROWS,
     value: rows,
@@ -18,7 +13,6 @@ export const acSetControlBarUserRows = rows => ({
 export const tSetControlBarRows = () => async (dispatch, getState) => {
     const onSuccess = rows => {
         dispatch(acSetControlBarUserRows(rows));
-        // dispatch(acSetControlBarRows(rows));
     };
 
     const onError = error => {

--- a/src/actions/controlBar.js
+++ b/src/actions/controlBar.js
@@ -3,6 +3,11 @@ import { apiGetControlBarRows } from '../api/controlBar';
 
 // actions
 
+export const acSetControlBarRows = rows => ({
+    type: actionTypes.SET_CONTROLBAR_ROWS,
+    value: rows,
+});
+
 export const acSetControlBarUserRows = rows => ({
     type: actionTypes.SET_CONTROLBAR_USER_ROWS,
     value: rows,

--- a/src/actions/controlBar.js
+++ b/src/actions/controlBar.js
@@ -8,11 +8,17 @@ export const acSetControlBarRows = rows => ({
     value: rows,
 });
 
+export const acSetControlBarUserRows = rows => ({
+    type: actionTypes.SET_CONTROLBAR_USER_ROWS,
+    value: rows,
+});
+
 // thunks
 
 export const tSetControlBarRows = () => async (dispatch, getState) => {
     const onSuccess = rows => {
-        dispatch(acSetControlBarRows(rows));
+        dispatch(acSetControlBarUserRows(rows));
+        // dispatch(acSetControlBarRows(rows));
     };
 
     const onError = error => {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -23,7 +23,4 @@ export const tSelectDashboardById = (id, name) => dispatch => {
 
     // reset filter
     dispatch(fromDashboardsFilter.acSetFilterName());
-
-    // collapse controlbar
-    dispatch(fromControlBar.acSetControlBarRows(1));
 };

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -16,7 +16,7 @@ export {
     fromItemFilter,
 };
 
-// depends on: fromSelected, fromDashboardsFilter, fromControlBar
+// depends on: fromSelected, fromDashboardsFilter
 export const tSelectDashboardById = (id, name) => dispatch => {
     // select dashboard by id
     dispatch(fromSelected.tSetSelectedDashboardById(id, name));

--- a/src/reducers/__tests__/controlBar.spec.js
+++ b/src/reducers/__tests__/controlBar.spec.js
@@ -1,0 +1,23 @@
+import reducer, { actionTypes, DEFAULT_ROWS } from '../controlBar';
+
+describe('controlbar reducer', () => {
+    it('should return the default state', () => {
+        const actualState = reducer(undefined, {});
+
+        expect(actualState).toEqual({ userRows: DEFAULT_ROWS });
+    });
+
+    it('should handle SET_CONTROLBAR_USER_ROWS', () => {
+        const rows = 4;
+        const action = {
+            type: actionTypes.SET_CONTROLBAR_USER_ROWS,
+            value: rows,
+        };
+
+        const expectedState = { userRows: rows };
+
+        const actualState = reducer(undefined, action);
+
+        expect(actualState).toEqual(expectedState);
+    });
+});

--- a/src/reducers/controlBar.js
+++ b/src/reducers/controlBar.js
@@ -4,19 +4,25 @@ import { validateReducer } from '../util';
 
 export const actionTypes = {
     SET_CONTROLBAR_ROWS: 'SET_CONTROLBAR_ROWS',
+    SET_CONTROLBAR_USER_ROWS: 'SET_CONTROLBAR_USER_ROWS',
 };
 
 export const DEFAULT_ROWS = 1;
 
-/**
- * Reducer functions that computes and returns the new state based on the given action
- * @function
- * @param {Object} state The current state
- * @param {Object} action The action to be evaluated
- */
 const rows = (state = DEFAULT_ROWS, action) => {
     switch (action.type) {
         case actionTypes.SET_CONTROLBAR_ROWS:
+            console.log('reducer', state, action);
+            return validateReducer(action.value, DEFAULT_ROWS);
+        default:
+            return state;
+    }
+};
+
+const userRows = (state = DEFAULT_ROWS, action) => {
+    switch (action.type) {
+        case actionTypes.SET_CONTROLBAR_USER_ROWS:
+            console.log('reducer 2', state, action);
             return validateReducer(action.value, DEFAULT_ROWS);
         default:
             return state;
@@ -25,6 +31,7 @@ const rows = (state = DEFAULT_ROWS, action) => {
 
 export default combineReducers({
     rows,
+    userRows,
 });
 
 /**

--- a/src/reducers/controlBar.js
+++ b/src/reducers/controlBar.js
@@ -3,20 +3,10 @@ import { combineReducers } from 'redux';
 import { validateReducer } from '../util';
 
 export const actionTypes = {
-    SET_CONTROLBAR_ROWS: 'SET_CONTROLBAR_ROWS',
     SET_CONTROLBAR_USER_ROWS: 'SET_CONTROLBAR_USER_ROWS',
 };
 
 export const DEFAULT_ROWS = 1;
-
-const rows = (state = DEFAULT_ROWS, action) => {
-    switch (action.type) {
-        case actionTypes.SET_CONTROLBAR_ROWS:
-            return validateReducer(action.value, DEFAULT_ROWS);
-        default:
-            return state;
-    }
-};
 
 const userRows = (state = DEFAULT_ROWS, action) => {
     switch (action.type) {
@@ -28,7 +18,6 @@ const userRows = (state = DEFAULT_ROWS, action) => {
 };
 
 export default combineReducers({
-    rows,
     userRows,
 });
 
@@ -42,4 +31,4 @@ export const sGetFromState = state => state.controlBar;
 
 // Selector dependency level 2
 
-export const sGetControlBarRows = state => sGetFromState(state).rows;
+export const sGetControlBarUserRows = state => sGetFromState(state).userRows;

--- a/src/reducers/controlBar.js
+++ b/src/reducers/controlBar.js
@@ -12,7 +12,6 @@ export const DEFAULT_ROWS = 1;
 const rows = (state = DEFAULT_ROWS, action) => {
     switch (action.type) {
         case actionTypes.SET_CONTROLBAR_ROWS:
-            console.log('reducer', state, action);
             return validateReducer(action.value, DEFAULT_ROWS);
         default:
             return state;
@@ -22,7 +21,6 @@ const rows = (state = DEFAULT_ROWS, action) => {
 const userRows = (state = DEFAULT_ROWS, action) => {
     switch (action.type) {
         case actionTypes.SET_CONTROLBAR_USER_ROWS:
-            console.log('reducer 2', state, action);
             return validateReducer(action.value, DEFAULT_ROWS);
         default:
             return state;


### PR DESCRIPTION
When the user clicks the CLOSE button in the dashboard controlbar, the height should be restored to the user's height setting, not to the minumum height. if the user setting is the same as the maximum height, then clicking on the CLOSE/VIEW_ALL_DASHBOARDS will have no effect, but the button text will change so the user knows that the action has taken place.