### PR TITLE
Dynamic pathname for css dependencies with referrals

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -52,6 +52,9 @@ const globals = Object.assign(
 );
 
 const scriptPrefix = dhisConfig.baseUrl;
+// "http://domain.com" or "https://domain.com" will be split into an array of 3 items 
+// prettier-ignore
+const pathnamePrefix = scriptPrefix.split('/').slice(3).join('/');
 
 // This is the development configuration.
 // It is focused on developer experience and fast rebuilds.
@@ -257,7 +260,7 @@ module.exports = {
             inject: true,
             template: paths.appHtml,
             vendorScripts: [
-                `./dhis-web-core-resource/fonts/roboto.css`,
+                `./${pathnamePrefix}/dhis-web-core-resource/fonts/roboto.css`,
                 `${scriptPrefix}/dhis-web-core-resource/babel-polyfill/6.20.0/dist/polyfill.js`,
                 `${scriptPrefix}/dhis-web-core-resource/react/16.2.0/umd/react.development.js`,
                 `${scriptPrefix}/dhis-web-core-resource/react-dom/16.2.0/umd/react-dom.development.js`,

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -12,6 +12,7 @@ const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin');
 const fs = require('fs');
 const getClientEnvironment = require('./env');
 const paths = require('./paths');
+const parse = require('url-parse');
 
 // Webpack uses `publicPath` to determine where the app is being served from.
 // In development, we always serve from the root. This makes config easier.
@@ -52,9 +53,7 @@ const globals = Object.assign(
 );
 
 const scriptPrefix = dhisConfig.baseUrl;
-// "http://domain.com" or "https://domain.com" will be split into an array of 3 items 
-// prettier-ignore
-const pathnamePrefix = scriptPrefix.split('/').slice(3).join('/');
+const pathnamePrefix = parse(scriptPrefix).pathname;
 
 // This is the development configuration.
 // It is focused on developer experience and fast rebuilds.
@@ -260,7 +259,7 @@ module.exports = {
             inject: true,
             template: paths.appHtml,
             vendorScripts: [
-                `./${pathnamePrefix}/dhis-web-core-resource/fonts/roboto.css`,
+                `.${pathnamePrefix}/dhis-web-core-resource/fonts/roboto.css`,
                 `${scriptPrefix}/dhis-web-core-resource/babel-polyfill/6.20.0/dist/polyfill.js`,
                 `${scriptPrefix}/dhis-web-core-resource/react/16.2.0/umd/react.development.js`,
                 `${scriptPrefix}/dhis-web-core-resource/react-dom/16.2.0/umd/react-dom.development.js`,

--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "d2-i18n-generate": "^1.x",
     "enzyme-adapter-react-16": "^1.1.1",
     "husky": "^0.15.0-rc.12",
-    "jest-enzyme": "^6.0.0"
+    "jest-enzyme": "^6.0.0",
+    "url-parse": "^1.3.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8621,6 +8621,13 @@ url-parse@^1.1.8:
     querystringify "~1.0.0"
     requires-port "~1.0.0"
 
+url-parse@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.3.0.tgz#04a06c420d22beb9804f7ada2d57ad13160a4258"
+  dependencies:
+    querystringify "~1.0.0"
+    requires-port "~1.0.0"
+
 url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"


### PR DESCRIPTION
CSS files that fetch other resources like fonts need to point to the CRA dev server with a relative path to the DHIS instance to prevent CORS issues. This fix enables this to work on machines that have dhis-core running on a non-standard url, i.e. localhost:8080/dhis