### PR TITLE
Fix AppItem iframe url (DHIS2-4019)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,174 +1,173 @@
 {
-  "name": "dashboards-app",
-  "version": "30.0.1",
-  "description": "DHIS2 Dashboards app",
-  "private": true,
-  "license": "BSD-3-Clause",
-  "dependencies": {
-    "autoprefixer": "7.1.6",
-    "babel-core": "6.26.0",
-    "babel-eslint": "7.2.3",
-    "babel-jest": "20.0.3",
-    "babel-loader": "7.1.2",
-    "babel-polyfill": "^6.26.0",
-    "babel-preset-es2015": "^6.24.1",
-    "babel-preset-react-app": "^3.1.0",
-    "babel-preset-stage-0": "^6.24.1",
-    "babel-runtime": "6.26.0",
-    "case-sensitive-paths-webpack-plugin": "2.1.1",
-    "chalk": "1.1.3",
-    "css-loader": "0.28.7",
-    "d2": "^29.0.0",
-    "d2-i18n": "^1.x",
-    "d2-manifest": "^1.0.0",
-    "d2-ui": "^29.0.10",
-    "d2-ui-sharing": "^1.0.0",
-    "d2-utilizr": "^0.2.15",
-    "dotenv": "4.0.0",
-    "enzyme": "^3.3.0",
-    "eslint": "4.10.0",
-    "eslint-config-prettier": "^2.9.0",
-    "eslint-config-react-app": "^2.0.1",
-    "eslint-loader": "1.9.0",
-    "eslint-plugin-flowtype": "2.39.1",
-    "eslint-plugin-import": "2.8.0",
-    "eslint-plugin-jsx-a11y": "5.1.1",
-    "eslint-plugin-prettier": "^2.3.1",
-    "eslint-plugin-react": "7.4.0",
-    "extract-text-webpack-plugin": "3.0.2",
-    "file-loader": "1.1.5",
-    "fs-extra": "3.0.1",
-    "html-webpack-plugin": "2.29.0",
-    "i18next": "^10.3.0",
-    "immutability-helper": "^2.6.3",
-    "jest": "20.0.4",
-    "jsdoc": "^3.5.5",
-    "lint-staged": "^7.0.0",
-    "material-ui": "^0.20.0",
-    "object-assign": "4.1.1",
-    "postcss-flexbugs-fixes": "3.2.0",
-    "postcss-loader": "2.0.8",
-    "postcss-rtl": "^1.2.3",
-    "prettier": "^1.11.1",
-    "promise": "8.0.1",
-    "prop-types": "^15.6.1",
-    "raf": "3.4.0",
-    "react": "^16.1.1",
-    "react-contenteditable": "^2.0.5",
-    "react-dev-utils": "^4.2.1",
-    "react-dom": "^16.1.1",
-    "react-grid-layout": "^0.16.0",
-    "react-redux": "^5.0.6",
-    "react-stub-context": "^0.8.1",
-    "react-tap-event-plugin": "^3.0.2",
-    "redux": "^3.7.2",
-    "redux-logger": "^3.0.6",
-    "redux-observable": "^0.17.0",
-    "redux-thunk": "^2.2.0",
-    "rxjs": "^5.5.2",
-    "style-loader": "0.19.0",
-    "sw-precache-webpack-plugin": "0.11.4",
-    "url-loader": "0.6.2",
-    "webpack": "3.8.1",
-    "webpack-dev-server": "2.9.4",
-    "webpack-manifest-plugin": "1.3.2",
-    "whatwg-fetch": "2.0.3"
-  },
-  "scripts": {
-    "documentation": "./node_modules/.bin/jsdoc -c jsdoc.json",
-    "prestart": "npm run localize && d2-manifest package.json ./public/manifest.webapp",
-    "start": "node scripts/start.js",
-    "build": "npm run localize && node scripts/build.js",
-    "coverage": "npm test -- --coverage",
-    "test": "node scripts/test.js --env=jsdom",
-    "lint": "eslint -c .eslintrc.json src",
-    "prebuild": "rm -rf build && npm run lint && mkdir build && npm run manifest",
-    "postbuild": "cp -r public/i18n build",
-    "manifest": "d2-manifest package.json build/manifest.webapp",
-    "deploy": "npm run build && mvn clean deploy",
-    "prettify": "prettier \"src/{**/*,*}.js\" --write",
-    "localize": "npm run extract-pot && d2-i18n-generate -n dashboards-app -p ./i18n/ -o ./src/locales/",
-    "extract-pot": "d2-i18n-extract -p src/ -o i18n/"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "npm run extract-pot && npm run prettify && CI=true npm run test && git add -A ."
+    "name": "dashboards-app",
+    "version": "30.0.1",
+    "description": "DHIS2 Dashboards app",
+    "private": true,
+    "license": "BSD-3-Clause",
+    "dependencies": {
+        "autoprefixer": "7.1.6",
+        "babel-core": "6.26.0",
+        "babel-eslint": "7.2.3",
+        "babel-jest": "20.0.3",
+        "babel-loader": "7.1.2",
+        "babel-polyfill": "^6.26.0",
+        "babel-preset-es2015": "^6.24.1",
+        "babel-preset-react-app": "^3.1.0",
+        "babel-preset-stage-0": "^6.24.1",
+        "babel-runtime": "6.26.0",
+        "case-sensitive-paths-webpack-plugin": "2.1.1",
+        "chalk": "1.1.3",
+        "css-loader": "0.28.7",
+        "d2": "^29.0.0",
+        "d2-i18n": "^1.x",
+        "d2-manifest": "^1.0.0",
+        "d2-ui": "^29.0.10",
+        "d2-ui-sharing": "^1.0.0",
+        "d2-utilizr": "^0.2.15",
+        "dotenv": "4.0.0",
+        "enzyme": "^3.3.0",
+        "eslint": "4.10.0",
+        "eslint-config-prettier": "^2.9.0",
+        "eslint-config-react-app": "^2.0.1",
+        "eslint-loader": "1.9.0",
+        "eslint-plugin-flowtype": "2.39.1",
+        "eslint-plugin-import": "2.8.0",
+        "eslint-plugin-jsx-a11y": "5.1.1",
+        "eslint-plugin-prettier": "^2.3.1",
+        "eslint-plugin-react": "7.4.0",
+        "extract-text-webpack-plugin": "3.0.2",
+        "file-loader": "1.1.5",
+        "fs-extra": "3.0.1",
+        "html-webpack-plugin": "2.29.0",
+        "i18next": "^10.3.0",
+        "immutability-helper": "^2.6.3",
+        "jest": "20.0.4",
+        "jsdoc": "^3.5.5",
+        "lint-staged": "^7.0.0",
+        "material-ui": "^0.20.0",
+        "object-assign": "4.1.1",
+        "postcss-flexbugs-fixes": "3.2.0",
+        "postcss-loader": "2.0.8",
+        "postcss-rtl": "^1.2.3",
+        "prettier": "^1.11.1",
+        "promise": "8.0.1",
+        "prop-types": "^15.6.1",
+        "raf": "3.4.0",
+        "react": "^16.1.1",
+        "react-contenteditable": "^2.0.5",
+        "react-dev-utils": "^4.2.1",
+        "react-dom": "^16.1.1",
+        "react-grid-layout": "^0.16.0",
+        "react-redux": "^5.0.6",
+        "react-stub-context": "^0.8.1",
+        "react-tap-event-plugin": "^3.0.2",
+        "redux": "^3.7.2",
+        "redux-logger": "^3.0.6",
+        "redux-observable": "^0.17.0",
+        "redux-thunk": "^2.2.0",
+        "rxjs": "^5.5.2",
+        "style-loader": "0.19.0",
+        "sw-precache-webpack-plugin": "0.11.4",
+        "url-loader": "0.6.2",
+        "webpack": "3.8.1",
+        "webpack-dev-server": "2.9.4",
+        "webpack-manifest-plugin": "1.3.2",
+        "whatwg-fetch": "2.0.3"
+    },
+    "scripts": {
+        "documentation": "./node_modules/.bin/jsdoc -c jsdoc.json",
+        "prestart":
+            "npm run localize && d2-manifest package.json ./public/manifest.webapp",
+        "start": "node scripts/start.js",
+        "build": "npm run localize && node scripts/build.js",
+        "coverage": "npm test -- --coverage",
+        "test": "node scripts/test.js --env=jsdom",
+        "lint": "eslint -c .eslintrc.json src",
+        "prebuild":
+            "rm -rf build && npm run lint && mkdir build && npm run manifest",
+        "postbuild": "cp -r public/i18n build",
+        "manifest": "d2-manifest package.json build/manifest.webapp",
+        "deploy": "npm run build && mvn clean deploy",
+        "prettify": "prettier \"src/{**/*,*}.js\" --write",
+        "localize":
+            "npm run extract-pot && d2-i18n-generate -n dashboards-app -p ./i18n/ -o ./src/locales/",
+        "extract-pot": "d2-i18n-extract -p src/ -o i18n/"
+    },
+    "husky": {
+        "hooks": {
+            "pre-commit":
+                "npm run extract-pot && npm run prettify && CI=true npm run test && git add -A ."
+        }
+    },
+    "manifest.webapp": {
+        "name": "Dashboards app",
+        "icons": {
+            "48": "icon.png"
+        },
+        "developer": {
+            "url": "",
+            "name": "DHIS2"
+        },
+        "dhis2": {
+            "apiVersion": "29"
+        },
+        "activities": {
+            "dhis": {
+                "href": ".."
+            }
+        }
+    },
+    "proxy": {
+        "/dhis-web-core-resource": {
+            "target": "http://localhost:8080"
+        }
+    },
+    "jest": {
+        "collectCoverageFrom": ["src/**/*.{js,jsx,mjs}"],
+        "setupFiles": [
+            "<rootDir>/config/polyfills.js",
+            "<rootDir>/config/shim.js"
+        ],
+        "setupTestFrameworkScriptFile": "<rootDir>/config/testSetup.js",
+        "testMatch": [
+            "<rootDir>/src/**/__tests__/**/*.{js,jsx,mjs}",
+            "<rootDir>/src/**/?(*.)(spec|test).{js,jsx,mjs}"
+        ],
+        "testEnvironment": "node",
+        "testURL": "http://localhost",
+        "transform": {
+            "^.+\\.(js|jsx|mjs)$": "<rootDir>/node_modules/babel-jest",
+            "^.+\\.css$": "<rootDir>/config/jest/cssTransform.js",
+            "^(?!.*\\.(js|jsx|mjs|css|json)$)":
+                "<rootDir>/config/jest/fileTransform.js"
+        },
+        "transformIgnorePatterns": ["/node_modules/(?!d2-ui).+\\.js$"],
+        "moduleNameMapper": {
+            "^react-native$": "react-native-web"
+        },
+        "moduleFileExtensions": [
+            "web.js",
+            "mjs",
+            "js",
+            "json",
+            "web.jsx",
+            "jsx",
+            "node"
+        ]
+    },
+    "babel": {
+        "presets": ["react-app"]
+    },
+    "eslintConfig": {
+        "extends": "react-app"
+    },
+    "devDependencies": {
+        "create-react-class": "^15.6.3",
+        "d2-i18n-extract": "^1.x",
+        "d2-i18n-generate": "^1.x",
+        "enzyme-adapter-react-16": "^1.1.1",
+        "husky": "^0.15.0-rc.12",
+        "jest-enzyme": "^6.0.0",
+        "url-parse": "^1.3.0"
     }
-  },
-  "manifest.webapp": {
-    "name": "Dashboards app",
-    "icons": {
-      "48": "icon.png"
-    },
-    "developer": {
-      "url": "",
-      "name": "DHIS2"
-    },
-    "dhis2": {
-      "apiVersion": "29"
-    },
-    "activities": {
-      "dhis": {
-        "href": ".."
-      }
-    }
-  },
-  "proxy": {
-    "/dhis-web-core-resource": {
-      "target": "http://localhost:8080"
-    }
-  },
-  "jest": {
-    "collectCoverageFrom": [
-      "src/**/*.{js,jsx,mjs}"
-    ],
-    "setupFiles": [
-      "<rootDir>/config/polyfills.js",
-      "<rootDir>/config/shim.js"
-    ],
-    "setupTestFrameworkScriptFile": "<rootDir>/config/testSetup.js",
-    "testMatch": [
-      "<rootDir>/src/**/__tests__/**/*.{js,jsx,mjs}",
-      "<rootDir>/src/**/?(*.)(spec|test).{js,jsx,mjs}"
-    ],
-    "testEnvironment": "node",
-    "testURL": "http://localhost",
-    "transform": {
-      "^.+\\.(js|jsx|mjs)$": "<rootDir>/node_modules/babel-jest",
-      "^.+\\.css$": "<rootDir>/config/jest/cssTransform.js",
-      "^(?!.*\\.(js|jsx|mjs|css|json)$)": "<rootDir>/config/jest/fileTransform.js"
-    },
-    "transformIgnorePatterns": [
-      "/node_modules/(?!d2-ui).+\\.js$"
-    ],
-    "moduleNameMapper": {
-      "^react-native$": "react-native-web"
-    },
-    "moduleFileExtensions": [
-      "web.js",
-      "mjs",
-      "js",
-      "json",
-      "web.jsx",
-      "jsx",
-      "node"
-    ]
-  },
-  "babel": {
-    "presets": [
-      "react-app"
-    ]
-  },
-  "eslintConfig": {
-    "extends": "react-app"
-  },
-  "devDependencies": {
-    "create-react-class": "^15.6.3",
-    "d2-i18n-extract": "^1.x",
-    "d2-i18n-generate": "^1.x",
-    "enzyme-adapter-react-16": "^1.1.1",
-    "husky": "^0.15.0-rc.12",
-    "jest-enzyme": "^6.0.0",
-    "url-parse": "^1.3.0"
-  }
 }

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "husky": {
         "hooks": {
             "pre-commit":
-                "npm run extract-pot && npm run prettify && CI=true npm run test && git add -A ."
+                "yarn extract-pot && CI=true yarn test && git add ./i18n/"
         }
     },
     "manifest.webapp": {

--- a/src/Item/AppItem/Item.js
+++ b/src/Item/AppItem/Item.js
@@ -22,7 +22,7 @@ const AppItem = ({ item }, context) => {
             <Line />
             <iframe
                 title={appDetails.name}
-                src={appDetails.launchUrl}
+                src={`${appDetails.launchUrl}?dashboardItemId=${item.id}`}
                 className="dashboard-item-content"
                 style={{
                     border: 'none',


### PR DESCRIPTION
Widgets loaded via AppItem need the dashboard item id reference in order to store data per dashboard item.
There can be several instances of the same widget with different data loaded in several dashboard items of the same dashboard.