### PR TITLE
Fix DHIS2-3485: /data in the URL will return the file content

### DIFF
--- a/src/itemTypes.js
+++ b/src/itemTypes.js
@@ -123,7 +123,7 @@ export const itemTypeMap = {
         propName: 'resources',
         countName: 'resourceCount',
         pluralTitle: i18n.t('Resources'),
-        appUrl: id => `api/documents/${id}`,
+        appUrl: id => `api/documents/${id}/data`,
         icon: 'Description',
     },
     [USERS]: {


### PR DESCRIPTION
Note: this does not seem to work on play/dev.
I've asked on webapi Slack channel if it's a server problem or an API problem.

Theoretically the fix should work, the URL format is documented here: https://docs.dhis2.org/master/en/developer/html/webapi_documents.html