### PR TITLE
DHIS2-4008: interpretations and comment sorting

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2018-07-05T08:26:35.452Z\n"
-"PO-Revision-Date: 2018-07-05T08:26:35.452Z\n"
+"POT-Creation-Date: 2019-01-23T12:54:26.213Z\n"
+"PO-Revision-Date: 2019-01-23T12:54:26.213Z\n"
 
 msgid "Delete"
 msgstr ""
@@ -84,9 +84,6 @@ msgid "View in Visualizer"
 msgstr ""
 
 msgid "Reply"
-msgstr ""
-
-msgid "created"
 msgstr ""
 
 msgid "Add your reply"

--- a/src/Item/PluginItem/Interpretations/Interpretation.js
+++ b/src/Item/PluginItem/Interpretations/Interpretation.js
@@ -265,7 +265,7 @@ class Interpretation extends Component {
 
         const comments = sortByDate(
             this.props.interpretation.comments,
-            i18n.t('created')
+            'created'
         ).map(comment => (
             <li
                 className="comment-container"

--- a/src/Item/PluginItem/Interpretations/Interpretations.js
+++ b/src/Item/PluginItem/Interpretations/Interpretations.js
@@ -74,7 +74,8 @@ class Interpretations extends Component {
         if (this.interpretationsLoaded()) {
             const sorted = sortByDate(
                 this.props.interpretations,
-                i18n.t('created')
+                'created',
+                false
             );
             Items = sorted.map(interpretation => {
                 return (

--- a/src/api/interpretations.js
+++ b/src/api/interpretations.js
@@ -11,8 +11,9 @@ export const interpretationFields = () => {
 
 // Api
 export const getInterpretation = id => {
-    const fields =
-        'id,text,created,user[id,displayName],likedBy,access,comments[id,text,created,user[id,displayName]]';
+    const fields = encodeURI(
+        'id,text,created,user[id,displayName],likedBy,access,comments[id,text,created,user[id,displayName]]'
+    );
     const url = `/interpretations/${id}?fields=${fields}`;
     return getInstance()
         .then(d2 => d2.Api.getApi().get(url))
@@ -91,9 +92,9 @@ export const deleteInterpretationComment = data => {
 
 export const fetchVisualization = data => {
     const typePath = itemTypeMap[data.objectType].endPointName;
-    const url = `/${typePath}/${
-        data.objectId
-    }?fields=id,name,interpretations[id]`;
+    const url = encodeURI(
+        `/${typePath}/${data.objectId}?fields=id,name,interpretations[id]`
+    );
 
     return getInstance()
         .then(d2 => d2.Api.getApi().get(url))


### PR DESCRIPTION
* Encode URI to make sure it works with different proxy/backend

* DHIS2-4008: fix interpretation/comment sorting

Also, do not pass translated field name to the sorting function.
As soon as a language different than English is used and there are
translations for it, the sorting breaks.

(cherry picked from commit 60a2da3e03930e3fc50d87302790709db5aac0d8)