### PR TITLE
chore: remove unnecessary development proxy

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -12,7 +12,6 @@ const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin');
 const fs = require('fs');
 const getClientEnvironment = require('./env');
 const paths = require('./paths');
-const parse = require('url-parse');
 
 // Webpack uses `publicPath` to determine where the app is being served from.
 // In development, we always serve from the root. This makes config easier.
@@ -34,7 +33,8 @@ try {
     // Failed to load config file - use default config
     console.warn(`\nWARNING! Failed to load DHIS config:`, e.message);
     dhisConfig = {
-        baseUrl: 'http://localhost:8080',
+        baseUrl:
+            process.env.REACT_APP_DHIS2_BASE_URL || 'http://localhost:8080',
         authorization: 'Basic YWRtaW46ZGlzdHJpY3Q=', // admin:district
     };
 }
@@ -53,7 +53,6 @@ const globals = Object.assign(
 );
 
 const scriptPrefix = dhisConfig.baseUrl;
-const pathnamePrefix = parse(scriptPrefix).pathname;
 
 // This is the development configuration.
 // It is focused on developer experience and fast rebuilds.
@@ -254,7 +253,7 @@ module.exports = {
             inject: true,
             template: paths.appHtml,
             vendorScripts: [
-                `.${pathnamePrefix}/dhis-web-core-resource/fonts/roboto.css`,
+                `${scriptPrefix}/dhis-web-core-resource/fonts/roboto.css`,
                 `${scriptPrefix}/dhis-web-core-resource/babel-polyfill/6.20.0/dist/polyfill.js`,
                 `${scriptPrefix}/dhis-web-core-resource/jquery/3.2.1/dist/jquery.js`,
                 `${scriptPrefix}/dhis-web-core-resource/jquery-migrate/3.0.1/dist/jquery-migrate.js`,

--- a/package.json
+++ b/package.json
@@ -119,11 +119,6 @@
             }
         }
     },
-    "proxy": {
-        "/dhis-web-core-resource": {
-            "target": "http://localhost:8080"
-        }
-    },
     "jest": {
         "collectCoverageFrom": [
             "src/**/*.{js,jsx,mjs}"
@@ -176,7 +171,6 @@
         "husky": "^0.15.0-rc.12",
         "jest-enzyme": "^7.0.1",
         "react-test-renderer": "^16.7.0",
-        "url-parse": "^1.3.0",
         "webpack-bundle-analyzer": "^3.0.3"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10823,7 +10823,7 @@ url-parse-lax@^1.0.0:
   dependencies:
     prepend-http "^1.0.1"
 
-url-parse@^1.1.8, url-parse@^1.3.0, url-parse@^1.4.3:
+url-parse@^1.1.8, url-parse@^1.4.3:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.4.tgz#cac1556e95faa0303691fec5cf9d5a1bc34648f8"
   integrity sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==


### PR DESCRIPTION
The proxy setup in package.json appears to be unnecessary, and breaks if the core is running anywhere other than `localhost:8080`.  The proxy was only used for `dhis-web-core-resources/fonts/roboto.css`, and other `core-resources` references are inserted as vendor scripts with the fully qualified DHIS2 baseUrl, so I've removed the proxy and used baseUrl instead.

I also added conditional support for `REACT_APP_DHIS2_BASE_URL` if no dhis_config is specified, before falling back to `localhost:8080`