### PR TITLE
Remove unnecessary vertical scrollbars on textareas in IE

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-01-23T10:48:21.617Z\n"
-"PO-Revision-Date: 2019-01-23T10:48:21.617Z\n"
+"POT-Creation-Date: 2019-01-28T15:36:13.698Z\n"
+"PO-Revision-Date: 2019-01-28T15:36:13.698Z\n"
 
 msgid "Dashboard"
 msgstr ""
@@ -129,6 +129,12 @@ msgid "more"
 msgstr ""
 
 msgid "Text box"
+msgstr ""
+
+msgid "Current translation"
+msgstr ""
+
+msgid "Currently editing"
 msgstr ""
 
 msgid "Add title here"

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
             "^(?!.*\\.(js|jsx|mjs|css|json)$)": "<rootDir>/config/jest/fileTransform.js"
         },
         "transformIgnorePatterns": [
-            "node_modules/(?!(@dhis2/d2-ui-[a-z-]+)/)"
+            "node_modules/(?!(d2-ui|@dhis2/d2-ui-[a-z-]+)/)"
         ],
         "moduleNameMapper": {
             "^react-native$": "react-native-web"

--- a/src/components/TitleBar/EditTitleBar.js
+++ b/src/components/TitleBar/EditTitleBar.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { withStyles } from '@material-ui/core/styles';
 import i18n from 'd2-i18n';
 import TextField from 'd2-ui/lib/text-field/TextField';
 
@@ -13,13 +14,30 @@ import { sGetEditDashboardRoot } from '../../reducers/editDashboard';
 import { sGetDashboardById } from '../../reducers/dashboards';
 import ItemSelect from '../ItemSelect/ItemSelect';
 
-const EditTitleBar = ({
+const styles = {
+    section: { display: 'flex', justifyContent: 'space-between' },
+    titleDescription: {
+        flex: '3',
+        marginRight: '20px',
+    },
+    title: { padding: '6px 0' },
+    itemSelect: {
+        flex: '2',
+        minWidth: '300px',
+        maxWidth: '730px',
+        position: 'relative',
+        top: '33px',
+    },
+};
+
+export const EditTitleBar = ({
     name,
     displayName,
     description,
     style,
     onChangeTitle,
     onChangeDescription,
+    classes,
 }) => {
     const titleStyle = Object.assign({}, style.title, {
         top: '-2px',
@@ -28,16 +46,16 @@ const EditTitleBar = ({
     const translatedName = () => {
         return displayName ? (
             <span style={style.description}>
-                Current translation: {displayName}
+                {i18n.t('Current translation')}: {displayName}
             </span>
         ) : null;
     };
 
     return (
-        <section style={{ display: 'flex', justifyContent: 'space-between' }}>
-            <div style={{ flex: '3', marginRight: '20px' }}>
-                <span>Currently editing</span>
-                <div style={{ padding: '6px 0' }}>
+        <section className={classes.section}>
+            <div className={classes.titleDescription}>
+                <span>{i18n.t('Currently editing')}</span>
+                <div className={classes.title}>
                     <TextField
                         multiline
                         fullWidth
@@ -61,15 +79,7 @@ const EditTitleBar = ({
                     onChange={onChangeDescription}
                 />
             </div>
-            <div
-                style={{
-                    flex: '2',
-                    minWidth: '300px',
-                    maxWidth: '730px',
-                    position: 'relative',
-                    top: '33px',
-                }}
-            >
+            <div className={classes.itemSelect}>
                 <ItemSelect />
             </div>
         </section>
@@ -78,14 +88,13 @@ const EditTitleBar = ({
 
 const mapStateToProps = state => {
     const selectedDashboard = orObject(sGetEditDashboardRoot(state));
-
     const displayName = orObject(sGetDashboardById(state, selectedDashboard.id))
         .displayName;
 
     return {
         name: selectedDashboard.name,
-        description: selectedDashboard.description,
         displayName,
+        description: selectedDashboard.description,
     };
 };
 
@@ -97,16 +106,20 @@ const mapDispatchToProps = {
 export default connect(
     mapStateToProps,
     mapDispatchToProps
-)(EditTitleBar);
+)(withStyles(styles)(EditTitleBar));
 
 EditTitleBar.propTypes = {
     name: PropTypes.string,
     displayName: PropTypes.string,
     description: PropTypes.string,
+    onChangeTitle: PropTypes.func.isRequired,
+    onChangeDescription: PropTypes.func.isRequired,
+    style: PropTypes.object,
 };
 
 EditTitleBar.defaultProps = {
     name: '',
     displayName: '',
     description: '',
+    style: {},
 };

--- a/src/components/TitleBar/TitleBar.css
+++ b/src/components/TitleBar/TitleBar.css
@@ -5,3 +5,7 @@
 .dashboard-description:focus {
     color: #777;
 }
+
+textarea {
+    overflow: auto;
+}

--- a/src/components/TitleBar/__tests__/EditTitleBar.spec.js
+++ b/src/components/TitleBar/__tests__/EditTitleBar.spec.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { EditTitleBar } from '../EditTitleBar';
+
+jest.mock('d2-ui/lib/text-field/TextField', () => 'textfield');
+jest.mock('../../ItemSelect/ItemSelect', () => 'itemselect');
+
+describe('EditTitleBar', () => {
+    it('renders correctly when displayName not provided', () => {
+        const tree = renderer
+            .create(
+                <EditTitleBar
+                    name="Rainbow Dash"
+                    description="The blue one"
+                    onChangeTitle={Function.prototype}
+                    onChangeDescription={Function.prototype}
+                    style={{
+                        title: { xyz: '890' },
+                        description: { abc: '123' },
+                    }}
+                    classes={{}}
+                />
+            )
+            .toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    it('renders correctly when displayName is provided', () => {
+        const tree = renderer
+            .create(
+                <EditTitleBar
+                    name="Rainbow Dash"
+                    displayName="Regnbue Dash"
+                    description="The blue one"
+                    onChangeTitle={Function.prototype}
+                    onChangeDescription={Function.prototype}
+                    style={{
+                        title: { xyz: '890' },
+                        description: { abc: '123' },
+                    }}
+                    classes={{}}
+                />
+            )
+            .toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+});

--- a/src/components/TitleBar/__tests__/EditTitleBar.spec.js
+++ b/src/components/TitleBar/__tests__/EditTitleBar.spec.js
@@ -6,41 +6,31 @@ jest.mock('d2-ui/lib/text-field/TextField', () => 'textfield');
 jest.mock('../../ItemSelect/ItemSelect', () => 'itemselect');
 
 describe('EditTitleBar', () => {
+    const props = {
+        name: 'Rainbow Dash',
+        description: 'The blue one',
+        onChangeTitle: Function.prototype,
+        onChangeDescription: Function.prototype,
+        style: {
+            title: { xyz: '890' },
+            description: { abc: '123' },
+        },
+        classes: {
+            section: { sectionStyle: 'section' },
+            titleDescription: { titleDescStyle: 'titleDesc' },
+            title: { titleStyle: 'title' },
+            itemSelect: { itemSelStyle: 'itemSel' },
+        },
+    };
+
     it('renders correctly when displayName not provided', () => {
-        const tree = renderer
-            .create(
-                <EditTitleBar
-                    name="Rainbow Dash"
-                    description="The blue one"
-                    onChangeTitle={Function.prototype}
-                    onChangeDescription={Function.prototype}
-                    style={{
-                        title: { xyz: '890' },
-                        description: { abc: '123' },
-                    }}
-                    classes={{}}
-                />
-            )
-            .toJSON();
+        const tree = renderer.create(<EditTitleBar {...props} />).toJSON();
         expect(tree).toMatchSnapshot();
     });
 
     it('renders correctly when displayName is provided', () => {
         const tree = renderer
-            .create(
-                <EditTitleBar
-                    name="Rainbow Dash"
-                    displayName="Regnbue Dash"
-                    description="The blue one"
-                    onChangeTitle={Function.prototype}
-                    onChangeDescription={Function.prototype}
-                    style={{
-                        title: { xyz: '890' },
-                        description: { abc: '123' },
-                    }}
-                    classes={{}}
-                />
-            )
+            .create(<EditTitleBar displayName="Regnbue Dash" {...props} />)
             .toJSON();
         expect(tree).toMatchSnapshot();
     });

--- a/src/components/TitleBar/__tests__/__snapshots__/EditTitleBar.spec.js.snap
+++ b/src/components/TitleBar/__tests__/__snapshots__/EditTitleBar.spec.js.snap
@@ -1,12 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EditTitleBar renders correctly when displayName is provided 1`] = `
-<section>
-  <div>
+<section
+  className={
+    Object {
+      "sectionStyle": "section",
+    }
+  }
+>
+  <div
+    className={
+      Object {
+        "titleDescStyle": "titleDesc",
+      }
+    }
+  >
     <span>
       Currently editing
     </span>
-    <div>
+    <div
+      className={
+        Object {
+          "titleStyle": "title",
+        }
+      }
+    >
       <textfield
         fullWidth={true}
         multiline={true}
@@ -49,19 +67,43 @@ exports[`EditTitleBar renders correctly when displayName is provided 1`] = `
       value="The blue one"
     />
   </div>
-  <div>
+  <div
+    className={
+      Object {
+        "itemSelStyle": "itemSel",
+      }
+    }
+  >
     <itemselect />
   </div>
 </section>
 `;
 
 exports[`EditTitleBar renders correctly when displayName not provided 1`] = `
-<section>
-  <div>
+<section
+  className={
+    Object {
+      "sectionStyle": "section",
+    }
+  }
+>
+  <div
+    className={
+      Object {
+        "titleDescStyle": "titleDesc",
+      }
+    }
+  >
     <span>
       Currently editing
     </span>
-    <div>
+    <div
+      className={
+        Object {
+          "titleStyle": "title",
+        }
+      }
+    >
       <textfield
         fullWidth={true}
         multiline={true}
@@ -93,7 +135,13 @@ exports[`EditTitleBar renders correctly when displayName not provided 1`] = `
       value="The blue one"
     />
   </div>
-  <div>
+  <div
+    className={
+      Object {
+        "itemSelStyle": "itemSel",
+      }
+    }
+  >
     <itemselect />
   </div>
 </section>

--- a/src/components/TitleBar/__tests__/__snapshots__/EditTitleBar.spec.js.snap
+++ b/src/components/TitleBar/__tests__/__snapshots__/EditTitleBar.spec.js.snap
@@ -1,0 +1,100 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EditTitleBar renders correctly when displayName is provided 1`] = `
+<section>
+  <div>
+    <span>
+      Currently editing
+    </span>
+    <div>
+      <textfield
+        fullWidth={true}
+        multiline={true}
+        onChange={[Function]}
+        placeholder="Add title here"
+        rows={1}
+        rowsMax={3}
+        style={
+          Object {
+            "top": "-2px",
+            "xyz": "890",
+          }
+        }
+        value="Rainbow Dash"
+      />
+      <span
+        style={
+          Object {
+            "abc": "123",
+          }
+        }
+      >
+        Current translation
+        : 
+        Regnbue Dash
+      </span>
+    </div>
+    <textfield
+      fullWidth={true}
+      multiline={true}
+      onChange={[Function]}
+      placeholder="Add description here"
+      rows={1}
+      rowsMax={3}
+      style={
+        Object {
+          "abc": "123",
+        }
+      }
+      value="The blue one"
+    />
+  </div>
+  <div>
+    <itemselect />
+  </div>
+</section>
+`;
+
+exports[`EditTitleBar renders correctly when displayName not provided 1`] = `
+<section>
+  <div>
+    <span>
+      Currently editing
+    </span>
+    <div>
+      <textfield
+        fullWidth={true}
+        multiline={true}
+        onChange={[Function]}
+        placeholder="Add title here"
+        rows={1}
+        rowsMax={3}
+        style={
+          Object {
+            "top": "-2px",
+            "xyz": "890",
+          }
+        }
+        value="Rainbow Dash"
+      />
+    </div>
+    <textfield
+      fullWidth={true}
+      multiline={true}
+      onChange={[Function]}
+      placeholder="Add description here"
+      rows={1}
+      rowsMax={3}
+      style={
+        Object {
+          "abc": "123",
+        }
+      }
+      value="The blue one"
+    />
+  </div>
+  <div>
+    <itemselect />
+  </div>
+</section>
+`;


### PR DESCRIPTION
Fixes [DHIS2-5598]

Vertical scrollbars were visible in edit mode for the title and description, even though there was no overflow.

Included in this PR:
* The actual fix is the addition of the css: `textarea { overflow: auto }`
* Add i18n.t on strings in the EditTitleBar file
* Added snapshot tests for EditTitleBar
* Use withStyles in EditTitleBar