### PR TITLE
add RichText Parser to VisualizationItem description [DHIS2-3422]

### DIFF
--- a/src/Item/PluginItem/ItemFooter.js
+++ b/src/Item/PluginItem/ItemFooter.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { Parser as RichTextParser } from '@dhis2/d2-ui-rich-text';
 import Interpretations from './Interpretations/Interpretations';
 import { colors } from '../../colors';
 import { getId, getDescription } from './plugin';
@@ -30,6 +31,7 @@ const style = {
     descriptionText: {
         fontSize: '13px',
         lineHeight: '17px',
+        whiteSpace: 'pre-line',
     },
 };
 
@@ -37,7 +39,9 @@ const ItemDescription = ({ description }) => {
     return (
         <div style={style.descriptionContainer}>
             <h3 style={style.descriptionTitle}>Description</h3>
-            <p style={style.descriptionText}>{description}</p>
+            <RichTextParser style={style.descriptionText}>
+                {description}
+            </RichTextParser>
         </div>
     );
 };


### PR DESCRIPTION
Related to ticket [3422](https://jira.dhis2.org/browse/DHIS2-3422).

Rich text are being rendered in the dashboard, and in the apps. But the description field are missing.
I've also added `pre-line` to the Parser in order to preserve the original format with carriage return.