### PR TITLE
chore/named imports

### DIFF
--- a/src/actions/controlBar.js
+++ b/src/actions/controlBar.js
@@ -1,4 +1,4 @@
-import { SET_CONTROLBAR_USER_ROWS } from '../reducers/user';
+import { SET_CONTROLBAR_USER_ROWS } from '../reducers/controlBar';
 import { apiGetControlBarRows } from '../api/controlBar';
 
 // actions

--- a/src/actions/controlBar.js
+++ b/src/actions/controlBar.js
@@ -1,15 +1,10 @@
-import { actionTypes } from '../reducers';
+import { SET_CONTROLBAR_USER_ROWS } from '../reducers/user';
 import { apiGetControlBarRows } from '../api/controlBar';
 
 // actions
 
-export const acSetControlBarRows = rows => ({
-    type: actionTypes.SET_CONTROLBAR_ROWS,
-    value: rows,
-});
-
 export const acSetControlBarUserRows = rows => ({
-    type: actionTypes.SET_CONTROLBAR_USER_ROWS,
+    type: SET_CONTROLBAR_USER_ROWS,
     value: rows,
 });
 

--- a/src/actions/dashboards.js
+++ b/src/actions/dashboards.js
@@ -1,10 +1,16 @@
-import { actionTypes } from '../reducers';
+import {
+    SET_DASHBOARDS,
+    ADD_DASHBOARDS,
+    SET_DASHBOARD_STARRED,
+    SET_DASHBOARD_DISPLAY_NAME,
+    SET_DASHBOARD_ITEMS,
+} from '../reducers/dashboards';
 import {
     getCustomDashboards,
     sGetDashboardById,
     sGetDashboardsSortedByStarred,
 } from '../reducers/dashboards';
-import { sGetUsername } from '../reducers/user';
+import { sGetUserUsername } from '../reducers/user';
 import { tSetSelectedDashboardById, acSetSelectedId } from './selected';
 import { acClearEditDashboard } from './editDashboard';
 import {
@@ -18,29 +24,29 @@ import { arrayToIdMap } from '../util';
 // actions
 
 export const acSetDashboards = dashboards => ({
-    type: actionTypes.SET_DASHBOARDS,
+    type: SET_DASHBOARDS,
     value: arrayToIdMap(getCustomDashboards(dashboards)),
 });
 
 export const acAppendDashboards = dashboards => ({
-    type: actionTypes.APPEND_DASHBOARDS,
+    type: ADD_DASHBOARDS,
     value: arrayToIdMap(getCustomDashboards(dashboards)),
 });
 
 export const acSetDashboardStarred = (dashboardId, isStarred) => ({
-    type: actionTypes.SET_DASHBOARD_STARRED,
+    type: SET_DASHBOARD_STARRED,
     dashboardId: dashboardId,
     value: isStarred,
 });
 
 export const acSetDashboardDisplayName = (dashboardId, value) => ({
-    type: actionTypes.SET_DASHBOARD_DISPLAY_NAME,
+    type: SET_DASHBOARD_DISPLAY_NAME,
     dashboardId,
     value,
 });
 
 export const acSetDashboardItems = value => ({
-    type: actionTypes.SET_DASHBOARD_ITEMS,
+    type: SET_DASHBOARD_ITEMS,
     value,
 });
 
@@ -64,7 +70,9 @@ export const tSelectDashboard = id => async (dispatch, getState) => {
         if (id) {
             dashboardToSelect = sGetDashboardById(state, id) || null;
         } else {
-            const preferredId = getPreferredDashboardId(sGetUsername(state));
+            const preferredId = getPreferredDashboardId(
+                sGetUserUsername(state)
+            );
             const dash = sGetDashboardById(state, preferredId);
             dashboardToSelect =
                 preferredId && dash

--- a/src/actions/dashboardsFilter.js
+++ b/src/actions/dashboardsFilter.js
@@ -1,18 +1,22 @@
-import { actionTypes } from '../reducers';
+import {
+    SET_DASHBOARDS_FILTER_NAME,
+    SET_DASHBOARDS_FILTER_OWNER,
+    SET_DASHBOARDS_FILTER_ORDER,
+} from '../reducers/dashboardsFilter';
 
 // actions
 
 export const acSetFilterName = value => ({
-    type: actionTypes.SET_DASHBOARDS_FILTER_NAME,
+    type: SET_DASHBOARDS_FILTER_NAME,
     value,
 });
 
 export const acSetFilterOwner = value => ({
-    type: actionTypes.SET_DASHBOARDS_FILTER_OWNER,
+    type: SET_DASHBOARDS_FILTER_OWNER,
     value,
 });
 
 export const acSetFilterOrder = value => ({
-    type: actionTypes.SET_DASHBOARDS_FILTER_ORDER,
+    type: SET_DASHBOARDS_FILTER_ORDER,
     value,
 });

--- a/src/actions/editDashboard.js
+++ b/src/actions/editDashboard.js
@@ -1,7 +1,17 @@
 import { generateUid } from 'd2/lib/uid';
 
-import { actionTypes } from '../reducers';
-import { fromEditDashboard } from '../reducers';
+import {
+    RECEIVED_EDIT_DASHBOARD,
+    START_NEW_DASHBOARD,
+    RECEIVED_NOT_EDITING,
+    RECEIVED_TITLE,
+    RECEIVED_DESCRIPTION,
+    RECEIVED_DASHBOARD_LAYOUT,
+    ADD_DASHBOARD_ITEM,
+    UPDATE_DASHBOARD_ITEM,
+    REMOVE_DASHBOARD_ITEM,
+} from '../reducers/editDashboard';
+import { sGetEditDashboardRoot } from '../reducers/editDashboard';
 import { updateDashboard, postDashboard } from '../api/editDashboard';
 import { tSetSelectedDashboardById } from '../actions/selected';
 import { NEW_ITEM_SHAPE } from '../components/ItemGrid/gridUtil';
@@ -27,31 +37,31 @@ export const acSetEditDashboard = (dashboard, items) => {
     };
 
     return {
-        type: actionTypes.RECEIVED_EDIT_DASHBOARD,
+        type: RECEIVED_EDIT_DASHBOARD,
         value: val,
     };
 };
 
 export const acSetEditNewDashboard = () => ({
-    type: actionTypes.START_NEW_DASHBOARD,
+    type: START_NEW_DASHBOARD,
 });
 
 export const acClearEditDashboard = () => ({
-    type: actionTypes.RECEIVED_NOT_EDITING,
+    type: RECEIVED_NOT_EDITING,
 });
 
 export const acSetDashboardTitle = value => ({
-    type: actionTypes.RECEIVED_TITLE,
+    type: RECEIVED_TITLE,
     value,
 });
 
 export const acSetDashboardDescription = value => ({
-    type: actionTypes.RECEIVED_DESCRIPTION,
+    type: RECEIVED_DESCRIPTION,
     value,
 });
 
 export const acUpdateDashboardLayout = value => ({
-    type: actionTypes.RECEIVED_DASHBOARD_LAYOUT,
+    type: RECEIVED_DASHBOARD_LAYOUT,
     value,
 });
 
@@ -61,7 +71,7 @@ export const acAddDashboardItem = item => {
     const itemPropName = itemTypeMap[type].propName;
 
     return {
-        type: actionTypes.ADD_DASHBOARD_ITEM,
+        type: ADD_DASHBOARD_ITEM,
         value: {
             id: generateUid(),
             type,
@@ -72,19 +82,19 @@ export const acAddDashboardItem = item => {
 };
 
 export const acUpdateDashboardItem = item => ({
-    type: actionTypes.UPDATE_DASHBOARD_ITEM,
+    type: UPDATE_DASHBOARD_ITEM,
     value: item,
 });
 
 export const acRemoveDashboardItem = value => ({
-    type: actionTypes.REMOVE_DASHBOARD_ITEM,
+    type: REMOVE_DASHBOARD_ITEM,
     value,
 });
 
 // thunks
 
 export const tSaveDashboard = () => async (dispatch, getState) => {
-    const dashboard = fromEditDashboard.sGetEditDashboard(getState());
+    const dashboard = sGetEditDashboardRoot(getState());
 
     const dashboardItems = dashboard.dashboardItems.map(item => {
         const text = isTextType(item)

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,26 +1,10 @@
-import * as fromDashboards from './dashboards';
-import * as fromSelected from './selected';
-import * as fromDashboardsFilter from './dashboardsFilter';
-import * as fromControlBar from './controlBar';
-import * as fromEditDashboard from './editDashboard';
-import * as fromUser from './user';
-import * as fromItemFilter from './itemFilter';
+import { tSetSelectedDashboardById } from './selected';
+import { acSetFilterName } from './dashboardsFilter';
 
-export {
-    fromDashboards,
-    fromSelected,
-    fromDashboardsFilter,
-    fromControlBar,
-    fromEditDashboard,
-    fromUser,
-    fromItemFilter,
-};
-
-// depends on: fromSelected, fromDashboardsFilter
 export const tSelectDashboardById = (id, name) => dispatch => {
     // select dashboard by id
-    dispatch(fromSelected.tSetSelectedDashboardById(id, name));
+    dispatch(tSetSelectedDashboardById(id, name));
 
     // reset filter
-    dispatch(fromDashboardsFilter.acSetFilterName());
+    dispatch(acSetFilterName());
 };

--- a/src/actions/itemFilter.js
+++ b/src/actions/itemFilter.js
@@ -1,11 +1,11 @@
-import { actionTypes } from '../reducers';
+import { SET_ITEM_FILTER } from '../reducers/itemFilter';
 
 export const FILTER_USER_ORG_UNIT = 'userOrgUnit';
 
 // actions
 
 export const acSetItemFilter = (key, value) => ({
-    type: actionTypes.SET_ITEM_FILTER,
+    type: SET_ITEM_FILTER,
     key,
     value,
 });

--- a/src/actions/selected.js
+++ b/src/actions/selected.js
@@ -2,9 +2,14 @@ import {
     SET_SELECTED_ID,
     SET_SELECTED_ISLOADING,
     SET_SELECTED_SHOWDESCRIPTION,
+} from '../reducers/selected';
+import {
     RECEIVED_VISUALIZATION,
     RECEIVED_ACTIVE_VISUALIZATION,
-} from '../reducers/selected';
+} from '../reducers/visualizations';
+import { sGetSelectedIsLoading } from '../reducers/selected';
+import { sGetUserUsername } from '../reducers/user';
+import { getCustomDashboards, sGetDashboardById } from '../reducers/dashboards';
 import { apiFetchDashboard } from '../api/dashboards';
 import { acSetDashboardItems, acAppendDashboards } from './dashboards';
 import { withShape } from '../components/ItemGrid/gridUtil';
@@ -21,10 +26,7 @@ import {
     MESSAGES,
 } from '../itemTypes';
 import { extractFavorite } from '../components/Item/VisualizationItem/plugin';
-import { getCustomDashboards, sGetDashboardById } from '../reducers/dashboards';
 import { orObject } from '../util';
-import { sGetSelectedIsLoading } from '../reducers/selected';
-import { sGetUserUsername } from '../reducers/user';
 
 // actions
 

--- a/src/actions/selected.js
+++ b/src/actions/selected.js
@@ -1,11 +1,16 @@
-import { actionTypes } from '../reducers';
+import {
+    SET_SELECTED_ID,
+    SET_SELECTED_ISLOADING,
+    SET_SELECTED_SHOWDESCRIPTION,
+    RECEIVED_VISUALIZATION,
+    RECEIVED_ACTIVE_VISUALIZATION,
+} from '../reducers/selected';
 import { apiFetchDashboard } from '../api/dashboards';
 import { acSetDashboardItems, acAppendDashboards } from './dashboards';
 import { withShape } from '../components/ItemGrid/gridUtil';
 import { tGetMessages } from '../components/Item/MessagesItem/actions';
 import { acReceivedSnackbarMessage, acCloseSnackbar } from './snackbar';
 import { storePreferredDashboardId } from '../api/localStorage';
-import { fromUser, fromSelected } from '../reducers';
 import { loadingDashboardMsg } from '../components/SnackbarMessage/SnackbarMessage';
 import {
     REPORT_TABLE,
@@ -18,32 +23,34 @@ import {
 import { extractFavorite } from '../components/Item/VisualizationItem/plugin';
 import { getCustomDashboards, sGetDashboardById } from '../reducers/dashboards';
 import { orObject } from '../util';
+import { sGetSelectedIsLoading } from '../reducers/selected';
+import { sGetUserUsername } from '../reducers/user';
 
 // actions
 
 export const acSetSelectedId = value => ({
-    type: actionTypes.SET_SELECTED_ID,
+    type: SET_SELECTED_ID,
     value,
 });
 
 export const acSetSelectedIsLoading = value => ({
-    type: actionTypes.SET_SELECTED_ISLOADING,
+    type: SET_SELECTED_ISLOADING,
     value,
 });
 
 export const acSetSelectedShowDescription = value => ({
-    type: actionTypes.SET_SELECTED_SHOWDESCRIPTION,
+    type: SET_SELECTED_SHOWDESCRIPTION,
     value,
 });
 
 export const acReceivedVisualization = value => ({
-    type: actionTypes.RECEIVED_VISUALIZATION,
+    type: RECEIVED_VISUALIZATION,
     value,
 });
 
 export const acReceivedActiveVisualization = (id, type, activeType) => {
     const action = {
-        type: actionTypes.RECEIVED_ACTIVE_VISUALIZATION,
+        type: RECEIVED_ACTIVE_VISUALIZATION,
         id,
     };
 
@@ -73,7 +80,7 @@ export const tSetSelectedDashboardById = id => async (dispatch, getState) => {
     const snackbarTimeout = setTimeout(() => {
         const dashboardName = orObject(sGetDashboardById(getState(), id))
             .displayName;
-        if (fromSelected.sGetSelectedIsLoading(getState()) && dashboardName) {
+        if (sGetSelectedIsLoading(getState()) && dashboardName) {
             loadingDashboardMsg.name = dashboardName;
 
             dispatch(
@@ -92,7 +99,7 @@ export const tSetSelectedDashboardById = id => async (dispatch, getState) => {
             acSetDashboardItems(withShape(customDashboard.dashboardItems))
         );
 
-        storePreferredDashboardId(fromUser.sGetUsername(getState()), id);
+        storePreferredDashboardId(sGetUserUsername(getState()), id);
 
         // add visualizations to store
         customDashboard.dashboardItems.forEach(item => {

--- a/src/actions/snackbar.js
+++ b/src/actions/snackbar.js
@@ -1,10 +1,13 @@
-import { actionTypes } from '../reducers';
+import {
+    RECEIVED_SNACKBAR_MESSAGE,
+    CLOSE_SNACKBAR,
+} from '../reducers/snackbar';
 
 export const acReceivedSnackbarMessage = value => ({
-    type: actionTypes.RECEIVED_SNACKBAR_MESSAGE,
+    type: RECEIVED_SNACKBAR_MESSAGE,
     value,
 });
 
 export const acCloseSnackbar = () => ({
-    type: actionTypes.CLOSE_SNACKBAR,
+    type: CLOSE_SNACKBAR,
 });

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -1,6 +1,6 @@
-import { actionTypes } from '../reducers';
+import { RECEIVED_USER } from '../reducers/user';
 
 export const acReceivedUser = value => ({
-    type: actionTypes.RECEIVED_USER,
+    type: RECEIVED_USER,
     value,
 });

--- a/src/api/controlBar.js
+++ b/src/api/controlBar.js
@@ -1,5 +1,5 @@
 import { getInstance } from 'd2/lib/d2';
-import { DEFAULT_ROWS } from '../reducers/controlBar';
+import { DEFAULT_STATE_CONTROLBAR_ROWS } from '../reducers/controlBar';
 
 const NAMESPACE = 'dashboard';
 const KEY = 'controlBarRows';
@@ -19,11 +19,11 @@ export const apiGetControlBarRows = async () => {
     if (hasKey) {
         return await namespace.get(KEY);
     } else {
-        await apiPostControlBarRows(DEFAULT_ROWS, namespace);
+        await apiPostControlBarRows(DEFAULT_STATE_CONTROLBAR_ROWS, namespace);
         console.log(
             '(These errors to /userDataStore/dashboard can be ignored)'
         );
-        return DEFAULT_ROWS;
+        return DEFAULT_STATE_CONTROLBAR_ROWS;
     }
 };
 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -6,10 +6,12 @@ import HeaderBarComponent from 'd2-ui/lib/app-header/HeaderBar';
 import headerBarStore$ from 'd2-ui/lib/app-header/headerBar.store';
 import withStateFrom from 'd2-ui/lib/component-helpers/withStateFrom';
 
-import { fromUser, fromDashboards, fromControlBar } from '../actions';
+import { EDIT, VIEW, NEW } from './Dashboard/dashboardModes';
+import { acReceivedUser } from '../actions/user';
+import { tFetchDashboards } from '../actions/dashboards';
+import { tSetControlBarRows } from '../actions/controlBar';
 import Dashboard from './Dashboard/Dashboard';
 import SnackbarMessage from './SnackbarMessage/SnackbarMessage';
-import { EDIT, VIEW, NEW } from './Dashboard/dashboardModes';
 
 import './App.css';
 
@@ -18,9 +20,9 @@ const HeaderBar = withStateFrom(headerBarStore$, HeaderBarComponent);
 class App extends Component {
     componentDidMount() {
         const { store, d2 } = this.context;
-        store.dispatch(fromUser.acReceivedUser(d2.currentUser));
-        store.dispatch(fromDashboards.tFetchDashboards());
-        store.dispatch(fromControlBar.tSetControlBarRows());
+        store.dispatch(acReceivedUser(d2.currentUser));
+        store.dispatch(tFetchDashboards());
+        store.dispatch(tSetControlBarRows());
     }
 
     getChildContext() {

--- a/src/components/ControlBarContainer/DashboardsBar.js
+++ b/src/components/ControlBarContainer/DashboardsBar.js
@@ -15,10 +15,13 @@ import {
     getOuterHeight,
 } from './controlBarDimensions';
 
-import * as fromActions from '../../actions';
-import * as fromReducers from '../../reducers';
-import { orObject, orArray } from '../../util';
+import { sGetControlBarUserRows } from '../../reducers/controlBar';
+import { sGetAllDashboards } from '../../reducers/dashboards';
+import { sGetFilterName } from '../../reducers/dashboardsFilter';
 import { sGetSelectedId } from '../../reducers/selected';
+import { acSetControlBarUserRows } from '../../actions/controlBar';
+import { acSetFilterName } from '../../actions/dashboardsFilter';
+import { orObject, orArray } from '../../util';
 import { apiPostControlBarRows } from '../../api/controlBar';
 
 import './ControlBarContainer.css';
@@ -139,17 +142,16 @@ export class DashboardsBar extends Component {
 }
 
 const mapStateToProps = state => ({
-    dashboards: fromReducers.fromDashboards.sGetAllDashboards(state),
-    name: fromReducers.fromDashboardsFilter.sGetFilterName(state),
-    userRows: (state.controlBar && state.controlBar.userRows) || MIN_ROW_COUNT,
+    dashboards: sGetAllDashboards(state),
+    name: sGetFilterName(state),
+    userRows: sGetControlBarUserRows(state),
     selectedId: sGetSelectedId(state),
 });
 
 const mapDispatchToProps = {
-    onChangeHeight: fromActions.fromControlBar.acSetControlBarUserRows,
-    onChangeFilterName: fromActions.fromDashboardsFilter.acSetFilterName,
+    onChangeHeight: acSetControlBarUserRows,
+    onChangeFilterName: acSetFilterName,
 };
-
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
     const dashboards = Object.values(orObject(stateProps.dashboards));
     const displayDashboards = arraySort(

--- a/src/components/ControlBarContainer/DashboardsBar.js
+++ b/src/components/ControlBarContainer/DashboardsBar.js
@@ -14,7 +14,6 @@ import {
     getInnerHeight,
     getOuterHeight,
 } from './controlBarDimensions';
-
 import { sGetControlBarUserRows } from '../../reducers/controlBar';
 import { sGetAllDashboards } from '../../reducers/dashboards';
 import { sGetFilterName } from '../../reducers/dashboardsFilter';

--- a/src/components/ControlBarContainer/EditBar.js
+++ b/src/components/ControlBarContainer/EditBar.js
@@ -18,7 +18,7 @@ import {
     acSetDashboardDisplayName,
 } from '../../actions/dashboards';
 import {
-    sGetEditDashboard,
+    sGetEditDashboardRoot,
     sGetIsNewDashboard,
 } from '../../reducers/editDashboard';
 import { CONTROL_BAR_ROW_HEIGHT, getOuterHeight } from './controlBarDimensions';
@@ -208,7 +208,7 @@ EditBar.contextTypes = {
 };
 
 const mapStateToProps = state => {
-    const dashboard = sGetEditDashboard(state);
+    const dashboard = sGetEditDashboardRoot(state);
 
     let deleteAccess;
     let updateAccess;

--- a/src/components/ControlBarContainer/Filter.js
+++ b/src/components/ControlBarContainer/Filter.js
@@ -7,7 +7,7 @@ import IconClear from 'material-ui/svg-icons/content/clear';
 import isEmpty from 'd2-utilizr/lib/isEmpty';
 
 import { colors } from '../../colors';
-import { DEFAULT_DASHBOARDS_FILTER_NAME } from '../../reducers/dashboardsFilter';
+import { DEFAULT_STATE_DASHBOARDS_FILTER_NAME } from '../../reducers/dashboardsFilter';
 
 export const KEYCODE_ENTER = 13;
 export const KEYCODE_ESCAPE = 27;
@@ -48,7 +48,7 @@ export class Filter extends Component {
         super(props);
 
         this.state = {
-            value: DEFAULT_DASHBOARDS_FILTER_NAME,
+            value: DEFAULT_STATE_DASHBOARDS_FILTER_NAME,
         };
     }
 

--- a/src/components/ControlBarContainer/Filter.js
+++ b/src/components/ControlBarContainer/Filter.js
@@ -7,7 +7,7 @@ import IconClear from 'material-ui/svg-icons/content/clear';
 import isEmpty from 'd2-utilizr/lib/isEmpty';
 
 import { colors } from '../../colors';
-import * as fromReducers from '../../reducers';
+import { DEFAULT_DASHBOARDS_FILTER_NAME } from '../../reducers/dashboardsFilter';
 
 export const KEYCODE_ENTER = 13;
 export const KEYCODE_ESCAPE = 27;
@@ -48,7 +48,7 @@ export class Filter extends Component {
         super(props);
 
         this.state = {
-            value: fromReducers.fromDashboardsFilter.DEFAULT_NAME,
+            value: DEFAULT_DASHBOARDS_FILTER_NAME,
         };
     }
 

--- a/src/components/Dashboard/Dashboard.js
+++ b/src/components/Dashboard/Dashboard.js
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
+import { tSelectDashboard } from '../../actions/dashboards';
+import { sDashboardsIsFetching } from '../../reducers/dashboards';
+import { EDIT, NEW } from './dashboardModes';
 import ViewDashboard from './ViewDashboard';
 import EditDashboard from './EditDashboard';
 import NewDashboard from './NewDashboard';
-import { fromDashboards } from '../../actions';
-import { sDashboardsIsFetching } from '../../reducers/dashboards';
-import { EDIT, NEW } from './dashboardModes';
 
 class Dashboard extends Component {
     setDashboard = () => {
@@ -43,6 +43,6 @@ const mapStateToProps = state => {
 export default connect(
     mapStateToProps,
     {
-        selectDashboard: fromDashboards.tSelectDashboard,
+        selectDashboard: tSelectDashboard,
     }
 )(Dashboard);

--- a/src/components/Dashboard/EditDashboard.js
+++ b/src/components/Dashboard/EditDashboard.js
@@ -2,8 +2,13 @@ import React, { Fragment, Component } from 'react';
 import { connect } from 'react-redux';
 import i18n from 'd2-i18n';
 
-import { fromDashboards, fromSelected } from '../../reducers';
 import { acSetEditDashboard } from '../../actions/editDashboard';
+import { sGetSelectedId } from '../../reducers/selected';
+import {
+    sGetDashboardById,
+    sGetDashboardItems,
+    sDashboardsIsFetching,
+} from '../../reducers/dashboards';
 import DashboardVerticalOffset from './DashboardVerticalOffset';
 import DashboardContent from './DashboardContent';
 import EditBar from '../ControlBarContainer/EditBar';
@@ -63,8 +68,8 @@ export class EditDashboard extends Component {
 }
 
 const mapStateToProps = state => {
-    const id = fromSelected.sGetSelectedId(state);
-    const dashboard = id ? fromDashboards.sGetDashboardById(state, id) : null;
+    const id = sGetSelectedId(state);
+    const dashboard = id ? sGetDashboardById(state, id) : null;
 
     const updateAccess =
         dashboard && dashboard.access ? dashboard.access.update : false;
@@ -73,8 +78,8 @@ const mapStateToProps = state => {
         dashboard,
         id,
         updateAccess,
-        items: fromDashboards.sGetDashboardItems(state),
-        dashboardsLoaded: !fromDashboards.sDashboardsIsFetching(state),
+        items: sGetDashboardItems(state),
+        dashboardsLoaded: !sDashboardsIsFetching(state),
     };
 };
 

--- a/src/components/Item/AppItem/Item.js
+++ b/src/components/Item/AppItem/Item.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import SvgIcon from 'd2-ui/lib/svg-icon/SvgIcon';
 
 import { FILTER_USER_ORG_UNIT } from '../../../actions/itemFilter';
-import { fromItemFilter } from '../../../reducers';
+import { sGetItemFilterRoot } from '../../../reducers/itemFilter';
 import ItemHeader from '../ItemHeader';
 import Line from '../../../widgets/Line';
 
@@ -78,7 +78,7 @@ AppItem.contextTypes = {
 };
 
 const mapStateToProps = state => ({
-    itemFilter: fromItemFilter.sGetFromState(state),
+    itemFilter: sGetItemFilterRoot(state),
 });
 
 export default connect(mapStateToProps)(AppItem);

--- a/src/components/Item/Item.js
+++ b/src/components/Item/Item.js
@@ -21,7 +21,7 @@ import {
     TEXT,
     SPACER,
 } from '../../itemTypes';
-import { DEFAULT_STATE } from '../../reducers/itemFilter';
+import { DEFAULT_STATE_ITEM_FILTER } from '../../reducers/itemFilter';
 
 const getGridItem = type => {
     switch (type) {
@@ -55,7 +55,9 @@ export const Item = props => {
         <GridItem
             item={props.item}
             editMode={props.editMode}
-            itemFilter={props.editMode ? DEFAULT_STATE : props.itemFilter}
+            itemFilter={
+                props.editMode ? DEFAULT_STATE_ITEM_FILTER : props.itemFilter
+            }
             onToggleItemExpanded={props.onToggleItemExpanded}
         />
     );

--- a/src/components/Item/MessagesItem/Item.js
+++ b/src/components/Item/MessagesItem/Item.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import i18n from 'd2-i18n';
 
-import { fromMessages } from '../../../reducers';
+import { sGetMessagesRoot } from '../../../reducers/messages';
 import { formatDate } from '../../../util';
 import { colors } from '../../../colors';
 import ItemHeader from '../ItemHeader';
@@ -132,7 +132,7 @@ MessagesItem.contextTypes = {
 
 const mapStateToProps = state => {
     return {
-        messages: Object.values(fromMessages.sGetMessages(state)),
+        messages: Object.values(sGetMessagesRoot(state)),
     };
 };
 

--- a/src/components/Item/MessagesItem/actions.js
+++ b/src/components/Item/MessagesItem/actions.js
@@ -1,4 +1,4 @@
-import { actionTypes } from '../../../reducers';
+import { RECEIVED_MESSAGES } from '../../../reducers/messages';
 import { getMessages } from '../../../api/messages';
 
 const onError = (action, error) => {
@@ -7,7 +7,7 @@ const onError = (action, error) => {
 };
 
 export const receivedMessages = value => ({
-    type: actionTypes.RECEIVED_MESSAGES,
+    type: RECEIVED_MESSAGES,
     value,
 });
 

--- a/src/components/Item/TextItem/Item.js
+++ b/src/components/Item/TextItem/Item.js
@@ -4,7 +4,8 @@ import i18n from 'd2-i18n';
 import TextField from 'd2-ui/lib/text-field/TextField';
 
 import { acUpdateDashboardItem } from '../../../actions/editDashboard';
-import { fromEditDashboard, fromDashboards } from '../../../reducers';
+import { sGetEditDashboardItems } from '../../../reducers/editDashboard';
+import { sGetDashboardItems } from '../../../reducers/dashboards';
 import ItemHeader from '../ItemHeader';
 import Line from '../../../widgets/Line';
 
@@ -74,8 +75,8 @@ const TextItem = props => {
 
 const mapStateToProps = (state, ownProps) => {
     const items = ownProps.editMode
-        ? fromEditDashboard.sGetEditDashboardItems(state)
-        : fromDashboards.sGetDashboardItems(state);
+        ? sGetEditDashboardItems(state)
+        : sGetDashboardItems(state);
 
     const item = items.find(item => item.id === ownProps.item.id);
 

--- a/src/components/Item/VisualizationItem/Interpretations/Interpretation.js
+++ b/src/components/Item/VisualizationItem/Interpretations/Interpretation.js
@@ -5,12 +5,10 @@ import { Parser as RichTextParser } from '@dhis2/d2-ui-rich-text';
 import i18n from 'd2-i18n';
 import SvgIcon from 'd2-ui/lib/svg-icon/SvgIcon';
 
-import { fromUser } from '../../../../reducers';
+import { sGetUserId, sGetIsSuperuser } from '../../../../reducers/user';
 import { colors } from '../../../../colors';
 import { formatDate, sortByDate } from '../../../../util';
 import { getLink } from '../plugin';
-import InputField from './InputField';
-
 import {
     tLikeInterpretation,
     tUnlikeInterpretation,
@@ -20,6 +18,7 @@ import {
     tDeleteInterpretation,
     tUpdateInterpretationComment,
 } from './actions';
+import InputField from './InputField';
 
 import './Interpretation.css';
 
@@ -335,8 +334,8 @@ class Interpretation extends Component {
 }
 
 const mapStateToProps = state => ({
-    userId: fromUser.sGetUserId(state),
-    userIsSuperuser: fromUser.sGetIsSuperuser(state),
+    userId: sGetUserId(state),
+    userIsSuperuser: sGetIsSuperuser(state),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/Item/VisualizationItem/Interpretations/Interpretations.js
+++ b/src/components/Item/VisualizationItem/Interpretations/Interpretations.js
@@ -2,12 +2,13 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import i18n from 'd2-i18n';
 
-import Interpretation from './Interpretation';
-import InputField from './InputField';
+import { sGetInterpretations } from '../../../../reducers/interpretations';
+import { sGetVisInterpretations } from '../../../../reducers/visualizations';
 import { tGetInterpretations, tPostInterpretation } from './actions';
-import * as fromReducers from '../../../../reducers';
 import { colors } from '../../../../colors';
 import { sortByDate } from '../../../../util';
+import Interpretation from './Interpretation';
+import InputField from './InputField';
 
 const style = {
     container: {
@@ -108,14 +109,11 @@ class Interpretations extends Component {
 }
 
 const mapStateToProps = (state, ownProps) => {
-    const { fromVisualizations, fromInterpretations } = fromReducers;
-    const ids = fromVisualizations
-        .sGetVisInterpretations(state, ownProps.objectId)
-        .map(i => i.id);
+    const ids = sGetVisInterpretations(state, ownProps.objectId).map(i => i.id);
 
     return {
         ids,
-        interpretations: fromInterpretations.sGetInterpretations(state, ids),
+        interpretations: sGetInterpretations(state, ids),
     };
 };
 

--- a/src/components/Item/VisualizationItem/Interpretations/actions.js
+++ b/src/components/Item/VisualizationItem/Interpretations/actions.js
@@ -3,8 +3,8 @@ import {
     RECEIVED_INTERPRETATION,
     ADD_INTERPRETATIONS,
     REMOVE_INTERPRETATION,
-    RECEIVED_VISUALIZATION,
 } from '../../../../reducers/interpretations';
+import { RECEIVED_VISUALIZATION } from '../../../../reducers/visualizations';
 import {
     postInterpretationLike,
     deleteInterpretationLike,

--- a/src/components/Item/VisualizationItem/Interpretations/actions.js
+++ b/src/components/Item/VisualizationItem/Interpretations/actions.js
@@ -1,4 +1,10 @@
-import { actionTypes, fromInterpretations } from '../../../../reducers';
+import {
+    sGetInterpretation,
+    RECEIVED_INTERPRETATION,
+    ADD_INTERPRETATIONS,
+    REMOVE_INTERPRETATION,
+    RECEIVED_VISUALIZATION,
+} from '../../../../reducers/interpretations';
 import {
     postInterpretationLike,
     deleteInterpretationLike,
@@ -17,22 +23,22 @@ import {
 // action creators
 
 export const addInterpretation = value => ({
-    type: actionTypes.RECEIVED_INTERPRETATION,
+    type: RECEIVED_INTERPRETATION,
     value,
 });
 
 export const addInterpretations = value => ({
-    type: actionTypes.ADD_INTERPRETATIONS,
+    type: ADD_INTERPRETATIONS,
     value,
 });
 
 export const removeInterpretation = value => ({
-    type: actionTypes.REMOVE_INTERPRETATION,
+    type: REMOVE_INTERPRETATION,
     value,
 });
 
 export const acReceivedVisualization = value => ({
-    type: actionTypes.RECEIVED_VISUALIZATION,
+    type: RECEIVED_VISUALIZATION,
     value,
 });
 
@@ -143,10 +149,7 @@ export const tPostInterpretation = data => async (dispatch, getState) => {
         const vis = await fetchVisualization(data);
 
         const newInterpretation = vis.interpretations.find(interpretation => {
-            const exists = !!fromInterpretations.sGetInterpretation(
-                getState(),
-                interpretation.id
-            );
+            const exists = !!sGetInterpretation(getState(), interpretation.id);
             return !exists;
         });
         await updateInterpretationInStore([newInterpretation.id], dispatch);

--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -8,8 +8,8 @@ import * as pluginManager from './plugin';
 import { getGridItemDomId } from '../../ItemGrid/gridUtil';
 import { getBaseUrl, orObject } from '../../../util';
 import { sGetVisualization } from '../../../reducers/visualizations';
+import { sGetItemFilterRoot } from '../../../reducers/itemFilter';
 import { acReceivedActiveVisualization } from '../../../actions/selected';
-import { fromItemFilter } from '../../../reducers';
 import { itemTypeMap } from '../../../itemTypes';
 import ItemHeader, { HEADER_HEIGHT } from '../ItemHeader';
 import ItemFooter from './ItemFooter';
@@ -235,7 +235,7 @@ Item.defaultProps = {
 };
 
 const mapStateToProps = (state, ownProps) => ({
-    itemFilter: fromItemFilter.sGetFromState(state),
+    itemFilter: sGetItemFilterRoot(state),
     visualization: sGetVisualization(
         state,
         pluginManager.extractFavorite(ownProps.item).id

--- a/src/components/ItemFilter/ItemFilter.js
+++ b/src/components/ItemFilter/ItemFilter.js
@@ -11,7 +11,7 @@ import {
     acSetItemFilter,
     FILTER_USER_ORG_UNIT,
 } from '../../actions/itemFilter';
-import { sGetFromState } from '../../reducers/itemFilter';
+import { sGetItemFilterRoot } from '../../reducers/itemFilter';
 import D2TextLink from '../../widgets/D2TextLink';
 
 const style = {
@@ -127,7 +127,7 @@ class ItemFilter extends Component {
 }
 
 const mapStateToProps = state => ({
-    selected: sGetFromState(state)[FILTER_USER_ORG_UNIT] || [],
+    selected: sGetItemFilterRoot(state)[FILTER_USER_ORG_UNIT] || [],
 });
 
 const ItemFilterCt = connect(

--- a/src/components/ItemGrid/ItemGrid.js
+++ b/src/components/ItemGrid/ItemGrid.js
@@ -21,7 +21,6 @@ import {
     onItemResize,
 } from './gridUtil';
 import { orArray } from '../../util';
-import * as fromReducers from '../../reducers';
 import DeleteItemButton from './DeleteItemButton';
 import ModalLoadingMask from '../../widgets/ModalLoadingMask';
 import NoContentMessage from '../../widgets/NoContentMessage';
@@ -30,6 +29,15 @@ import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
 
 import './ItemGrid.css';
+import { sGetSelectedId, sGetSelectedIsLoading } from '../../reducers/selected';
+import {
+    sGetEditDashboard,
+    sGetEditDashboardItems,
+} from '../../reducers/editDashboard';
+import {
+    sGetDashboardById,
+    sGetDashboardItems,
+} from '../../reducers/dashboards';
 
 // Component
 
@@ -164,22 +172,16 @@ ItemGrid.defaultProps = {
 // Container
 
 const mapStateToProps = (state, ownProps) => {
-    const { fromSelected, fromEditDashboard, fromDashboards } = fromReducers;
-
     const selectedDashboard = ownProps.edit
-        ? fromEditDashboard.sGetEditDashboard(state)
-        : fromDashboards.sGetDashboardById(
-              state,
-              fromSelected.sGetSelectedId(state)
-          );
+        ? sGetEditDashboard(state)
+        : sGetDashboardById(state, sGetSelectedId(state));
 
     const dashboardItems = ownProps.edit
-        ? fromEditDashboard.sGetEditDashboardItems(state)
-        : fromDashboards.sGetDashboardItems(state);
+        ? sGetEditDashboardItems(state)
+        : sGetDashboardItems(state);
 
     return {
-        isLoading:
-            fromSelected.sGetSelectedIsLoading(state) || !selectedDashboard,
+        isLoading: sGetSelectedIsLoading(state) || !selectedDashboard,
         dashboardItems,
     };
 };

--- a/src/components/ItemGrid/ItemGrid.js
+++ b/src/components/ItemGrid/ItemGrid.js
@@ -31,7 +31,7 @@ import 'react-resizable/css/styles.css';
 import './ItemGrid.css';
 import { sGetSelectedId, sGetSelectedIsLoading } from '../../reducers/selected';
 import {
-    sGetEditDashboard,
+    sGetEditDashboardRoot,
     sGetEditDashboardItems,
 } from '../../reducers/editDashboard';
 import {
@@ -173,7 +173,7 @@ ItemGrid.defaultProps = {
 
 const mapStateToProps = (state, ownProps) => {
     const selectedDashboard = ownProps.edit
-        ? sGetEditDashboard(state)
+        ? sGetEditDashboardRoot(state)
         : sGetDashboardById(state, sGetSelectedId(state));
 
     const dashboardItems = ownProps.edit

--- a/src/components/ItemSelect/ItemSelectList.js
+++ b/src/components/ItemSelect/ItemSelectList.js
@@ -9,7 +9,7 @@ import SvgIcon from 'd2-ui/lib/svg-icon/SvgIcon';
 
 import { tAddListItemContent } from './actions';
 import { acAddDashboardItem } from '../../actions/editDashboard';
-import { sGetEditDashboard } from '../../reducers/editDashboard';
+import { sGetEditDashboardRoot } from '../../reducers/editDashboard';
 import {
     itemTypeMap,
     getItemUrl,
@@ -175,7 +175,7 @@ ItemSelectList.contextTypes = {
 
 export default connect(
     state => ({
-        dashboardId: sGetEditDashboard(state).id,
+        dashboardId: sGetEditDashboardRoot(state).id,
     }),
     {
         acAddDashboardItem,

--- a/src/components/ItemSelect/actions.js
+++ b/src/components/ItemSelect/actions.js
@@ -1,4 +1,4 @@
-import { sGetEditDashboard } from '../../reducers/editDashboard';
+import { sGetEditDashboardRoot } from '../../reducers/editDashboard';
 import { itemTypeMap } from '../../itemTypes';
 import {
     acAddDashboardItem,
@@ -11,7 +11,7 @@ export const tAddListItemContent = (dashboardId, type, content) => (
 ) => {
     const state = getState();
     const listItemType = itemTypeMap[type].propName;
-    const dashboardItems = sGetEditDashboard(state).dashboardItems;
+    const dashboardItems = sGetEditDashboardRoot(state).dashboardItems;
     const dashboardItemIndex = dashboardItems.findIndex(
         item => item.type === type
     );

--- a/src/components/TitleBar/EditTitleBar.js
+++ b/src/components/TitleBar/EditTitleBar.js
@@ -8,8 +8,9 @@ import {
     acSetDashboardTitle,
     acSetDashboardDescription,
 } from '../../actions/editDashboard';
-import * as fromReducers from '../../reducers';
 import { orObject } from '../../util';
+import { sGetEditDashboardRoot } from '../../reducers/editDashboard';
+import { sGetDashboardById } from '../../reducers/dashboards';
 import ItemSelect from '../ItemSelect/ItemSelect';
 
 const EditTitleBar = ({
@@ -76,16 +77,10 @@ const EditTitleBar = ({
 };
 
 const mapStateToProps = state => {
-    const selectedDashboard = orObject(
-        fromReducers.fromEditDashboard.sGetEditDashboard(state)
-    );
+    const selectedDashboard = orObject(sGetEditDashboardRoot(state));
 
-    const displayName = orObject(
-        fromReducers.fromDashboards.sGetDashboardById(
-            state,
-            selectedDashboard.id
-        )
-    ).displayName;
+    const displayName = orObject(sGetDashboardById(state, selectedDashboard.id))
+        .displayName;
 
     return {
         name: selectedDashboard.name,

--- a/src/components/TitleBar/ViewTitleBar.js
+++ b/src/components/TitleBar/ViewTitleBar.js
@@ -6,13 +6,21 @@ import i18n from 'd2-i18n';
 import SharingDialog from 'd2-ui-sharing';
 import SvgIcon from 'd2-ui/lib/svg-icon/SvgIcon';
 
-import * as fromReducers from '../../reducers';
 import { orObject } from '../../util';
 import { tStarDashboard } from '../../actions/dashboards';
 import { acSetSelectedShowDescription } from '../../actions/selected';
 import FilterDialog from '../ItemFilter/ItemFilter';
 import FlatButton from '../../widgets/FlatButton';
 import Info from './Info';
+import {
+    sGetSelectedId,
+    sGetSelectedShowDescription,
+} from '../../reducers/selected';
+import {
+    sGetDashboardById,
+    sGetDashboardItems,
+} from '../../reducers/dashboards';
+import { sGetFilterKeys } from '../../reducers/itemFilter';
 
 const NO_DESCRIPTION = i18n.t('No description');
 
@@ -178,19 +186,18 @@ class ViewTitleBar extends Component {
 }
 
 const mapStateToProps = state => {
-    const { fromSelected, fromDashboards, fromItemFilter } = fromReducers;
-    const id = fromSelected.sGetSelectedId(state);
-    const dashboard = orObject(fromDashboards.sGetDashboardById(state, id));
+    const id = sGetSelectedId(state);
+    const dashboard = orObject(sGetDashboardById(state, id));
 
     return {
         id,
         name: dashboard.displayName,
         description: dashboard.displayDescription,
-        dashboardItems: fromDashboards.sGetDashboardItems(state),
-        showDescription: fromSelected.sGetSelectedShowDescription(state),
+        dashboardItems: sGetDashboardItems(state),
+        showDescription: sGetSelectedShowDescription(state),
         starred: dashboard.starred,
         access: orObject(dashboard.access),
-        itemFilterKeys: fromItemFilter.sGetFilterKeys(state),
+        itemFilterKeys: sGetFilterKeys(state),
     };
 };
 

--- a/src/reducers/__tests__/controlBar.spec.js
+++ b/src/reducers/__tests__/controlBar.spec.js
@@ -1,16 +1,21 @@
-import reducer, { actionTypes, DEFAULT_ROWS } from '../controlBar';
+import reducer, {
+    SET_CONTROLBAR_USER_ROWS,
+    DEFAULT_STATE_CONTROLBAR_ROWS,
+} from '../controlBar';
 
 describe('controlbar reducer', () => {
     it('should return the default state', () => {
         const actualState = reducer(undefined, {});
 
-        expect(actualState).toEqual({ userRows: DEFAULT_ROWS });
+        expect(actualState).toEqual({
+            userRows: DEFAULT_STATE_CONTROLBAR_ROWS,
+        });
     });
 
     it('should handle SET_CONTROLBAR_USER_ROWS', () => {
         const rows = 4;
         const action = {
-            type: actionTypes.SET_CONTROLBAR_USER_ROWS,
+            type: SET_CONTROLBAR_USER_ROWS,
             value: rows,
         };
 

--- a/src/reducers/__tests__/dashboards.spec.js
+++ b/src/reducers/__tests__/dashboards.spec.js
@@ -1,7 +1,7 @@
 import reducer, {
     actionTypes,
     DEFAULT_DASHBOARDS,
-    sGetFromState,
+    sGetDashboardsRoot,
     sGetDashboardById,
     sGetAllDashboards,
     sGetStarredDashboards,
@@ -81,9 +81,9 @@ describe('dashboards reducer', () => {
         expect(actualState).toEqual(expectedState);
     });
 
-    it('APPEND_DASHBOARDS: should append to the list of dashboards and leave the items untouched', () => {
+    it('ADD_DASHBOARDS: should append to the list of dashboards and leave the items untouched', () => {
         const actualState = reducer(dashboardsState, {
-            type: actionTypes.APPEND_DASHBOARDS,
+            type: actionTypes.ADD_DASHBOARDS,
             value: dashboards,
         });
 
@@ -171,8 +171,8 @@ const dash3 = dashboardsState.byId[dashId3];
 const dash4 = dashboardsState.byId[dashId4];
 
 describe('dashboards selectors', () => {
-    it('sGetFromState: should return the root prop', () => {
-        const actualState = sGetFromState(testState);
+    it('sGetDashboardsRoot: should return the root prop', () => {
+        const actualState = sGetDashboardsRoot(testState);
 
         expect(actualState).toEqual(dashboardsState);
     });

--- a/src/reducers/__tests__/dashboards.spec.js
+++ b/src/reducers/__tests__/dashboards.spec.js
@@ -1,6 +1,5 @@
 import reducer, {
-    actionTypes,
-    DEFAULT_DASHBOARDS,
+    DEFAULT_STATE_DASHBOARDS,
     sGetDashboardsRoot,
     sGetDashboardById,
     sGetAllDashboards,
@@ -9,6 +8,11 @@ import reducer, {
     sGetStarredDashboardIds,
     sGetUnstarredDashboardIds,
     sGetDashboardsSortedByStarred,
+    SET_DASHBOARDS,
+    ADD_DASHBOARDS,
+    SET_DASHBOARD_STARRED,
+    SET_DASHBOARD_DISPLAY_NAME,
+    SET_DASHBOARD_ITEMS,
 } from '../dashboards';
 
 const dashId1 = 'dash1';
@@ -64,12 +68,12 @@ describe('dashboards reducer', () => {
     it('should return the default state', () => {
         const actualState = reducer(undefined, { type: 'NO_MATCH' });
 
-        expect(actualState).toEqual(DEFAULT_DASHBOARDS);
+        expect(actualState).toEqual(DEFAULT_STATE_DASHBOARDS);
     });
 
     it('SET_DASHBOARDS: should set the new list of dashboards and clear the items array', () => {
         const actualState = reducer(dashboardsState, {
-            type: actionTypes.SET_DASHBOARDS,
+            type: SET_DASHBOARDS,
             value: dashboards,
         });
 
@@ -83,7 +87,7 @@ describe('dashboards reducer', () => {
 
     it('ADD_DASHBOARDS: should append to the list of dashboards and leave the items untouched', () => {
         const actualState = reducer(dashboardsState, {
-            type: actionTypes.ADD_DASHBOARDS,
+            type: ADD_DASHBOARDS,
             value: dashboards,
         });
 
@@ -102,7 +106,7 @@ describe('dashboards reducer', () => {
         const starredValue = true;
 
         const actualState = reducer(dashboardsState, {
-            type: actionTypes.SET_DASHBOARD_STARRED,
+            type: SET_DASHBOARD_STARRED,
             dashboardId: dashId1,
             value: starredValue,
         });
@@ -125,7 +129,7 @@ describe('dashboards reducer', () => {
         const displayName = 'nome tradotto';
 
         const actualState = reducer(dashboardsState, {
-            type: actionTypes.SET_DASHBOARD_DISPLAY_NAME,
+            type: SET_DASHBOARD_DISPLAY_NAME,
             dashboardId: dashId1,
             value: displayName,
         });
@@ -148,7 +152,7 @@ describe('dashboards reducer', () => {
         const items = [{ id: 'item2', type: 'CHART' }];
 
         const actualState = reducer(dashboardsState, {
-            type: actionTypes.SET_DASHBOARD_ITEMS,
+            type: SET_DASHBOARD_ITEMS,
             value: items,
         });
 

--- a/src/reducers/__tests__/editDashboard.spec.js
+++ b/src/reducers/__tests__/editDashboard.spec.js
@@ -1,9 +1,17 @@
 import update from 'immutability-helper';
 import reducer, {
-    actionTypes,
-    sGetIsEditing,
-    DEFAULT_STATE,
+    DEFAULT_STATE_EDIT_DASHBOARD,
     NEW_DASHBOARD_STATE,
+    sGetIsEditing,
+    RECEIVED_DASHBOARD_LAYOUT,
+    RECEIVED_NOT_EDITING,
+    START_NEW_DASHBOARD,
+    RECEIVED_EDIT_DASHBOARD,
+    RECEIVED_TITLE,
+    RECEIVED_DESCRIPTION,
+    ADD_DASHBOARD_ITEM,
+    UPDATE_DASHBOARD_ITEM,
+    REMOVE_DASHBOARD_ITEM,
 } from '../editDashboard';
 
 describe('editDashboard', () => {
@@ -43,7 +51,7 @@ describe('editDashboard', () => {
             ];
 
             const actualState = reducer(initialState, {
-                type: actionTypes.RECEIVED_DASHBOARD_LAYOUT,
+                type: RECEIVED_DASHBOARD_LAYOUT,
                 value: newLayout,
             });
 
@@ -74,20 +82,20 @@ describe('editDashboard', () => {
         it('should return the default state', () => {
             const actualState = reducer(undefined, {});
 
-            expect(actualState).toEqual(DEFAULT_STATE);
+            expect(actualState).toEqual(DEFAULT_STATE_EDIT_DASHBOARD);
         });
 
         it('should handle the action RECEIVED_NOT_EDITING', () => {
             const actualState = reducer(initialState, {
-                type: actionTypes.RECEIVED_NOT_EDITING,
+                type: RECEIVED_NOT_EDITING,
             });
 
-            expect(actualState).toEqual(DEFAULT_STATE);
+            expect(actualState).toEqual(DEFAULT_STATE_EDIT_DASHBOARD);
         });
 
         it('should return the state for a new dashboard', () => {
-            const actualState = reducer(DEFAULT_STATE, {
-                type: actionTypes.START_NEW_DASHBOARD,
+            const actualState = reducer(DEFAULT_STATE_EDIT_DASHBOARD, {
+                type: START_NEW_DASHBOARD,
             });
 
             expect(actualState).toEqual(NEW_DASHBOARD_STATE);
@@ -95,7 +103,7 @@ describe('editDashboard', () => {
 
         it('should set the dashboard to be edited', () => {
             const actualState = reducer(initialState, {
-                type: actionTypes.RECEIVED_EDIT_DASHBOARD,
+                type: RECEIVED_EDIT_DASHBOARD,
                 value: newState,
             });
 
@@ -111,7 +119,7 @@ describe('editDashboard', () => {
             const title = 'moohaha scary dashboard';
 
             const actualState = reducer(initialState, {
-                type: actionTypes.RECEIVED_TITLE,
+                type: RECEIVED_TITLE,
                 value: title,
             });
 
@@ -128,7 +136,7 @@ describe('editDashboard', () => {
             const description = 'moohaha scary dashboard dashboard';
 
             const actualState = reducer(initialState, {
-                type: actionTypes.RECEIVED_DESCRIPTION,
+                type: RECEIVED_DESCRIPTION,
                 value: description,
             });
 
@@ -150,7 +158,7 @@ describe('editDashboard', () => {
             };
 
             const actualState = reducer(initialState, {
-                type: actionTypes.ADD_DASHBOARD_ITEM,
+                type: ADD_DASHBOARD_ITEM,
                 value: newItem,
             });
 
@@ -180,7 +188,7 @@ describe('editDashboard', () => {
             };
 
             const actualState = reducer(initialState, {
-                type: actionTypes.UPDATE_DASHBOARD_ITEM,
+                type: UPDATE_DASHBOARD_ITEM,
                 value: updatedDashboardItem,
             });
 
@@ -195,7 +203,7 @@ describe('editDashboard', () => {
             const itemToRemove = initialState.dashboardItems[removeIdx];
 
             const actualState = reducer(initialState, {
-                type: actionTypes.REMOVE_DASHBOARD_ITEM,
+                type: REMOVE_DASHBOARD_ITEM,
                 value: itemToRemove.id,
             });
 

--- a/src/reducers/__tests__/interpretations.spec.js
+++ b/src/reducers/__tests__/interpretations.spec.js
@@ -1,4 +1,8 @@
-import reducer, { actionTypes } from '../interpretations';
+import reducer, {
+    ADD_INTERPRETATIONS,
+    REMOVE_INTERPRETATION,
+    RECEIVED_INTERPRETATION,
+} from '../interpretations';
 import update from 'immutability-helper';
 
 describe('interpretations reducer', () => {
@@ -22,7 +26,7 @@ describe('interpretations reducer', () => {
         const newInterpretation = { id: 'int2', text: 'woot' };
 
         const actualState = reducer(currentState, {
-            type: actionTypes.RECEIVED_INTERPRETATION,
+            type: RECEIVED_INTERPRETATION,
             value: newInterpretation,
         });
 
@@ -43,7 +47,7 @@ describe('interpretations reducer', () => {
         ];
 
         const actualState = reducer(currentState, {
-            type: actionTypes.ADD_INTERPRETATIONS,
+            type: ADD_INTERPRETATIONS,
             value: newInterpretations,
         });
 
@@ -57,7 +61,7 @@ describe('interpretations reducer', () => {
 
     it('should remove an interpretation', () => {
         const actualState = reducer(currentState, {
-            type: actionTypes.REMOVE_INTERPRETATION,
+            type: REMOVE_INTERPRETATION,
             value: 'int1',
         });
 
@@ -72,7 +76,7 @@ describe('interpretations reducer', () => {
         const updatedInterpretation = { id: 'int1', text: 'edit, edit' };
 
         const actualState = reducer(currentState, {
-            type: actionTypes.RECEIVED_INTERPRETATION,
+            type: RECEIVED_INTERPRETATION,
             value: updatedInterpretation,
         });
 

--- a/src/reducers/__tests__/itemFilter.spec.js
+++ b/src/reducers/__tests__/itemFilter.spec.js
@@ -1,4 +1,7 @@
-import reducer, { actionTypes, DEFAULT_STATE } from '../itemFilter';
+import reducer, {
+    DEFAULT_STATE_ITEM_FILTER,
+    SET_ITEM_FILTER,
+} from '../itemFilter';
 
 const testKey = 'userOrgUnit';
 const testValue = ['uid'];
@@ -10,14 +13,14 @@ const testState = {
 describe('item filter reducer', () => {
     describe('reducer', () => {
         it('should return the default state', () => {
-            const actualState = reducer(DEFAULT_STATE, {});
+            const actualState = reducer(DEFAULT_STATE_ITEM_FILTER, {});
 
-            expect(actualState).toEqual(DEFAULT_STATE);
+            expect(actualState).toEqual(DEFAULT_STATE_ITEM_FILTER);
         });
 
         it('should set a filter', () => {
             const action = {
-                type: actionTypes.SET_ITEM_FILTER,
+                type: SET_ITEM_FILTER,
                 key: testKey,
                 value: testValue,
             };
@@ -31,11 +34,11 @@ describe('item filter reducer', () => {
 
         it('should remove a filter', () => {
             const action = {
-                type: actionTypes.SET_ITEM_FILTER,
+                type: SET_ITEM_FILTER,
                 key: testKey,
             };
 
-            const expectedState = DEFAULT_STATE;
+            const expectedState = DEFAULT_STATE_ITEM_FILTER;
 
             const actualState = reducer(testState, action);
 

--- a/src/reducers/__tests__/messages.spec.js
+++ b/src/reducers/__tests__/messages.spec.js
@@ -1,4 +1,4 @@
-import reducer, { actionTypes } from '../messages';
+import reducer, { RECEIVED_MESSAGES } from '../messages';
 
 describe('messages reducer', () => {
     const currentState = {
@@ -25,7 +25,7 @@ describe('messages reducer', () => {
         ];
 
         const actualState = reducer(currentState, {
-            type: actionTypes.RECEIVED_MESSAGES,
+            type: RECEIVED_MESSAGES,
             value: newMessages,
         });
 
@@ -42,7 +42,7 @@ describe('messages reducer', () => {
         const newMessages = [{ id: 'msg1', text: 'mooo' }];
 
         const actualState = reducer(currentState, {
-            type: actionTypes.RECEIVED_MESSAGES,
+            type: RECEIVED_MESSAGES,
             value: newMessages,
         });
 

--- a/src/reducers/__tests__/selected.spec.js
+++ b/src/reducers/__tests__/selected.spec.js
@@ -1,4 +1,8 @@
-import reducer, { actionTypes } from '../selected';
+import reducer, {
+    SET_SELECTED_ID,
+    SET_SELECTED_ISLOADING,
+    SET_SELECTED_SHOWDESCRIPTION,
+} from '../selected';
 
 describe('selected dashboard reducer', () => {
     const defaultState = {
@@ -13,7 +17,7 @@ describe('selected dashboard reducer', () => {
             const expectedState = Object.assign({}, defaultState, { id });
 
             const actualState = reducer(defaultState, {
-                type: actionTypes.SET_SELECTED_ID,
+                type: SET_SELECTED_ID,
                 value: id,
             });
 
@@ -27,7 +31,7 @@ describe('selected dashboard reducer', () => {
             });
 
             const actualState = reducer(defaultState, {
-                type: actionTypes.SET_SELECTED_ISLOADING,
+                type: SET_SELECTED_ISLOADING,
                 value: isLoading,
             });
 
@@ -41,7 +45,7 @@ describe('selected dashboard reducer', () => {
             });
 
             const actualState = reducer(defaultState, {
-                type: actionTypes.SET_SELECTED_SHOWDESCRIPTION,
+                type: SET_SELECTED_SHOWDESCRIPTION,
                 value: showDescription,
             });
 

--- a/src/reducers/__tests__/snackbar.spec.js
+++ b/src/reducers/__tests__/snackbar.spec.js
@@ -1,10 +1,14 @@
-import reducer, { actionTypes, DEFAULT_STATE } from '../snackbar';
+import reducer, {
+    DEFAULT_STATE_SNACKBAR,
+    RECEIVED_SNACKBAR_MESSAGE,
+    CLOSE_SNACKBAR,
+} from '../snackbar';
 
 describe('snackbar reducer', () => {
     it('should return the default state', () => {
         const actualState = reducer(undefined, {});
 
-        expect(actualState).toEqual(DEFAULT_STATE);
+        expect(actualState).toEqual(DEFAULT_STATE_SNACKBAR);
     });
 
     it('should handle RECEIVED_SNACKBAR_MESSAGE action with message object containing only message text', () => {
@@ -14,7 +18,7 @@ describe('snackbar reducer', () => {
         };
 
         const action = {
-            type: actionTypes.RECEIVED_SNACKBAR_MESSAGE,
+            type: RECEIVED_SNACKBAR_MESSAGE,
             value: {
                 message,
             },
@@ -26,7 +30,7 @@ describe('snackbar reducer', () => {
             open: false,
         };
 
-        const actualState = reducer(DEFAULT_STATE, action);
+        const actualState = reducer(DEFAULT_STATE_SNACKBAR, action);
         expect(actualState).toEqual(expectedState);
     });
 
@@ -38,7 +42,7 @@ describe('snackbar reducer', () => {
         const duration = 3000;
 
         const action = {
-            type: actionTypes.RECEIVED_SNACKBAR_MESSAGE,
+            type: RECEIVED_SNACKBAR_MESSAGE,
             value: {
                 message,
             },
@@ -69,7 +73,7 @@ describe('snackbar reducer', () => {
         const open = true;
 
         const action = {
-            type: actionTypes.RECEIVED_SNACKBAR_MESSAGE,
+            type: RECEIVED_SNACKBAR_MESSAGE,
             value: {
                 message,
                 duration,
@@ -83,7 +87,7 @@ describe('snackbar reducer', () => {
             open,
         };
 
-        const actualState = reducer(DEFAULT_STATE, action);
+        const actualState = reducer(DEFAULT_STATE_SNACKBAR, action);
         expect(actualState).toEqual(expectedState);
     });
 
@@ -93,7 +97,7 @@ describe('snackbar reducer', () => {
         const open = true;
 
         const action = {
-            type: actionTypes.RECEIVED_SNACKBAR_MESSAGE,
+            type: RECEIVED_SNACKBAR_MESSAGE,
             value: {
                 message,
                 duration,
@@ -107,13 +111,13 @@ describe('snackbar reducer', () => {
             open,
         };
 
-        const actualState = reducer(DEFAULT_STATE, action);
+        const actualState = reducer(DEFAULT_STATE_SNACKBAR, action);
         expect(actualState).toEqual(expectedState);
     });
 
     it('should handle the CLOSE_SNACKBAR action', () => {
         const action = {
-            type: actionTypes.CLOSE_SNACKBAR,
+            type: CLOSE_SNACKBAR,
         };
 
         const currentState = {
@@ -124,6 +128,6 @@ describe('snackbar reducer', () => {
 
         const actualState = reducer(currentState, action);
 
-        expect(actualState).toEqual(DEFAULT_STATE);
+        expect(actualState).toEqual(DEFAULT_STATE_SNACKBAR);
     });
 });

--- a/src/reducers/__tests__/user.spec.js
+++ b/src/reducers/__tests__/user.spec.js
@@ -1,10 +1,10 @@
-import reducer, { actionTypes, defaultState } from '../user';
+import reducer, { DEFAULT_STATE_USER, RECEIVED_USER } from '../user';
 
 describe('user reducer', () => {
     it('should return the default state', () => {
         const actualState = reducer(undefined, {});
 
-        expect(actualState).toEqual(defaultState);
+        expect(actualState).toEqual(DEFAULT_STATE_USER);
     });
 
     it('should handle RECEIVED_USER action', () => {
@@ -13,7 +13,7 @@ describe('user reducer', () => {
         const uiLocale = 'teletubbie';
 
         const action = {
-            type: actionTypes.RECEIVED_USER,
+            type: RECEIVED_USER,
             value: {
                 id,
                 username,
@@ -33,7 +33,7 @@ describe('user reducer', () => {
             isSuperuser: true,
         };
 
-        const actualState = reducer(defaultState, action);
+        const actualState = reducer(DEFAULT_STATE_USER, action);
         expect(actualState).toEqual(expectedState);
     });
 });

--- a/src/reducers/__tests__/visualizations.spec.js
+++ b/src/reducers/__tests__/visualizations.spec.js
@@ -1,4 +1,8 @@
-import reducer, { actionTypes, DEFAULT_STATE } from '../visualizations';
+import reducer, {
+    DEFAULT_STATE_VISUALIZATIONS,
+    RECEIVED_VISUALIZATION,
+    RECEIVED_ACTIVE_VISUALIZATION,
+} from '../visualizations';
 
 describe('visualizations reducer', () => {
     const activeType = 'CHART';
@@ -24,18 +28,18 @@ describe('visualizations reducer', () => {
 
     it('should return the default state', () => {
         const actualState = reducer(undefined, { type: 'NO_MATCH' });
-        const expectedState = DEFAULT_STATE;
+        const expectedState = DEFAULT_STATE_VISUALIZATIONS;
 
         expect(actualState).toEqual(expectedState);
     });
 
     it('should add a visualization (RECEIVED_VISUALIZATION)', () => {
         const action = {
-            type: actionTypes.RECEIVED_VISUALIZATION,
+            type: RECEIVED_VISUALIZATION,
             value: visualization,
         };
 
-        const actualState = reducer(DEFAULT_STATE, action);
+        const actualState = reducer(DEFAULT_STATE_VISUALIZATIONS, action);
         const expectedState = state;
 
         expect(actualState).toEqual(expectedState);
@@ -43,7 +47,7 @@ describe('visualizations reducer', () => {
 
     it('should update a visualization with activeType (RECEIVED_ACTIVE_VISUALIZATION)', () => {
         const action = {
-            type: actionTypes.RECEIVED_ACTIVE_VISUALIZATION,
+            type: RECEIVED_ACTIVE_VISUALIZATION,
             id: visualization.id,
             activeType,
         };
@@ -57,7 +61,7 @@ describe('visualizations reducer', () => {
 
     it('should update a visualization with removed activeType (RECEIVED_ACTIVE_VISUALIZATION)', () => {
         const action = {
-            type: actionTypes.RECEIVED_ACTIVE_VISUALIZATION,
+            type: RECEIVED_ACTIVE_VISUALIZATION,
             id: visualization.id,
         };
 

--- a/src/reducers/controlBar.js
+++ b/src/reducers/controlBar.js
@@ -2,16 +2,14 @@
 import { combineReducers } from 'redux';
 import { validateReducer } from '../util';
 
-export const actionTypes = {
-    SET_CONTROLBAR_USER_ROWS: 'SET_CONTROLBAR_USER_ROWS',
-};
+export const SET_CONTROLBAR_USER_ROWS = 'SET_CONTROLBAR_USER_ROWS';
 
-export const DEFAULT_ROWS = 1;
+export const DEFAULT_STATE_CONTROLBAR_ROWS = 1;
 
-const userRows = (state = DEFAULT_ROWS, action) => {
+const userRows = (state = DEFAULT_STATE_CONTROLBAR_ROWS, action) => {
     switch (action.type) {
-        case actionTypes.SET_CONTROLBAR_USER_ROWS:
-            return validateReducer(action.value, DEFAULT_ROWS);
+        case SET_CONTROLBAR_USER_ROWS:
+            return validateReducer(action.value, DEFAULT_STATE_CONTROLBAR_ROWS);
         default:
             return state;
     }

--- a/src/reducers/controlBar.js
+++ b/src/reducers/controlBar.js
@@ -27,8 +27,9 @@ export default combineReducers({
  * @param {Object} state
  * @returns {Object}
  */
-export const sGetFromState = state => state.controlBar;
+export const sGetControlBarRoot = state => state.controlBar;
 
 // Selector dependency level 2
 
-export const sGetControlBarUserRows = state => sGetFromState(state).userRows;
+export const sGetControlBarUserRows = state =>
+    sGetControlBarRoot(state).userRows;

--- a/src/reducers/dashboards.js
+++ b/src/reducers/dashboards.js
@@ -2,6 +2,7 @@
 
 import arrayFrom from 'd2-utilizr/lib/arrayFrom';
 import arraySort from 'd2-utilizr/lib/arraySort';
+
 import { orArray, orObject } from '../util';
 import {
     SPACER,
@@ -10,15 +11,13 @@ import {
     emptyTextItemContent,
 } from '../itemTypes';
 
-export const actionTypes = {
-    SET_DASHBOARDS: 'SET_DASHBOARDS',
-    ADD_DASHBOARDS: 'ADD_DASHBOARDS',
-    SET_DASHBOARD_STARRED: 'SET_DASHBOARD_STARRED',
-    SET_DASHBOARD_DISPLAY_NAME: 'SET_DASHBOARD_DISPLAY_NAME',
-    SET_DASHBOARD_ITEMS: 'SET_DASHBOARD_ITEMS',
-};
+export const SET_DASHBOARDS = 'SET_DASHBOARDS';
+export const ADD_DASHBOARDS = 'ADD_DASHBOARDS';
+export const SET_DASHBOARD_STARRED = 'SET_DASHBOARD_STARRED';
+export const SET_DASHBOARD_DISPLAY_NAME = 'SET_DASHBOARD_DISPLAY_NAME';
+export const SET_DASHBOARD_ITEMS = 'SET_DASHBOARD_ITEMS';
 
-export const DEFAULT_DASHBOARDS = {
+export const DEFAULT_STATE_DASHBOARDS = {
     byId: null,
     items: [],
 };
@@ -43,15 +42,15 @@ const updateDashboardProp = (state, dashboardId, prop, value) => ({
  * @param {Object} action The action to be evaluated
  * @returns {Object}
  */
-export default (state = DEFAULT_DASHBOARDS, action) => {
+export default (state = DEFAULT_STATE_DASHBOARDS, action) => {
     switch (action.type) {
-        case actionTypes.SET_DASHBOARDS: {
+        case SET_DASHBOARDS: {
             return {
                 byId: action.value,
                 items: [],
             };
         }
-        case actionTypes.ADD_DASHBOARDS: {
+        case ADD_DASHBOARDS: {
             return {
                 ...state,
                 byId: {
@@ -60,7 +59,7 @@ export default (state = DEFAULT_DASHBOARDS, action) => {
                 },
             };
         }
-        case actionTypes.SET_DASHBOARD_STARRED: {
+        case SET_DASHBOARD_STARRED: {
             return updateDashboardProp(
                 state,
                 action.dashboardId,
@@ -68,7 +67,7 @@ export default (state = DEFAULT_DASHBOARDS, action) => {
                 action.value
             );
         }
-        case actionTypes.SET_DASHBOARD_DISPLAY_NAME: {
+        case SET_DASHBOARD_DISPLAY_NAME: {
             return updateDashboardProp(
                 state,
                 action.dashboardId,
@@ -76,7 +75,7 @@ export default (state = DEFAULT_DASHBOARDS, action) => {
                 action.value
             );
         }
-        case actionTypes.SET_DASHBOARD_ITEMS: {
+        case SET_DASHBOARD_ITEMS: {
             return {
                 ...state,
                 items: action.value,

--- a/src/reducers/dashboards.js
+++ b/src/reducers/dashboards.js
@@ -12,7 +12,7 @@ import {
 
 export const actionTypes = {
     SET_DASHBOARDS: 'SET_DASHBOARDS',
-    APPEND_DASHBOARDS: 'APPEND_DASHBOARDS',
+    ADD_DASHBOARDS: 'ADD_DASHBOARDS',
     SET_DASHBOARD_STARRED: 'SET_DASHBOARD_STARRED',
     SET_DASHBOARD_DISPLAY_NAME: 'SET_DASHBOARD_DISPLAY_NAME',
     SET_DASHBOARD_ITEMS: 'SET_DASHBOARD_ITEMS',
@@ -51,7 +51,7 @@ export default (state = DEFAULT_DASHBOARDS, action) => {
                 items: [],
             };
         }
-        case actionTypes.APPEND_DASHBOARDS: {
+        case actionTypes.ADD_DASHBOARDS: {
             return {
                 ...state,
                 byId: {
@@ -89,7 +89,7 @@ export default (state = DEFAULT_DASHBOARDS, action) => {
 
 // root selector
 
-export const sGetFromState = state => state.dashboards;
+export const sGetDashboardsRoot = state => state.dashboards;
 
 // selector level 1
 
@@ -107,10 +107,10 @@ export const sGetFromState = state => state.dashboards;
  * @returns {Object | undefined}
  */
 export const sGetDashboardById = (state, id) =>
-    orObject(sGetFromState(state).byId)[id];
+    orObject(sGetDashboardsRoot(state).byId)[id];
 
 export const sDashboardsIsFetching = state => {
-    return sGetFromState(state).byId === null;
+    return sGetDashboardsRoot(state).byId === null;
 };
 
 /**
@@ -120,7 +120,8 @@ export const sDashboardsIsFetching = state => {
  * @param {Object} state The current state
  * @returns {Object | undefined}
  */
-export const sGetAllDashboards = state => orObject(sGetFromState(state).byId);
+export const sGetAllDashboards = state =>
+    orObject(sGetDashboardsRoot(state).byId);
 
 /**
  * Selector which returns the current dashboard items
@@ -129,7 +130,7 @@ export const sGetAllDashboards = state => orObject(sGetFromState(state).byId);
  * @param {Object} state The current state
  * @returns {Array}
  */
-export const sGetDashboardItems = state => sGetFromState(state).items;
+export const sGetDashboardItems = state => sGetDashboardsRoot(state).items;
 
 // selector level 2
 

--- a/src/reducers/dashboardsFilter.js
+++ b/src/reducers/dashboardsFilter.js
@@ -1,11 +1,9 @@
 import { combineReducers } from 'redux';
 import { validateReducer } from '../util';
 
-export const actionTypes = {
-    SET_DASHBOARDS_FILTER_NAME: 'SET_DASHBOARDS_FILTER_NAME',
-    SET_DASHBOARDS_FILTER_OWNER: 'SET_DASHBOARDS_FILTER_OWNER',
-    SET_DASHBOARDS_FILTER_ORDER: 'SET_DASHBOARDS_FILTER_ORDER',
-};
+export const SET_DASHBOARDS_FILTER_NAME = 'SET_DASHBOARDS_FILTER_NAME';
+export const SET_DASHBOARDS_FILTER_OWNER = 'SET_DASHBOARDS_FILTER_OWNER';
+export const SET_DASHBOARDS_FILTER_ORDER = 'SET_DASHBOARDS_FILTER_ORDER';
 
 export const ownerData = [
     { id: 'ALL', value: 'All users' },
@@ -22,40 +20,40 @@ export const orderData = [
     { id: 'CREATED:ASC', value: 'Created date (desc)' },
 ];
 
-export const DEFAULT_DASHBOARDS_FILTER_NAME = '';
-export const DEFAULT_DASHBOARDS_FILTER_OWNER = ownerData[0].id;
-export const DEFAULT_DASHBOARDS_FILTER_ORDER = orderData[0].id;
+export const DEFAULT_STATE_DASHBOARDS_FILTER_NAME = '';
+export const DEFAULT_STATE_DASHBOARDS_FILTER_OWNER = ownerData[0].id;
+export const DEFAULT_STATE_DASHBOARDS_FILTER_ORDER = orderData[0].id;
 
-const name = (state = DEFAULT_DASHBOARDS_FILTER_NAME, action) => {
+const name = (state = DEFAULT_STATE_DASHBOARDS_FILTER_NAME, action) => {
     switch (action.type) {
-        case actionTypes.SET_DASHBOARDS_FILTER_NAME:
+        case SET_DASHBOARDS_FILTER_NAME:
             return validateReducer(
                 action.value,
-                DEFAULT_DASHBOARDS_FILTER_NAME
+                DEFAULT_STATE_DASHBOARDS_FILTER_NAME
             );
         default:
             return state;
     }
 };
 
-const owner = (state = DEFAULT_DASHBOARDS_FILTER_OWNER, action) => {
+const owner = (state = DEFAULT_STATE_DASHBOARDS_FILTER_OWNER, action) => {
     switch (action.type) {
-        case actionTypes.SET_DASHBOARDS_FILTER_OWNER:
+        case SET_DASHBOARDS_FILTER_OWNER:
             return validateReducer(
                 action.value,
-                DEFAULT_DASHBOARDS_FILTER_NAME
+                DEFAULT_STATE_DASHBOARDS_FILTER_NAME
             );
         default:
             return state;
     }
 };
 
-const order = (state = DEFAULT_DASHBOARDS_FILTER_ORDER, action) => {
+const order = (state = DEFAULT_STATE_DASHBOARDS_FILTER_ORDER, action) => {
     switch (action.type) {
-        case actionTypes.SET_DASHBOARDS_FILTER_ORDER:
+        case SET_DASHBOARDS_FILTER_ORDER:
             return validateReducer(
                 action.value,
-                DEFAULT_DASHBOARDS_FILTER_ORDER
+                DEFAULT_STATE_DASHBOARDS_FILTER_ORDER
             );
         default:
             return state;

--- a/src/reducers/dashboardsFilter.js
+++ b/src/reducers/dashboardsFilter.js
@@ -22,32 +22,41 @@ export const orderData = [
     { id: 'CREATED:ASC', value: 'Created date (desc)' },
 ];
 
-export const DEFAULT_NAME = '';
-export const DEFAULT_OWNER = ownerData[0].id;
-export const DEFAULT_ORDER = orderData[0].id;
+export const DEFAULT_DASHBOARDS_FILTER_NAME = '';
+export const DEFAULT_DASHBOARDS_FILTER_OWNER = ownerData[0].id;
+export const DEFAULT_DASHBOARDS_FILTER_ORDER = orderData[0].id;
 
-const name = (state = DEFAULT_NAME, action) => {
+const name = (state = DEFAULT_DASHBOARDS_FILTER_NAME, action) => {
     switch (action.type) {
         case actionTypes.SET_DASHBOARDS_FILTER_NAME:
-            return validateReducer(action.value, DEFAULT_NAME);
+            return validateReducer(
+                action.value,
+                DEFAULT_DASHBOARDS_FILTER_NAME
+            );
         default:
             return state;
     }
 };
 
-const owner = (state = DEFAULT_OWNER, action) => {
+const owner = (state = DEFAULT_DASHBOARDS_FILTER_OWNER, action) => {
     switch (action.type) {
         case actionTypes.SET_DASHBOARDS_FILTER_OWNER:
-            return validateReducer(action.value, DEFAULT_NAME);
+            return validateReducer(
+                action.value,
+                DEFAULT_DASHBOARDS_FILTER_NAME
+            );
         default:
             return state;
     }
 };
 
-const order = (state = DEFAULT_ORDER, action) => {
+const order = (state = DEFAULT_DASHBOARDS_FILTER_ORDER, action) => {
     switch (action.type) {
         case actionTypes.SET_DASHBOARDS_FILTER_ORDER:
-            return validateReducer(action.value, DEFAULT_ORDER);
+            return validateReducer(
+                action.value,
+                DEFAULT_DASHBOARDS_FILTER_ORDER
+            );
         default:
             return state;
     }

--- a/src/reducers/dashboardsFilter.js
+++ b/src/reducers/dashboardsFilter.js
@@ -70,10 +70,10 @@ export default combineReducers({
 
 // selectors
 
-export const sGetFromState = state => state.dashboardsFilter;
+export const sGetDashboardsFilterRoot = state => state.dashboardsFilter;
 
 // selector dependency level 2
 
-export const sGetFilterName = state => sGetFromState(state).name;
-export const sGetFilterOwner = state => sGetFromState(state).owner;
-export const sGetFilterOrder = state => sGetFromState(state).order;
+export const sGetFilterName = state => sGetDashboardsFilterRoot(state).name;
+export const sGetFilterOwner = state => sGetDashboardsFilterRoot(state).owner;
+export const sGetFilterOrder = state => sGetDashboardsFilterRoot(state).order;

--- a/src/reducers/editDashboard.js
+++ b/src/reducers/editDashboard.js
@@ -3,19 +3,17 @@ import update from 'immutability-helper';
 import isEmpty from 'lodash/isEmpty';
 import { orArray, orObject } from '../util';
 
-export const actionTypes = {
-    RECEIVED_EDIT_DASHBOARD: 'RECEIVED_EDIT_DASHBOARD',
-    RECEIVED_NOT_EDITING: 'RECEIVED_NOT_EDITING',
-    START_NEW_DASHBOARD: 'START_NEW_DASHBOARD',
-    RECEIVED_TITLE: 'RECEIVED_TITLE',
-    RECEIVED_DESCRIPTION: 'RECEIVED_DESCRIPTION',
-    ADD_DASHBOARD_ITEM: 'ADD_DASHBOARD_ITEM',
-    REMOVE_DASHBOARD_ITEM: 'REMOVE_DASHBOARD_ITEM',
-    UPDATE_DASHBOARD_ITEM: 'UPDATE_DASHBOARD_ITEM',
-    RECEIVED_DASHBOARD_LAYOUT: 'RECEIVED_DASHBOARD_LAYOUT',
-};
+export const RECEIVED_EDIT_DASHBOARD = 'RECEIVED_EDIT_DASHBOARD';
+export const RECEIVED_NOT_EDITING = 'RECEIVED_NOT_EDITING';
+export const START_NEW_DASHBOARD = 'START_NEW_DASHBOARD';
+export const RECEIVED_TITLE = 'RECEIVED_TITLE';
+export const RECEIVED_DESCRIPTION = 'RECEIVED_DESCRIPTION';
+export const ADD_DASHBOARD_ITEM = 'ADD_DASHBOARD_ITEM';
+export const REMOVE_DASHBOARD_ITEM = 'REMOVE_DASHBOARD_ITEM';
+export const UPDATE_DASHBOARD_ITEM = 'UPDATE_DASHBOARD_ITEM';
+export const RECEIVED_DASHBOARD_LAYOUT = 'RECEIVED_DASHBOARD_LAYOUT';
 
-export const DEFAULT_STATE = {};
+export const DEFAULT_STATE_EDIT_DASHBOARD = {};
 export const NEW_DASHBOARD_STATE = {
     id: '',
     name: '',
@@ -24,31 +22,31 @@ export const NEW_DASHBOARD_STATE = {
     dashboardItems: [],
 };
 
-export default (state = DEFAULT_STATE, action) => {
+export default (state = DEFAULT_STATE_EDIT_DASHBOARD, action) => {
     switch (action.type) {
-        case actionTypes.RECEIVED_EDIT_DASHBOARD:
+        case RECEIVED_EDIT_DASHBOARD:
             const newState = {};
             Object.keys(NEW_DASHBOARD_STATE).map(
                 k => (newState[k] = action.value[k])
             );
             return newState;
-        case actionTypes.RECEIVED_NOT_EDITING:
-            return DEFAULT_STATE;
-        case actionTypes.START_NEW_DASHBOARD:
+        case RECEIVED_NOT_EDITING:
+            return DEFAULT_STATE_EDIT_DASHBOARD;
+        case START_NEW_DASHBOARD:
             return NEW_DASHBOARD_STATE;
-        case actionTypes.RECEIVED_TITLE: {
+        case RECEIVED_TITLE: {
             return Object.assign({}, state, { name: action.value });
         }
-        case actionTypes.RECEIVED_DESCRIPTION: {
+        case RECEIVED_DESCRIPTION: {
             return Object.assign({}, state, {
                 description: action.value,
             });
         }
-        case actionTypes.ADD_DASHBOARD_ITEM:
+        case ADD_DASHBOARD_ITEM:
             return update(state, {
                 dashboardItems: { $unshift: [action.value] },
             });
-        case actionTypes.REMOVE_DASHBOARD_ITEM: {
+        case REMOVE_DASHBOARD_ITEM: {
             const idToRemove = action.value;
 
             const dashboardItemIndex = state.dashboardItems.findIndex(
@@ -65,7 +63,7 @@ export default (state = DEFAULT_STATE, action) => {
 
             return state;
         }
-        case actionTypes.RECEIVED_DASHBOARD_LAYOUT: {
+        case RECEIVED_DASHBOARD_LAYOUT: {
             const stateItems = orArray(state.dashboardItems);
 
             const newStateItems = action.value.map(({ x, y, w, h, i }) => {
@@ -78,7 +76,7 @@ export default (state = DEFAULT_STATE, action) => {
                 dashboardItems: { $set: newStateItems },
             });
         }
-        case actionTypes.UPDATE_DASHBOARD_ITEM: {
+        case UPDATE_DASHBOARD_ITEM: {
             const dashboardItem = action.value;
 
             const dashboardItemIndex = state.dashboardItems.findIndex(

--- a/src/reducers/editDashboard.js
+++ b/src/reducers/editDashboard.js
@@ -104,15 +104,17 @@ export default (state = DEFAULT_STATE, action) => {
 
 // root selector
 
-export const sGetEditDashboard = state => state.editDashboard;
+export const sGetEditDashboardRoot = state => state.editDashboard;
 
 // selectors
 
 export const sGetIsEditing = state => !isEmpty(state.editDashboard);
 
 export const sGetIsNewDashboard = state => {
-    return !isEmpty(state.editDashboard) && sGetEditDashboard(state).id === '';
+    return (
+        !isEmpty(state.editDashboard) && sGetEditDashboardRoot(state).id === ''
+    );
 };
 
 export const sGetEditDashboardItems = state =>
-    orObject(sGetEditDashboard(state)).dashboardItems;
+    orObject(sGetEditDashboardRoot(state)).dashboardItems;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,38 +1,27 @@
 import { combineReducers } from 'redux';
 import arraySort from 'd2-utilizr/lib/arraySort';
-import dashboards, * as fromDashboards from './dashboards';
-import selected, * as fromSelected from './selected';
-import dashboardsFilter, * as fromDashboardsFilter from './dashboardsFilter';
-import controlBar, * as fromControlBar from './controlBar';
-import interpretations, * as fromInterpretations from './interpretations';
-import visualizations, * as fromVisualizations from './visualizations';
-import editDashboard, * as fromEditDashboard from './editDashboard';
-import messages, * as fromMessages from './messages';
-import user, * as fromUser from './user';
-import snackbar, * as fromSnackbar from './snackbar';
-import itemFilter, * as fromItemFilter from './itemFilter';
-import style, * as fromStyle from './style';
+
+import dashboards, { sGetDashboardsRoot } from './dashboards';
+import selected from './selected';
+import dashboardsFilter, {
+    ownerData,
+    sGetFilterName,
+    sGetFilterOrder,
+    sGetFilterOwner,
+} from './dashboardsFilter';
+import controlBar from './controlBar';
+import interpretations from './interpretations';
+import visualizations from './visualizations';
+import editDashboard from './editDashboard';
+import messages from './messages';
+import user from './user';
+import snackbar from './snackbar';
+import itemFilter from './itemFilter';
+import style from './style';
 
 const USER = 'system';
 
-// action types
-
-export const actionTypes = {
-    ...fromDashboards.actionTypes,
-    ...fromSelected.actionTypes,
-    ...fromDashboardsFilter.actionTypes,
-    ...fromControlBar.actionTypes,
-    ...fromInterpretations.actionTypes,
-    ...fromVisualizations.actionTypes,
-    ...fromMessages.actionTypes,
-    ...fromUser.actionTypes,
-    ...fromEditDashboard.actionTypes,
-    ...fromItemFilter.actionTypes,
-    ...fromStyle.actionTypes,
-    ...fromSnackbar.actionTypes,
-};
-
-// reducers
+// Reducers
 
 export default combineReducers({
     dashboards,
@@ -49,8 +38,7 @@ export default combineReducers({
     snackbar,
 });
 
-// map constants to data
-
+// Map constants to data
 const mapConstToData = {
     NAME: 'name',
     ITEMS: 'numberOfItems',
@@ -58,33 +46,18 @@ const mapConstToData = {
     OWNER: 'owner',
 };
 
-// selectors
+// Selectors
 
-export {
-    fromDashboards,
-    fromSelected,
-    fromDashboardsFilter,
-    fromControlBar,
-    fromInterpretations,
-    fromVisualizations,
-    fromMessages,
-    fromEditDashboard,
-    fromUser,
-    fromItemFilter,
-    fromStyle,
-    fromSnackbar,
-};
-
-// filter dashboards by name
+// Filter dashboards by name
 export const sFilterDashboardsByName = (dashboards, filter) =>
     dashboards.filter(d =>
         d.displayName.toLowerCase().includes(filter.toLowerCase())
     );
 
-// filter dashboards by owner
+// Filter dashboards by owner, TODO FIXME
 export const sFilterDashboardsByOwner = (dashboards, filter) => {
-    const ME = fromDashboardsFilter.ownerData[1]; // TODO
-    const OTHERS = fromDashboardsFilter.ownerData[2]; // TODO
+    const ME = ownerData[1]; // TODO
+    const OTHERS = ownerData[2]; // TODO
 
     switch (filter) {
         case ME:
@@ -96,7 +69,7 @@ export const sFilterDashboardsByOwner = (dashboards, filter) => {
     }
 };
 
-// filter dashboards by order
+// Filter dashboards by order
 export const sFilterDashboardsByOrder = (dashboards, filter) => {
     const filterValues = filter.split(':');
 
@@ -106,15 +79,15 @@ export const sFilterDashboardsByOrder = (dashboards, filter) => {
     return arraySort(dashboards, direction, mapConstToData[key]);
 };
 
-// selectors dependency level 2
+// Selectors dependency level 2
 
-// get filtered dashboards
+// Get filtered dashboards
 export const sGetFilteredDashboards = state => {
-    const dashboards = fromDashboards.sGetFromState(state);
+    const dashboards = sGetDashboardsRoot(state);
 
-    const nameFilter = fromDashboardsFilter.sGetFilterName(state);
-    const ownerFilter = fromDashboardsFilter.sGetFilterOwner(state);
-    const orderFilter = fromDashboardsFilter.sGetFilterOrder(state);
+    const nameFilter = sGetFilterName(state);
+    const ownerFilter = sGetFilterOwner(state);
+    const orderFilter = sGetFilterOrder(state);
 
     return sFilterDashboardsByOrder(
         sFilterDashboardsByName(

--- a/src/reducers/interpretations.js
+++ b/src/reducers/interpretations.js
@@ -37,18 +37,18 @@ export default (state = {}, action) => {
 
 // Selectors
 
-export const sGetInterpretation = (state, id) => {
-    return state.interpretations[id] || null;
-};
+export const sGetInterpretationsRoot = state => state.interpretations;
 
-export const sGetInterpretations = (state, ids) => {
-    const interpretations = {};
+export const sGetInterpretation = (state, id) =>
+    sGetInterpretationsRoot(state)[id] || null;
 
-    ids.forEach(id => {
-        if (state.interpretations[id]) {
-            interpretations[id] = Object.assign({}, state.interpretations[id]);
+export const sGetInterpretations = (state, ids) =>
+    ids.reduce((ipts, id) => {
+        const ipt = sGetInterpretationsRoot(state)[id];
+
+        if (ipt) {
+            ipts[id] = Object.assign({}, ipt);
         }
-    });
 
-    return interpretations;
-};
+        return ipts;
+    }, {});

--- a/src/reducers/interpretations.js
+++ b/src/reducers/interpretations.js
@@ -2,22 +2,20 @@
 
 import update from 'immutability-helper';
 
-export const actionTypes = {
-    RECEIVED_INTERPRETATION: 'RECEIVED_INTERPRETATION',
-    ADD_INTERPRETATIONS: 'ADD_INTERPRETATIONS',
-    REMOVE_INTERPRETATION: 'REMOVE_INTERPRETATION',
-};
+export const RECEIVED_INTERPRETATION = 'RECEIVED_INTERPRETATION';
+export const ADD_INTERPRETATIONS = 'ADD_INTERPRETATIONS';
+export const REMOVE_INTERPRETATION = 'REMOVE_INTERPRETATION';
 
 // Reducer
 
 export default (state = {}, action) => {
     switch (action.type) {
-        case actionTypes.RECEIVED_INTERPRETATION: {
+        case RECEIVED_INTERPRETATION: {
             return Object.assign({}, state, {
                 [action.value.id]: action.value,
             });
         }
-        case actionTypes.ADD_INTERPRETATIONS: {
+        case ADD_INTERPRETATIONS: {
             const newInterpretations = action.value.reduce((acc, curr) => {
                 return {
                     ...acc,
@@ -27,7 +25,7 @@ export default (state = {}, action) => {
 
             return Object.assign({}, state, newInterpretations);
         }
-        case actionTypes.REMOVE_INTERPRETATION: {
+        case REMOVE_INTERPRETATION: {
             return update(state, { $unset: [action.value] });
         }
         default:

--- a/src/reducers/itemFilter.js
+++ b/src/reducers/itemFilter.js
@@ -23,10 +23,8 @@ export default (state = DEFAULT_STATE, action) => {
     }
 };
 
-// root selector
-
-export const sGetFromState = state => state.itemFilter;
-
 // selectors
 
-export const sGetFilterKeys = state => Object.keys(sGetFromState(state));
+export const sGetItemFilterRoot = state => state.itemFilter;
+
+export const sGetFilterKeys = state => Object.keys(sGetItemFilterRoot(state));

--- a/src/reducers/itemFilter.js
+++ b/src/reducers/itemFilter.js
@@ -1,15 +1,13 @@
 import objectClean from 'd2-utilizr/lib/objectClean';
 import isEmpty from 'd2-utilizr/lib/isEmpty';
 
-export const actionTypes = {
-    SET_ITEM_FILTER: 'SET_ITEM_FILTER',
-};
+export const SET_ITEM_FILTER = 'SET_ITEM_FILTER';
 
-export const DEFAULT_STATE = {};
+export const DEFAULT_STATE_ITEM_FILTER = {};
 
-export default (state = DEFAULT_STATE, action) => {
+export default (state = DEFAULT_STATE_ITEM_FILTER, action) => {
     switch (action.type) {
-        case actionTypes.SET_ITEM_FILTER: {
+        case SET_ITEM_FILTER: {
             return objectClean(
                 {
                     ...state,

--- a/src/reducers/messages.js
+++ b/src/reducers/messages.js
@@ -1,13 +1,11 @@
 import update from 'immutability-helper';
 import { arrayToIdMap } from '../util';
 
-export const actionTypes = {
-    RECEIVED_MESSAGES: 'RECEIVED_MESSAGES',
-};
+export const RECEIVED_MESSAGES = 'RECEIVED_MESSAGES';
 
 export default (state = {}, action) => {
     switch (action.type) {
-        case actionTypes.RECEIVED_MESSAGES: {
+        case RECEIVED_MESSAGES: {
             const conversations = arrayToIdMap(action.value);
 
             const newState = update(state, { $merge: conversations });

--- a/src/reducers/messages.js
+++ b/src/reducers/messages.js
@@ -21,4 +21,4 @@ export default (state = {}, action) => {
 
 // selectors
 
-export const sGetMessages = state => state.messages;
+export const sGetMessagesRoot = state => state.messages;

--- a/src/reducers/selected.js
+++ b/src/reducers/selected.js
@@ -3,15 +3,13 @@ import { combineReducers } from 'redux';
 
 import { validateReducer } from '../util';
 
-export const actionTypes = {
-    SET_SELECTED_ID: 'SET_SELECTED_ID',
-    SET_SELECTED_ISLOADING: 'SET_SELECTED_ISLOADING',
-    SET_SELECTED_SHOWDESCRIPTION: 'SET_SELECTED_SHOWDESCRIPTION',
-};
+export const SET_SELECTED_ID = 'SET_SELECTED_ID';
+export const SET_SELECTED_ISLOADING = 'SET_SELECTED_ISLOADING';
+export const SET_SELECTED_SHOWDESCRIPTION = 'SET_SELECTED_SHOWDESCRIPTION';
 
-export const DEFAULT_SELECTED_ID = null;
-export const DEFAULT_SELECTED_ISLOADING = false;
-export const DEFAULT_SELECTED_SHOWDESCRIPTION = false;
+export const DEFAULT_STATE_SELECTED_ID = null;
+export const DEFAULT_STATE_SELECTED_ISLOADING = false;
+export const DEFAULT_STATE_SELECTED_SHOWDESCRIPTION = false;
 
 /**
  * Reducer functions that computes and returns the new state based on the given action
@@ -19,30 +17,36 @@ export const DEFAULT_SELECTED_SHOWDESCRIPTION = false;
  * @param {Object} state The current state
  * @param {Object} action The action to be evaluated
  */
-const id = (state = DEFAULT_SELECTED_ID, action) => {
+const id = (state = DEFAULT_STATE_SELECTED_ID, action) => {
     switch (action.type) {
-        case actionTypes.SET_SELECTED_ID:
-            return validateReducer(action.value, DEFAULT_SELECTED_ID);
+        case SET_SELECTED_ID:
+            return validateReducer(action.value, DEFAULT_STATE_SELECTED_ID);
         default:
             return state;
     }
 };
 
-const isLoading = (state = DEFAULT_SELECTED_ISLOADING, action) => {
+const isLoading = (state = DEFAULT_STATE_SELECTED_ISLOADING, action) => {
     switch (action.type) {
-        case actionTypes.SET_SELECTED_ISLOADING:
-            return validateReducer(action.value, DEFAULT_SELECTED_ISLOADING);
-        default:
-            return state;
-    }
-};
-
-const showDescription = (state = DEFAULT_SELECTED_SHOWDESCRIPTION, action) => {
-    switch (action.type) {
-        case actionTypes.SET_SELECTED_SHOWDESCRIPTION:
+        case SET_SELECTED_ISLOADING:
             return validateReducer(
                 action.value,
-                DEFAULT_SELECTED_SHOWDESCRIPTION
+                DEFAULT_STATE_SELECTED_ISLOADING
+            );
+        default:
+            return state;
+    }
+};
+
+const showDescription = (
+    state = DEFAULT_STATE_SELECTED_SHOWDESCRIPTION,
+    action
+) => {
+    switch (action.type) {
+        case SET_SELECTED_SHOWDESCRIPTION:
+            return validateReducer(
+                action.value,
+                DEFAULT_STATE_SELECTED_SHOWDESCRIPTION
             );
         default:
             return state;

--- a/src/reducers/selected.js
+++ b/src/reducers/selected.js
@@ -55,14 +55,13 @@ export default combineReducers({
     showDescription,
 });
 
-// Selector level 1
-export const sGetFromState = state => state.selected;
+// Selectors
 
-// Selector dependency level 2
+export const sGetSelectedRoot = state => state.selected;
 
-export const sGetSelectedId = state => sGetFromState(state).id;
+export const sGetSelectedId = state => sGetSelectedRoot(state).id;
 
-export const sGetSelectedIsLoading = state => sGetFromState(state).isLoading;
+export const sGetSelectedIsLoading = state => sGetSelectedRoot(state).isLoading;
 
 export const sGetSelectedShowDescription = state =>
-    sGetFromState(state).showDescription;
+    sGetSelectedRoot(state).showDescription;

--- a/src/reducers/snackbar.js
+++ b/src/reducers/snackbar.js
@@ -1,21 +1,19 @@
-export const actionTypes = {
-    RECEIVED_SNACKBAR_MESSAGE: 'RECEIVED_SNACKBAR_MESSAGE',
-    CLOSE_SNACKBAR: 'CLOSE_SNACKBAR',
-};
+export const RECEIVED_SNACKBAR_MESSAGE = 'RECEIVED_SNACKBAR_MESSAGE';
+export const CLOSE_SNACKBAR = 'CLOSE_SNACKBAR';
 
-export const DEFAULT_STATE = {
+export const DEFAULT_STATE_SNACKBAR = {
     message: {},
     duration: null,
     open: false,
 };
 
-export default (state = DEFAULT_STATE, action) => {
+export default (state = DEFAULT_STATE_SNACKBAR, action) => {
     switch (action.type) {
-        case actionTypes.RECEIVED_SNACKBAR_MESSAGE: {
+        case RECEIVED_SNACKBAR_MESSAGE: {
             return { ...state, ...action.value };
         }
-        case actionTypes.CLOSE_SNACKBAR: {
-            return DEFAULT_STATE;
+        case CLOSE_SNACKBAR: {
+            return DEFAULT_STATE_SNACKBAR;
         }
         default:
             return state;
@@ -24,4 +22,4 @@ export default (state = DEFAULT_STATE, action) => {
 
 // selectors
 
-export const sGetSnackbar = state => state.snackbar || DEFAULT_STATE;
+export const sGetSnackbar = state => state.snackbar || DEFAULT_STATE_SNACKBAR;

--- a/src/reducers/style.js
+++ b/src/reducers/style.js
@@ -30,4 +30,4 @@ export default style;
  * @param {Object} state
  * @returns {Object}
  */
-export const sGetFromState = state => state.style;
+export const sGetStyleRoot = state => state.style;

--- a/src/reducers/style.js
+++ b/src/reducers/style.js
@@ -1,11 +1,9 @@
 /** @module reducers/selected */
 import { validateReducer } from '../util';
 
-export const actionTypes = {
-    SET_STYLE: 'SET_STYLE',
-};
+export const SET_STYLE = 'SET_STYLE';
 
-export const DEFAULT_STYLE = 'LIST';
+export const DEFAULT_STATE_STYLE = 'LIST';
 
 /**
  * Reducer functions that computes and returns the new state based on the given action
@@ -13,10 +11,10 @@ export const DEFAULT_STYLE = 'LIST';
  * @param {Object} state The current state
  * @param {Object} action The action to be evaluated
  */
-const style = (state = DEFAULT_STYLE, action) => {
+const style = (state = DEFAULT_STATE_STYLE, action) => {
     switch (action.type) {
-        case actionTypes.SET_STYLE:
-            return validateReducer(action.value, DEFAULT_STYLE);
+        case SET_STYLE:
+            return validateReducer(action.value, DEFAULT_STATE_STYLE);
         default:
             return state;
     }

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -1,17 +1,15 @@
-export const actionTypes = {
-    RECEIVED_USER: 'RECEIVED_USER',
-};
+export const RECEIVED_USER = 'RECEIVED_USER';
 
-export const defaultState = {
+export const DEFAULT_STATE_USER = {
     id: '',
     username: '',
     uiLocale: '',
     isSuperuser: false,
 };
 
-export default (state = defaultState, action) => {
+export default (state = DEFAULT_STATE_USER, action) => {
     switch (action.type) {
-        case actionTypes.RECEIVED_USER: {
+        case RECEIVED_USER: {
             return fromD2ToUserObj(action.value);
         }
         default:

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -31,6 +31,6 @@ function fromD2ToUserObj(d2Object) {
 // selectors
 
 export const sGetUserId = state => state.user.id;
-export const sGetUsername = state => state.user.username;
+export const sGetUserUsername = state => state.user.username;
 export const sGetIsSuperuser = state => state.user.isSuperuser;
 export const sGetUiLocale = state => state.user.uiLocale;

--- a/src/reducers/visualizations.js
+++ b/src/reducers/visualizations.js
@@ -38,11 +38,11 @@ export default (state = DEFAULT_STATE, action) => {
 };
 
 // root selector
-export const sGetFromState = state => state.visualizations;
+export const sGetVisualizationsRoot = state => state.visualizations;
 
 // selectors level 1
 export const sGetVisualization = (state, id) => {
-    return sGetFromState(state)[id];
+    return sGetVisualizationsRoot(state)[id];
 };
 
 // selectors level 2

--- a/src/reducers/visualizations.js
+++ b/src/reducers/visualizations.js
@@ -3,24 +3,22 @@ import objectClean from 'd2-utilizr/lib/objectClean';
 
 /** @module reducers/visualizations */
 
+export const RECEIVED_VISUALIZATION = 'RECEIVED_VISUALIZATION';
+export const RECEIVED_ACTIVE_VISUALIZATION = 'RECEIVED_ACTIVE_VISUALIZATION';
+
+export const DEFAULT_STATE_VISUALIZATIONS = {};
+
 const isEmpty = p => p === undefined || p === null;
 
-export const actionTypes = {
-    RECEIVED_VISUALIZATION: 'RECEIVED_VISUALIZATION',
-    RECEIVED_ACTIVE_VISUALIZATION: 'RECEIVED_ACTIVE_VISUALIZATION',
-};
-
-export const DEFAULT_STATE = {};
-
-export default (state = DEFAULT_STATE, action) => {
+export default (state = DEFAULT_STATE_VISUALIZATIONS, action) => {
     switch (action.type) {
-        case actionTypes.RECEIVED_VISUALIZATION: {
+        case RECEIVED_VISUALIZATION: {
             return {
                 ...state,
                 [action.value.id]: action.value,
             };
         }
-        case actionTypes.RECEIVED_ACTIVE_VISUALIZATION: {
+        case RECEIVED_ACTIVE_VISUALIZATION: {
             return {
                 ...state,
                 [action.id]: objectClean(

--- a/yarn.lock
+++ b/yarn.lock
@@ -197,6 +197,11 @@ acorn@^5.0.0, acorn@^5.3.0:
   version "5.5.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
 
+acorn@^5.7.3:
+  version "5.7.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
+  integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
+
 acorn@^6.0.2:
   version "6.0.4"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.0.4.tgz#77377e7353b72ec5104550aa2d2097a2fd40b754"
@@ -1806,7 +1811,7 @@ chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.1.0:
+chalk@^2.0.0, chalk@^2.1.0, chalk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   integrity sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==
@@ -1818,15 +1823,6 @@ chalk@^2.0.0, chalk@^2.1.0:
 chalk@^2.0.1, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65"
-  dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
-
-chalk@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
-  integrity sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==
   dependencies:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
@@ -2129,7 +2125,7 @@ commander@2.15.x, commander@^2.13.0, commander@^2.14.1, commander@^2.9.0, comman
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
 
-commander@^2.18.0:
+commander@^2.11.0, commander@^2.18.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
@@ -4618,6 +4614,13 @@ iconv-lite@0.4.23:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
   integrity sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
+
+iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
@@ -8829,7 +8832,7 @@ safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
-safe-buffer@5.1.2:
+safe-buffer@5.1.2, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -9719,6 +9722,11 @@ tryer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
+
+tslib@^1.9.0:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+  integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
- Remove the fromX pattern (e.g. fromReducers.fromDashboard.xxx) and import the actual variables instead
- Remove the actionTypes objects and import/export all actions instead
- Rename all default state variables to "DEFAULT_STATE_xxx"
- Rename all root selectors from e.g. "sGetFromState" to e.g. "sGetDashboardsRoot"
- Remove an unused action creator
- Rename a misspelled selector