### PR TITLE
Cancel request if type is already active (DHIS2-4186)

### DIFF
--- a/src/Item/PluginItem/Item.js
+++ b/src/Item/PluginItem/Item.js
@@ -132,7 +132,15 @@ class Item extends Component {
         );
     };
 
+    getActiveType = () =>
+        this.props.visualization.activeType || this.props.item.type;
+
     onSelectVisualization = activeType => {
+        // Cancel request if type is already active
+        if (activeType === this.getActiveType()) {
+            return;
+        }
+
         pluginManager.unmount(
             this.props.item,
             this.props.visualization.activeType || this.props.item.type


### PR DESCRIPTION
Check new active type against `current active type  ||  original visualization type`.

This works because current active type is `undefined` before first switching of type, but never after that, even when you switch back to original type.