### PR TITLE
DHIS2-4008: interpretations and comment sorting

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2018-12-11T14:16:32.939Z\n"
-"PO-Revision-Date: 2018-12-11T14:16:32.939Z\n"
+"POT-Creation-Date: 2019-01-23T10:48:21.617Z\n"
+"PO-Revision-Date: 2019-01-23T10:48:21.617Z\n"
 
 msgid "Dashboard"
 msgstr ""
@@ -99,9 +99,6 @@ msgid "View in Visualizer"
 msgstr ""
 
 msgid "Reply"
-msgstr ""
-
-msgid "created"
 msgstr ""
 
 msgid "Add your reply"

--- a/src/api/interpretations.js
+++ b/src/api/interpretations.js
@@ -11,8 +11,9 @@ export const interpretationFields = () => {
 
 // Api
 export const getInterpretation = id => {
-    const fields =
-        'id,text,created,user[id,displayName],likedBy,access,comments[id,text,created,user[id,displayName]]';
+    const fields = encodeURI(
+        'id,text,created,user[id,displayName],likedBy,access,comments[id,text,created,user[id,displayName]]'
+    );
     const url = `/interpretations/${id}?fields=${fields}`;
     return getInstance()
         .then(d2 => d2.Api.getApi().get(url))
@@ -91,9 +92,9 @@ export const deleteInterpretationComment = data => {
 
 export const fetchVisualization = data => {
     const typePath = itemTypeMap[data.objectType].endPointName;
-    const url = `/${typePath}/${
-        data.objectId
-    }?fields=id,name,interpretations[id]`;
+    const url = encodeURI(
+        `/${typePath}/${data.objectId}?fields=id,name,interpretations[id]`
+    );
 
     return getInstance()
         .then(d2 => d2.Api.getApi().get(url))

--- a/src/components/Item/VisualizationItem/Interpretations/Interpretation.js
+++ b/src/components/Item/VisualizationItem/Interpretations/Interpretation.js
@@ -264,7 +264,7 @@ class Interpretation extends Component {
 
         const comments = sortByDate(
             this.props.interpretation.comments,
-            i18n.t('created')
+            'created'
         ).map(comment => (
             <li
                 className="comment-container"

--- a/src/components/Item/VisualizationItem/Interpretations/Interpretations.js
+++ b/src/components/Item/VisualizationItem/Interpretations/Interpretations.js
@@ -75,7 +75,8 @@ class Interpretations extends Component {
         if (this.interpretationsLoaded()) {
             const sorted = sortByDate(
                 this.props.interpretations,
-                i18n.t('created')
+                'created',
+                false
             );
             Items = sorted.map(interpretation => {
                 return (


### PR DESCRIPTION
This PR fixes the interpretations and comments sorting.
Interpretations must be sorted by created date descending, with the most recent on top.
Comments must be sorted by created date ascending, the oldest at the top.

Also fixed an issue with some API URLs which didn't work with my Docker backend.
The URLs were not encoded and contain square brackets in the `fields` query parameter.

Scott said the fix should be backported to 2.30.
I'm not sure we need this fix in 2.32 since we are replacing the whole interpretations implementation with the updated d2-ui interpretations component.