### PR TITLE
DHIS2-4749: fix comparison for finding app widget

### DIFF
--- a/src/Item/AppItem/Item.js
+++ b/src/Item/AppItem/Item.js
@@ -34,7 +34,7 @@ const AppItem = ({ item, itemFilter }, context) => {
 
     if (appKey) {
         appDetails = context.d2.system.installedApps.find(
-            app => app.folderName === appKey
+            app => app.key === appKey
         );
     }
 


### PR DESCRIPTION
It seems that by coincidence folderName was matching appKey. But
folderName has changed now, and in any case it was wrong to compare
folderName with appKey as key is what is actually read and written in
dashboardItems and comes from the same object present in both api/apps and api/dashboard/q responses.