### PR TITLE
Separate items from dashboards in redux store (DHIS2-3299)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import withStateFrom from 'd2-ui/lib/component-helpers/withStateFrom';
 import Snackbar from 'material-ui/Snackbar';
 
 import PageContainer from './PageContainer/PageContainer';
+import PageContainerSpacer from './PageContainer/PageContainerSpacer';
 import ControlBarContainer from './ControlBarContainer/ControlBarContainer';
 import SnackbarMessage from './SnackbarMessage';
 
@@ -45,6 +46,7 @@ class App extends Component {
             <div className="app-wrapper">
                 <HeaderBar />
                 <ControlBarContainer />
+                <PageContainerSpacer />
                 <PageContainer />
                 <Snackbar
                     open={this.props.snackbarOpen}

--- a/src/ControlBarContainer/DashboardsBar.js
+++ b/src/ControlBarContainer/DashboardsBar.js
@@ -152,7 +152,7 @@ export class DashboardsBar extends Component {
 }
 
 const mapStateToProps = state => ({
-    dashboards: fromReducers.fromDashboards.sGetFromState(state),
+    dashboards: fromReducers.fromDashboards.sGetById(state),
     name: fromReducers.fromDashboardsFilter.sGetFilterName(state),
     userRows: (state.controlBar && state.controlBar.userRows) || MIN_ROW_COUNT,
     selectedId: sGetSelectedId(state),

--- a/src/Item/PluginItem/Item.js
+++ b/src/Item/PluginItem/Item.js
@@ -216,6 +216,16 @@ Item.contextTypes = {
     d2: PropTypes.object,
 };
 
+Item.propTypes = {
+    itemFilter: PropTypes.object,
+    visualization: PropTypes.object,
+};
+
+Item.defaultProps = {
+    itemFilter: {},
+    visualization: {},
+};
+
 const mapStateToProps = (state, ownProps) => ({
     itemFilter: fromItemFilter.sGetFromState(state),
     visualization: sGetVisualization(

--- a/src/Item/SpacerItem/Item.js
+++ b/src/Item/SpacerItem/Item.js
@@ -1,12 +1,13 @@
 import React, { Fragment } from 'react';
 import i18n from 'd2-i18n';
 import ItemHeader from '../ItemHeader';
+import { colors } from '../../colors';
 
 const style = {
     margin: '21px 28px',
     fontSize: '14px',
     lineHeight: '18px',
-    color: '#666',
+    color: colors.charcoalGrey,
 };
 
 const SpacerItem = () => {

--- a/src/Item/SpacerItem/Item.js
+++ b/src/Item/SpacerItem/Item.js
@@ -3,9 +3,10 @@ import i18n from 'd2-i18n';
 import ItemHeader from '../ItemHeader';
 
 const style = {
-    margin: '10px',
-    fontSize: '15px',
+    margin: '21px 28px',
+    fontSize: '14px',
     lineHeight: '18px',
+    color: '#666',
 };
 
 const SpacerItem = () => {

--- a/src/Item/TextItem/Item.js
+++ b/src/Item/TextItem/Item.js
@@ -7,6 +7,8 @@ import Line from '../../widgets/Line';
 import TextField from 'd2-ui/lib/text-field/TextField';
 import { acUpdateDashboardItem } from '../../actions/editDashboard';
 import { sGetSelectedDashboard } from '../../reducers';
+import { orArray } from '../../util';
+import { sGetItems } from '../../reducers/dashboards';
 
 const style = {
     textDiv: {
@@ -72,14 +74,11 @@ const TextItem = props => {
     return <Fragment>{editMode ? editItem() : viewItem()}</Fragment>;
 };
 
-export default connect(
-    (state, ownProps) => ({
-        text:
-            sGetSelectedDashboard(state).dashboardItems.find(
-                item => item.id === ownProps.item.id
-            ).text || '',
-    }),
-    {
-        acUpdateDashboardItem,
-    }
-)(TextItem);
+const mapStateToProps = (state, ownProps) => ({
+    text:
+        sGetItems(state).find(item => item.id === ownProps.item.id).text || '',
+});
+
+export default connect(mapStateToProps, {
+    acUpdateDashboardItem,
+})(TextItem);

--- a/src/Item/TextItem/Item.js
+++ b/src/Item/TextItem/Item.js
@@ -6,7 +6,7 @@ import ItemHeader from '../ItemHeader';
 import Line from '../../widgets/Line';
 import TextField from 'd2-ui/lib/text-field/TextField';
 import { acUpdateDashboardItem } from '../../actions/editDashboard';
-import { sGetItems } from '../../reducers/dashboards';
+import { sGetCurrentDashboardItems } from '../../reducers';
 
 const style = {
     textDiv: {
@@ -74,7 +74,9 @@ const TextItem = props => {
 
 const mapStateToProps = (state, ownProps) => ({
     text:
-        sGetItems(state).find(item => item.id === ownProps.item.id).text || '',
+        sGetCurrentDashboardItems(state).find(
+            item => item.id === ownProps.item.id
+        ).text || '',
 });
 
 export default connect(mapStateToProps, {

--- a/src/Item/TextItem/Item.js
+++ b/src/Item/TextItem/Item.js
@@ -6,8 +6,6 @@ import ItemHeader from '../ItemHeader';
 import Line from '../../widgets/Line';
 import TextField from 'd2-ui/lib/text-field/TextField';
 import { acUpdateDashboardItem } from '../../actions/editDashboard';
-import { sGetSelectedDashboard } from '../../reducers';
-import { orArray } from '../../util';
 import { sGetItems } from '../../reducers/dashboards';
 
 const style = {

--- a/src/ItemGrid/ItemGrid.css
+++ b/src/ItemGrid/ItemGrid.css
@@ -42,6 +42,12 @@
     user-select: none;
 }
 
+/* react-resizable */
+
+.react-resizable-handle {
+    background: none;
+}
+
 /* dashboard item - header */
 
 .dashboard-item-header {

--- a/src/ItemGrid/ItemGrid.js
+++ b/src/ItemGrid/ItemGrid.js
@@ -186,9 +186,7 @@ const mapDispatchToProps = {
 };
 
 const mergeProps = (stateProps, dispatchProps) => {
-    console.log('stateProps.dashboardItems', stateProps.dashboardItems);
     const validItems = orArray(stateProps.dashboardItems).filter(hasShape);
-    console.log('validItems', validItems);
 
     return {
         ...dispatchProps,

--- a/src/ItemGrid/ItemGrid.js
+++ b/src/ItemGrid/ItemGrid.js
@@ -165,21 +165,18 @@ ItemGrid.defaultProps = {
 const mapStateToProps = state => {
     const {
         sGetSelectedDashboard,
+        sGetCurrentDashboardItems,
         fromSelected,
         fromEditDashboard,
     } = fromReducers;
 
     const selectedDashboard = sGetSelectedDashboard(state);
 
-    const dashboardItems = selectedDashboard
-        ? selectedDashboard.dashboardItems
-        : null;
-
     return {
         edit: fromEditDashboard.sGetIsEditing(state),
         isLoading:
             fromSelected.sGetSelectedIsLoading(state) || !selectedDashboard,
-        dashboardItems,
+        dashboardItems: sGetCurrentDashboardItems(state),
     };
 };
 
@@ -200,8 +197,6 @@ const mergeProps = (stateProps, dispatchProps) => {
     };
 };
 
-const ItemGridCt = connect(mapStateToProps, mapDispatchToProps, mergeProps)(
+export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(
     ItemGrid
 );
-
-export default ItemGridCt;

--- a/src/ItemGrid/ItemGrid.js
+++ b/src/ItemGrid/ItemGrid.js
@@ -186,7 +186,9 @@ const mapDispatchToProps = {
 };
 
 const mergeProps = (stateProps, dispatchProps) => {
+    console.log('stateProps.dashboardItems', stateProps.dashboardItems);
     const validItems = orArray(stateProps.dashboardItems).filter(hasShape);
+    console.log('validItems', validItems);
 
     return {
         ...dispatchProps,

--- a/src/PageContainer/PageContainer.js
+++ b/src/PageContainer/PageContainer.js
@@ -1,22 +1,17 @@
-// Adjust the top margin of the page so it starts below the control bar
 import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import isEmpty from 'lodash/isEmpty';
 import i18n from 'd2-i18n';
 
-import { CONTROL_BAR_ROW_HEIGHT } from '../ControlBarContainer/ControlBarContainer';
 import { sGetIsEditing } from '../reducers/editDashboard';
-import { sGetControlBarUserRows } from '../reducers/controlBar';
 import { sGetFromState } from '../reducers/dashboards';
 import TitleBar from '../TitleBar/TitleBar';
 import ItemGrid from '../ItemGrid/ItemGrid';
 import NoContentMessage from '../widgets/NoContentMessage';
 
-const DEFAULT_TOP_MARGIN = 80;
-
 export const PageContainer = props => {
     const Content = () =>
-        !isEmpty(props.dashboards) || props.edit ? (
+        !props.dashboardsIsEmpty || props.edit ? (
             <Fragment>
                 <TitleBar />
                 <ItemGrid />
@@ -30,26 +25,20 @@ export const PageContainer = props => {
         );
 
     return (
-        <div
-            className="dashboard-wrapper"
-            style={{ marginTop: props.marginTop }}
-        >
-            {props.dashboards === null ? null : <Content />}
+        <div className="dashboard-wrapper">
+            {props.dashboardsIsNull ? null : <Content />}
         </div>
     );
-    // }
 };
 
 const mapStateToProps = state => {
     const edit = sGetIsEditing(state);
-    const rows = sGetControlBarUserRows(state);
     const dashboards = sGetFromState(state);
 
     return {
-        marginTop:
-            DEFAULT_TOP_MARGIN + CONTROL_BAR_ROW_HEIGHT * (edit ? 1 : rows),
         edit,
-        dashboards,
+        dashboardsIsEmpty: isEmpty(dashboards),
+        dashboardsIsNull: dashboards === null,
     };
 };
 

--- a/src/PageContainer/PageContainerSpacer.js
+++ b/src/PageContainer/PageContainerSpacer.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import { CONTROL_BAR_ROW_HEIGHT } from '../ControlBarContainer/ControlBarContainer';
+import { sGetIsEditing } from '../reducers/editDashboard';
+import { sGetControlBarUserRows } from '../reducers/controlBar';
+
+const DEFAULT_TOP_MARGIN = 80;
+
+const PageContainerSpacer = props => (
+    <div className="page-spacer" style={{ marginTop: props.marginTop }} />
+);
+
+const mapStateToProps = state => {
+    const edit = sGetIsEditing(state);
+    const rows = sGetControlBarUserRows(state);
+
+    return {
+        marginTop:
+            DEFAULT_TOP_MARGIN + CONTROL_BAR_ROW_HEIGHT * (edit ? 1 : rows),
+    };
+};
+
+export default connect(mapStateToProps)(PageContainerSpacer);

--- a/src/PageContainer/PageContainerSpacer.js
+++ b/src/PageContainer/PageContainerSpacer.js
@@ -8,7 +8,10 @@ import { sGetControlBarUserRows } from '../reducers/controlBar';
 const DEFAULT_TOP_MARGIN = 80;
 
 const PageContainerSpacer = props => (
-    <div className="page-spacer" style={{ marginTop: props.marginTop }} />
+    <div
+        className="page-container-top-margin"
+        style={{ marginTop: props.marginTop }}
+    />
 );
 
 const mapStateToProps = state => {

--- a/src/PageContainer/__tests__/PageContainer.spec.js
+++ b/src/PageContainer/__tests__/PageContainer.spec.js
@@ -17,29 +17,27 @@ describe('PageContainer', () => {
 
     beforeEach(() => {
         props = {
-            dashboards: undefined,
             edit: undefined,
-            marginTop: 1,
+            dashboardsIsEmpty: undefined,
+            dashboardsIsNull: undefined,
         };
         shallowPageContainer = undefined;
     });
 
     it('renders a div', () => {
-        props.dashboards = ['dashboard1'];
-        props.edit = false;
         expect(pageContainer().find('div').length).toBeGreaterThan(0);
     });
 
-    describe('when dashboards is null', () => {
+    describe('when "dashboardsIsNull" is true', () => {
         it('does not render any children inside the div', () => {
-            props.dashboards = null;
+            props.dashboardsIsNull = true;
             expect(pageContainer().children().length).toBe(0);
         });
     });
 
-    describe('when dashboards is an empty array', () => {
+    describe('when "dashboardsIsEmpty" is true', () => {
         beforeEach(() => {
-            props.dashboards = [];
+            props.dashboardsIsEmpty = true;
         });
 
         describe('when not in edit mode', () => {
@@ -66,9 +64,9 @@ describe('PageContainer', () => {
         });
     });
 
-    describe('when dashboards is an array with values', () => {
+    describe('when "dashboardsIsEmpty" is false', () => {
         it('renders a Titlebar and ItemGrid', () => {
-            props.dashboards = ['dashboard1'];
+            props.dashboardsIsEmpty = false;
             const children = pageContainer().children();
 
             expect(children.length).toBe(1);

--- a/src/TitleBar/ViewTitleBar.js
+++ b/src/TitleBar/ViewTitleBar.js
@@ -183,6 +183,7 @@ const mapStateToProps = state => {
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
     const selectedDashboard = orObject(stateProps.selectedDashboard);
+    const { starred, dashboardItems, showDescription } = stateProps;
     const { dispatch } = dispatchProps;
 
     return {
@@ -190,24 +191,19 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
         ...ownProps,
         onStarClick: () =>
             dispatch(
-                fromDashboards.tStarDashboard(
-                    selectedDashboard.id,
-                    !stateProps.starred
-                )
+                fromDashboards.tStarDashboard(selectedDashboard.id, !starred)
             ),
         onEditClick: () => {
             dispatch(
                 fromEditDashboard.acSetEditDashboard(
                     selectedDashboard,
-                    stateProps.dashboardItems
+                    dashboardItems
                 )
             );
         },
         onInfoClick: () =>
             dispatch(
-                fromSelected.acSetSelectedShowDescription(
-                    !stateProps.showDescription
-                )
+                fromSelected.acSetSelectedShowDescription(!showDescription)
             ),
     };
 };

--- a/src/TitleBar/ViewTitleBar.js
+++ b/src/TitleBar/ViewTitleBar.js
@@ -171,6 +171,7 @@ const mapStateToProps = state => {
 
     return {
         selectedDashboard,
+        dashboardItems: fromReducers.sGetCurrentDashboardItems(state),
         showDescription: fromReducers.fromSelected.sGetSelectedShowDescription(
             state
         ),
@@ -195,7 +196,12 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
                 )
             ),
         onEditClick: () => {
-            dispatch(fromEditDashboard.acSetEditDashboard(selectedDashboard));
+            dispatch(
+                fromEditDashboard.acSetEditDashboard(
+                    selectedDashboard,
+                    stateProps.dashboardItems
+                )
+            );
         },
         onInfoClick: () =>
             dispatch(

--- a/src/actions/dashboards.js
+++ b/src/actions/dashboards.js
@@ -53,9 +53,10 @@ export const tSetDashboards = () => async (dispatch, getState) => {
             sGetUsername(state)
         );
 
-        const dashboardToSelect = preferredDashboardId
-            ? sGetById(state, preferredDashboardId)
-            : sGetSortedDashboards(state)[0];
+        const preferredDashboard = sGetById(state, preferredDashboardId);
+
+        const dashboardToSelect =
+            preferredDashboard || sGetSortedDashboards(state)[0];
 
         if (dashboardToSelect) {
             dispatch(tSetSelectedDashboardById(dashboardToSelect.id));

--- a/src/actions/dashboards.js
+++ b/src/actions/dashboards.js
@@ -3,7 +3,9 @@ import {
     getCustomDashboards,
     sGetStarredDashboardIds,
     sGetById,
-    sGetFromState,
+    sGetFirstStarredDashboardId,
+    sGetUnstarredDashboardIds,
+    sGetSortedDashboards,
 } from '../reducers/dashboards';
 import { sGetUsername } from '../reducers/user';
 import { tSetSelectedDashboardById } from './selected';
@@ -50,19 +52,16 @@ export const acSetDashboardItems = value => ({
 export const tSetDashboards = () => async (dispatch, getState) => {
     const onSuccess = () => {
         const state = getState();
-
-        const preferredDashboard = sGetById(
-            state,
-            getPreferredDashboardId(sGetUsername(state))
+        const preferredDashboardId = getPreferredDashboardId(
+            sGetUsername(state)
         );
 
-        const dashboardId = preferredDashboard
-            ? preferredDashboard.id
-            : sGetStarredDashboardIds(state)[0] ||
-              Object.keys(sGetFromState(state))[0];
+        const dashboardToSelect = preferredDashboardId
+            ? sGetById(state, preferredDashboardId)
+            : sGetSortedDashboards(state)[0];
 
-        if (dashboardId) {
-            dispatch(tSetSelectedDashboardById(dashboardId));
+        if (dashboardToSelect) {
+            dispatch(tSetSelectedDashboardById(dashboardToSelect.id));
         }
     };
 

--- a/src/actions/dashboards.js
+++ b/src/actions/dashboards.js
@@ -1,10 +1,7 @@
 import { actionTypes } from '../reducers';
 import {
     getCustomDashboards,
-    sGetStarredDashboardIds,
     sGetById,
-    sGetFirstStarredDashboardId,
-    sGetUnstarredDashboardIds,
     sGetSortedDashboards,
 } from '../reducers/dashboards';
 import { sGetUsername } from '../reducers/user';

--- a/src/actions/dashboards.js
+++ b/src/actions/dashboards.js
@@ -98,10 +98,10 @@ export const tStarDashboard = (id, isStarred) => async (dispatch, getState) => {
 };
 
 export const tDeleteDashboard = id => async (dispatch, getState) => {
-    const onSuccess = () => {
-        dispatch(acClearEditDashboard());
+    const onSuccess = async () => {
+        await dispatch(tSetDashboards());
 
-        return dispatch(tSetDashboards());
+        return dispatch(acClearEditDashboard());
     };
 
     try {

--- a/src/actions/dashboards.js
+++ b/src/actions/dashboards.js
@@ -52,11 +52,12 @@ export const tSetDashboards = () => async (dispatch, getState) => {
         const preferredDashboardId = getPreferredDashboardId(
             sGetUsername(state)
         );
-
         const preferredDashboard = sGetById(state, preferredDashboardId);
 
         const dashboardToSelect =
-            preferredDashboard || sGetSortedDashboards(state)[0];
+            preferredDashboardId && preferredDashboard
+                ? preferredDashboard
+                : sGetSortedDashboards(state)[0];
 
         if (dashboardToSelect) {
             dispatch(tSetSelectedDashboardById(dashboardToSelect.id));

--- a/src/actions/dashboards.js
+++ b/src/actions/dashboards.js
@@ -18,14 +18,18 @@ import { arrayToIdMap } from '../util';
 
 // actions
 
-export const acSetDashboards = (dashboards, append) => ({
+export const acSetDashboards = dashboards => ({
     type: actionTypes.SET_DASHBOARDS,
-    append: !!append,
     value: arrayToIdMap(getCustomDashboards(dashboards)),
 });
 
-export const acStarDashboard = (dashboardId, isStarred) => ({
-    type: actionTypes.STAR_DASHBOARD,
+export const acAppendDashboards = dashboards => ({
+    type: actionTypes.APPEND_DASHBOARDS,
+    value: arrayToIdMap(getCustomDashboards(dashboards)),
+});
+
+export const acSetDashboardStarred = (dashboardId, isStarred) => ({
+    type: actionTypes.SET_DASHBOARD_STARRED,
     dashboardId: dashboardId,
     value: isStarred,
 });
@@ -33,6 +37,11 @@ export const acStarDashboard = (dashboardId, isStarred) => ({
 export const acSetDashboardDisplayName = (dashboardId, value) => ({
     type: actionTypes.SET_DASHBOARD_DISPLAY_NAME,
     dashboardId,
+    value,
+});
+
+export const acSetDashboardItems = value => ({
+    type: actionTypes.SET_DASHBOARD_ITEMS,
     value,
 });
 
@@ -74,7 +83,7 @@ export const tSetDashboards = () => async (dispatch, getState) => {
 
 export const tStarDashboard = (id, isStarred) => async (dispatch, getState) => {
     const onSuccess = id => {
-        dispatch(acStarDashboard(id, isStarred));
+        dispatch(acSetDashboardStarred(id, isStarred));
         return id;
     };
 

--- a/src/actions/editDashboard.js
+++ b/src/actions/editDashboard.js
@@ -19,10 +19,26 @@ const onError = error => {
 
 // actions
 
-export const acSetEditDashboard = value => ({
-    type: actionTypes.RECEIVED_EDIT_DASHBOARD,
-    value,
-});
+export const acSetEditDashboard = (dashboard, items) => {
+    console.log('dashboard, items', dashboard, items);
+    const val = {
+        ...dashboard,
+        dashboardItems: items,
+    };
+    console.log('val', val);
+    return {
+        type: actionTypes.RECEIVED_EDIT_DASHBOARD,
+        value: val,
+    };
+};
+
+// export const acSetEditDashboard = (dashboard, items) => ({
+//     type: actionTypes.RECEIVED_EDIT_DASHBOARD,
+//     value: {
+//         ...dashboard,
+//         dashboardItems: items,
+//     },
+// });
 
 export const acSetEditNewDashboard = () => ({
     type: actionTypes.START_NEW_DASHBOARD,
@@ -96,7 +112,7 @@ export const tSaveDashboard = () => async (dispatch, getState) => {
         ...dashboard,
         dashboardItems,
     };
-    console.log('dashboardToSave', dashboardToSave);
+
     try {
         const selectedId = dashboardToSave.id
             ? await updateDashboard(dashboardToSave)

--- a/src/actions/editDashboard.js
+++ b/src/actions/editDashboard.js
@@ -20,12 +20,11 @@ const onError = error => {
 // actions
 
 export const acSetEditDashboard = (dashboard, items) => {
-    console.log('dashboard, items', dashboard, items);
     const val = {
         ...dashboard,
         dashboardItems: items,
     };
-    console.log('val', val);
+
     return {
         type: actionTypes.RECEIVED_EDIT_DASHBOARD,
         value: val,

--- a/src/actions/editDashboard.js
+++ b/src/actions/editDashboard.js
@@ -31,14 +31,6 @@ export const acSetEditDashboard = (dashboard, items) => {
     };
 };
 
-// export const acSetEditDashboard = (dashboard, items) => ({
-//     type: actionTypes.RECEIVED_EDIT_DASHBOARD,
-//     value: {
-//         ...dashboard,
-//         dashboardItems: items,
-//     },
-// });
-
 export const acSetEditNewDashboard = () => ({
     type: actionTypes.START_NEW_DASHBOARD,
 });

--- a/src/actions/editDashboard.js
+++ b/src/actions/editDashboard.js
@@ -96,7 +96,7 @@ export const tSaveDashboard = () => async (dispatch, getState) => {
         ...dashboard,
         dashboardItems,
     };
-
+    console.log('dashboardToSave', dashboardToSave);
     try {
         const selectedId = dashboardToSave.id
             ? await updateDashboard(dashboardToSave)

--- a/src/actions/selected.js
+++ b/src/actions/selected.js
@@ -1,6 +1,6 @@
 import { actionTypes } from '../reducers';
 import { apiFetchSelected } from '../api/dashboards';
-import { acSetDashboardItems } from './dashboards';
+import { acSetDashboardItems, acAppendDashboards } from './dashboards';
 import { withShape } from '../ItemGrid/gridUtil';
 import { tGetMessages } from '../Item/MessagesItem/actions';
 import { acReceivedSnackbarMessage, acCloseSnackbar } from './snackbar';
@@ -77,6 +77,13 @@ export const tSetSelectedDashboardById = (id, name = '') => async (
     }, 500);
 
     const onSuccess = selected => {
+        // set dashboard items
+        dispatch(acSetDashboardItems(withShape(selected.dashboardItems)));
+
+        // add dashboard
+        dispatch(acAppendDashboards(selected));
+
+        // store preferred dashboard
         storePreferredDashboardId(fromUser.sGetUsername(getState()), id);
 
         // add visualizations to store
@@ -102,15 +109,14 @@ export const tSetSelectedDashboardById = (id, name = '') => async (
             }
         });
 
-        // set dashboard items
-        dispatch(acSetDashboardItems(withShape(selected.dashboardItems)));
-
         // set selected dashboard
         dispatch(acSetSelectedId(id));
 
         // remove loading indicator
         dispatch(acSetSelectedIsLoading(false));
+
         clearTimeout(snackbarTimeout);
+
         dispatch(acCloseSnackbar());
 
         return selected;

--- a/src/actions/selected.js
+++ b/src/actions/selected.js
@@ -16,6 +16,7 @@ import {
     MESSAGES,
 } from '../itemTypes';
 import { extractFavorite } from '../Item/PluginItem/plugin';
+import { getCustomDashboards } from '../reducers/dashboards';
 
 // actions
 
@@ -77,8 +78,12 @@ export const tSetSelectedDashboardById = (id, name = '') => async (
     }, 500);
 
     const onSuccess = selected => {
+        const customDashboard = getCustomDashboards(selected)[0];
+
         // set dashboard items
-        dispatch(acSetDashboardItems(withShape(selected.dashboardItems)));
+        dispatch(
+            acSetDashboardItems(withShape(customDashboard.dashboardItems))
+        );
 
         // add dashboard
         dispatch(acAppendDashboards(selected));
@@ -87,7 +92,7 @@ export const tSetSelectedDashboardById = (id, name = '') => async (
         storePreferredDashboardId(fromUser.sGetUsername(getState()), id);
 
         // add visualizations to store
-        selected.dashboardItems.forEach(item => {
+        customDashboard.dashboardItems.forEach(item => {
             switch (item.type) {
                 case REPORT_TABLE:
                 case CHART:

--- a/src/actions/selected.js
+++ b/src/actions/selected.js
@@ -1,6 +1,6 @@
 import { actionTypes } from '../reducers';
 import { apiFetchSelected } from '../api/dashboards';
-import { acSetDashboards } from './dashboards';
+import { acSetDashboardItems } from './dashboards';
 import { withShape } from '../ItemGrid/gridUtil';
 import { tGetMessages } from '../Item/MessagesItem/actions';
 import { acReceivedSnackbarMessage, acCloseSnackbar } from './snackbar';
@@ -77,13 +77,6 @@ export const tSetSelectedDashboardById = (id, name = '') => async (
     }, 500);
 
     const onSuccess = selected => {
-        const dashboard = {
-            ...selected,
-            dashboardItems: withShape(selected.dashboardItems),
-        };
-
-        dispatch(acSetDashboards(dashboard, true));
-
         storePreferredDashboardId(fromUser.sGetUsername(getState()), id);
 
         // add visualizations to store
@@ -108,6 +101,9 @@ export const tSetSelectedDashboardById = (id, name = '') => async (
                     break;
             }
         });
+
+        // set dashboard items
+        dispatch(acSetDashboardItems(withShape(selected.dashboardItems)));
 
         // set selected dashboard
         dispatch(acSetSelectedId(id));

--- a/src/reducers/__tests__/dashboards.spec.js
+++ b/src/reducers/__tests__/dashboards.spec.js
@@ -93,7 +93,7 @@ describe('dashboards reducer', () => {
         expect(actualState).toEqual(expectedState);
     });
 
-    it('SET_DASHBOARD_STARRED: should set "displayName" on a dashboard', () => {
+    it('SET_DASHBOARD_DISPLAYNAME: should set "displayName" on a dashboard', () => {
         const displayName = 'nome tradotto';
 
         const actualState = reducer(currentState, {

--- a/src/reducers/__tests__/dashboards.spec.js
+++ b/src/reducers/__tests__/dashboards.spec.js
@@ -1,18 +1,39 @@
 import reducer, { actionTypes, DEFAULT_DASHBOARDS } from '../dashboards';
 
 describe('dashboards reducer', () => {
-    const boards = {
+    const currentBoards = {
         dash1: {
             id: 'dash1',
             name: 'good stuff',
             displayName: 'untranslated',
-            dashboardItems: [],
+            starred: false,
         },
+    };
+
+    const boards = {
         dash2: {
             id: 'dash2',
             name: 'ok stuff',
-            dashboardItems: [{ id: '234' }],
         },
+    };
+
+    const currentItems = [
+        {
+            id: 'item1',
+            type: 'CHART',
+        },
+    ];
+
+    const items = [
+        {
+            id: 'item2',
+            type: 'MAP',
+        },
+    ];
+
+    const currentState = {
+        byId: currentBoards,
+        items: currentItems,
     };
 
     it('should return the default state', () => {
@@ -21,47 +42,90 @@ describe('dashboards reducer', () => {
         expect(actualState).toEqual(DEFAULT_DASHBOARDS);
     });
 
-    it('should set the list of dashboards by replacing the existing list', () => {
-        const currentState = { dash0: { id: 'dash0' } };
+    it('SET_DASHBOARDS: should set the new list of dashboards and clear the items array', () => {
         const actualState = reducer(currentState, {
             type: actionTypes.SET_DASHBOARDS,
-            append: false,
             value: boards,
         });
 
-        expect(actualState).toEqual(boards);
+        const expectedState = {
+            byId: boards,
+            items: [],
+        };
+
+        expect(actualState).toEqual(expectedState);
     });
 
-    it('should append to the list of dashboards', () => {
-        const currentState = { dash0: { id: 'dash0' } };
+    it('APPEND_DASHBOARDS: should append to the list of dashboards and leave the items untouched', () => {
         const actualState = reducer(currentState, {
-            type: actionTypes.SET_DASHBOARDS,
-            append: true,
+            type: actionTypes.APPEND_DASHBOARDS,
             value: boards,
         });
 
-        const expected = Object.assign({}, boards, currentState);
+        const expectedState = {
+            ...currentState,
+            byId: {
+                ...currentState.byId,
+                ...boards,
+            },
+        };
 
-        expect(actualState).toEqual(expected);
+        expect(actualState).toEqual(expectedState);
     });
 
-    it('should set the displayName on a dashboard', () => {
-        const currentState = boards;
+    it('SET_DASHBOARD_STARRED: should set "starred" on a dashboard', () => {
+        const actualState = reducer(currentState, {
+            type: actionTypes.SET_DASHBOARD_STARRED,
+            dashboardId: 'dash1',
+            value: true,
+        });
+
+        const expectedState = {
+            ...currentState,
+            byId: {
+                dash1: {
+                    ...currentBoards.dash1,
+                    starred: true,
+                },
+            },
+        };
+
+        expect(actualState).toEqual(expectedState);
+    });
+
+    it('SET_DASHBOARD_STARRED: should set "displayName" on a dashboard', () => {
+        const displayName = 'nome tradotto';
+
         const actualState = reducer(currentState, {
             type: actionTypes.SET_DASHBOARD_DISPLAY_NAME,
             dashboardId: 'dash1',
-            value: 'bella roba',
+            value: displayName,
         });
 
-        const expected = Object.assign({}, currentState, {
-            dash1: {
-                id: 'dash1',
-                name: 'good stuff',
-                displayName: 'bella roba',
-                dashboardItems: [],
+        const expectedState = {
+            ...currentState,
+            byId: {
+                dash1: {
+                    ...currentBoards.dash1,
+                    displayName: displayName,
+                },
             },
+        };
+
+        expect(actualState).toEqual(expectedState);
+    });
+
+    it('SET_DASHBOARD_ITEMS: should set the new list of dashboard items', () => {
+        const actualState = reducer(currentState, {
+            type: actionTypes.SET_DASHBOARD_ITEMS,
+            value: items,
         });
 
-        expect(actualState).toEqual(expected);
+        const expectedState = {
+            ...currentState,
+            items,
+        };
+
+        expect(actualState).toEqual(expectedState);
     });
 });

--- a/src/reducers/dashboards.js
+++ b/src/reducers/dashboards.js
@@ -1,7 +1,7 @@
 /** @module reducers/dashboards */
 
 import arrayFrom from 'd2-utilizr/lib/arrayFrom';
-import { orArray, orNull, orObject } from '../util';
+import { orArray, orObject } from '../util';
 import {
     SPACER,
     isSpacerType,
@@ -9,23 +9,31 @@ import {
     emptyTextItemContent,
 } from '../itemTypes';
 
-/**
- * Action types for the dashboard reducer
- * @constant
- * @type {Object}
- */
 export const actionTypes = {
     SET_DASHBOARDS: 'SET_DASHBOARDS',
-    STAR_DASHBOARD: 'STAR_DASHBOARD',
+    APPEND_DASHBOARDS: 'APPEND_DASHBOARDS',
+    SET_DASHBOARD_STARRED: 'SET_DASHBOARD_STARRED',
     SET_DASHBOARD_DISPLAY_NAME: 'SET_DASHBOARD_DISPLAY_NAME',
+    SET_DASHBOARD_ITEMS: 'SET_DASHBOARD_ITEMS',
 };
 
-/**
- * The default list of dashboards
- * @constant
- * @type {Array}
- */
-export const DEFAULT_DASHBOARDS = null;
+export const DEFAULT_DASHBOARDS = {
+    byId: null,
+    items: [],
+};
+
+// reducer helper functions
+
+const updateDashboardProp = (state, dashboardId, prop, value) => ({
+    byId: {
+        ...state.byId,
+        [dashboardId]: {
+            ...state.byId[dashboardId],
+            [prop]: value,
+        },
+    },
+    items: state.items,
+});
 
 /**
  * Reducer that computes and returns the new state based on the given action
@@ -38,26 +46,39 @@ export default (state = DEFAULT_DASHBOARDS, action) => {
     switch (action.type) {
         case actionTypes.SET_DASHBOARDS: {
             return {
-                ...(action.append ? orObject(state) : {}),
-                ...action.value,
+                byId: action.value,
+                items: [],
             };
         }
-        case actionTypes.STAR_DASHBOARD: {
+        case actionTypes.APPEND_DASHBOARDS: {
             return {
                 ...state,
-                [action.dashboardId]: {
-                    ...state[action.dashboardId],
-                    starred: action.value,
+                byId: {
+                    ...state.byId,
+                    ...action.value,
                 },
             };
+        }
+        case actionTypes.SET_DASHBOARD_STARRED: {
+            return updateDashboardProp(
+                state,
+                action.dashboardId,
+                'starred',
+                action.value
+            );
         }
         case actionTypes.SET_DASHBOARD_DISPLAY_NAME: {
+            return updateDashboardProp(
+                state,
+                action.dashboardId,
+                'displayName',
+                action.value
+            );
+        }
+        case actionTypes.SET_DASHBOARD_ITEMS: {
             return {
                 ...state,
-                [action.dashboardId]: {
-                    ...state[action.dashboardId],
-                    displayName: action.value,
-                },
+                items: action.value,
             };
         }
         default:
@@ -65,38 +86,63 @@ export default (state = DEFAULT_DASHBOARDS, action) => {
     }
 };
 
-// selectors
+// root selector
+
+export const sGetFromState = state => state.dashboards;
+
+// selector level 1
 
 /**
- * Selector which returns dashboards from the state object
- * If state.dashboards is null, then the dashboards api request
- * has not yet completed. If state.dashboards is an empty object
- * then the dashboards api request is complete, and there are no
- * dashboards
+ * Selector which returns dashboards by id from the state object
+ * If no id is provided it returns all dashboards
+ * If no matching dashboard is found it returns undefined
+ * If dashboards.byId is null, then the dashboards api request
+ * has not yet completed. If dashboards.byId is an empty object
+ * then the dashboards api request is complete, and no dashboards
+ * were returned
+ *
+ * @function
+ * @param {Object} state The current state
+ * @param {Number} id The id of the dashboard
+ * @returns {Object | undefined}
+ */
+export const sGetById = (state, id) =>
+    id ? sGetFromState(state).byId[id] : sGetFromState(state).byId;
+
+/**
+ * Selector which returns the current dashboard items
  *
  * @function
  * @param {Object} state The current state
  * @returns {Array}
  */
-export const sGetFromState = state => state.dashboards;
+export const sGetItems = state => sGetFromState(state).items;
+
+// selector level 2
 
 /**
- * Returns a dashboard based on id, from the state object.
- * If no matching dashboard is found, then undefined is returned
+ * Selector which returns starred dashboards
+ *
  * @function
  * @param {Object} state The current state
- * @param {number} id The id of the dashboard to retrieve
- * @returns {Object|undefined}
+ * @returns {Array}
  */
-export const sGetById = (state, id) =>
-    orNull(orObject(sGetFromState(state))[id]);
+export const sGetStarredDashboards = state =>
+    Object.values(orObject(sGetById(state))).filter(
+        dashboard => dashboard.starred === true
+    );
 
-export const sGetStarredDashboardIds = state => {
-    const dashboards = Object.values(orObject(sGetFromState(state)));
-    return dashboards
-        .filter(dashboard => dashboard.starred === true)
-        .map(starred => starred.id);
-};
+// selector level 3
+
+/**
+ * Selector which returns starred dashboard ids
+ *
+ * @function
+ * @param {Object} state The current state
+ * @returns {Array}
+ */
+export const sGetStarredDashboardIds = state =>
+    sGetStarredDashboards(state).map(dashboard => dashboard.id);
 
 /**
  * Returns the array of dashboards, customized for ui

--- a/src/reducers/dashboards.js
+++ b/src/reducers/dashboards.js
@@ -1,6 +1,7 @@
 /** @module reducers/dashboards */
 
 import arrayFrom from 'd2-utilizr/lib/arrayFrom';
+import arraySort from 'd2-utilizr/lib/arraySort';
 import { orArray, orObject } from '../util';
 import {
     SPACER,
@@ -121,28 +122,45 @@ export const sGetItems = state => sGetFromState(state).items;
 // selector level 2
 
 /**
- * Selector which returns starred dashboards
+ * Generic selector which returns filtered dashboards
  *
  * @function
  * @param {Object} state The current state
+ * @param {Object} propName The name of the filter prop
+ * @param {Object} value The value of the filter prop
  * @returns {Array}
  */
-export const sGetStarredDashboards = state =>
+const sGetDashboardsByProp = (state, propName, value) =>
     Object.values(orObject(sGetById(state))).filter(
-        dashboard => dashboard.starred === true
+        dashboard => dashboard[propName] === value
     );
 
 // selector level 3
 
-/**
- * Selector which returns starred dashboard ids
- *
- * @function
- * @param {Object} state The current state
- * @returns {Array}
- */
-export const sGetStarredDashboardIds = state =>
-    sGetStarredDashboards(state).map(dashboard => dashboard.id);
+export const sGetStarredDashboards = state =>
+    sGetDashboardsByProp(state, 'starred', true);
+
+export const sGetUnstarredDashboards = state =>
+    sGetDashboardsByProp(state, 'starred', false);
+
+// selector level 4
+
+export const sGetStarredDashboardIds = state => {
+    return sGetStarredDashboards(state).map(dashboard => dashboard.id);
+};
+
+export const sGetUnstarredDashboardIds = state =>
+    sGetUnstarredDashboards(state).map(dashboard => dashboard.id);
+
+// selector level 5
+
+export const sGetSortedDashboards = state =>
+    [].concat(
+        arraySort(sGetStarredDashboards(state)),
+        arraySort(sGetUnstarredDashboardIds(state))
+    );
+
+// utils
 
 /**
  * Returns the array of dashboards, customized for ui

--- a/src/reducers/dashboards.js
+++ b/src/reducers/dashboards.js
@@ -156,8 +156,8 @@ export const sGetUnstarredDashboardIds = state =>
 
 export const sGetSortedDashboards = state =>
     [].concat(
-        arraySort(sGetStarredDashboards(state)),
-        arraySort(sGetUnstarredDashboardIds(state))
+        arraySort(sGetStarredDashboards(state), 'ASC', 'displayName'),
+        arraySort(sGetUnstarredDashboardIds(state), 'ASC', 'displayName')
     );
 
 // utils

--- a/src/reducers/editDashboard.js
+++ b/src/reducers/editDashboard.js
@@ -108,9 +108,7 @@ export const sGetEditDashboard = state => state.editDashboard;
 
 // selectors
 
-export const sGetIsEditing = state => {
-    return !isEmpty(state.editDashboard);
-};
+export const sGetIsEditing = state => !isEmpty(state.editDashboard);
 
 export const sGetEditDashboardItems = state =>
     orObject(sGetEditDashboard(state)).dashboardItems;

--- a/src/reducers/editDashboard.js
+++ b/src/reducers/editDashboard.js
@@ -1,7 +1,7 @@
 /** @module reducers/editDashboard */
 import update from 'immutability-helper';
 import isEmpty from 'lodash/isEmpty';
-import { orArray } from '../util';
+import { orArray, orObject } from '../util';
 
 export const actionTypes = {
     RECEIVED_EDIT_DASHBOARD: 'RECEIVED_EDIT_DASHBOARD',
@@ -102,9 +102,15 @@ export default (state = DEFAULT_STATE, action) => {
     }
 };
 
-// selectors
+// root selector
+
 export const sGetEditDashboard = state => state.editDashboard;
+
+// selectors
 
 export const sGetIsEditing = state => {
     return !isEmpty(state.editDashboard);
 };
+
+export const sGetEditDashboardItems = state =>
+    orObject(sGetEditDashboard(state)).dashboardItems;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -81,6 +81,12 @@ export const sGetSelectedDashboard = state =>
         ? fromEditDashboard.sGetEditDashboard(state)
         : fromDashboards.sGetById(state, fromSelected.sGetSelectedId(state));
 
+// get current dashboard items, normal or edit
+export const sGetCurrentDashboardItems = state =>
+    fromEditDashboard.sGetIsEditing(state)
+        ? fromEditDashboard.sGetEditDashboardItems(state)
+        : fromDashboards.sGetItems(state);
+
 // filter dashboards by name
 export const sFilterDashboardsByName = (dashboards, filter) =>
     dashboards.filter(d =>


### PR DESCRIPTION
- refactors state.dashboards into byId (the dashboards list) and items (array holding the current dashboard items) so that the grid could listen to changes to the items only and not dashboard related stuff like "starred" etc
- updated tests
- moved the page container top margin (which is listening to the number of controlbar row among other things) to a separate component so that the whole page (grid etc) does not reload when the controlbar height is changed
- changed the connected page container props from listening to the dashboards object reference to instead only check if the dashboards list is empty or null
- css fix that removes the extra bottom right corner arrow on items in edit mode (react-resizable)
- css update for the spacer item text in edit mode:
--- aligns the item content margin with the text item
--- makes the spacer description text a bit brighter so that it's clear that it's just a description and not actual text (like the text item)