### PR TITLE
Feat/data statistics

### DIFF
--- a/src/actions/selected.js
+++ b/src/actions/selected.js
@@ -69,8 +69,6 @@ export const tLoadDashboard = id => async (dispatch, getState) => {
         const dash = await apiFetchDashboard(id);
         dispatch(acAppendDashboards(dash));
 
-        apiPostDataStatistics('DASHBOARD_VIEW', id);
-
         return Promise.resolve(dash);
     } catch (err) {
         console.log('Error: ', err);

--- a/src/actions/selected.js
+++ b/src/actions/selected.js
@@ -27,6 +27,7 @@ import {
 } from '../modules/itemTypes';
 import { extractFavorite } from '../components/Item/VisualizationItem/plugin';
 import { orObject } from '../modules/util';
+import { apiPostDataStatistics } from '../api/dataStatistics';
 
 // actions
 
@@ -67,6 +68,8 @@ export const tLoadDashboard = id => async (dispatch, getState) => {
     try {
         const dash = await apiFetchDashboard(id);
         dispatch(acAppendDashboards(dash));
+
+        apiPostDataStatistics('DASHBOARD_VIEW', id);
 
         return Promise.resolve(dash);
     } catch (err) {

--- a/src/actions/selected.js
+++ b/src/actions/selected.js
@@ -27,7 +27,6 @@ import {
 } from '../modules/itemTypes';
 import { extractFavorite } from '../components/Item/VisualizationItem/plugin';
 import { orObject } from '../modules/util';
-import { apiPostDataStatistics } from '../api/dataStatistics';
 
 // actions
 

--- a/src/api/dataStatistics.js
+++ b/src/api/dataStatistics.js
@@ -1,0 +1,8 @@
+import { getInstance } from 'd2';
+
+export const apiPostDataStatistics = async (eventType, id) => {
+    const d2 = await getInstance();
+    const url = `dataStatistics?eventType=${eventType}&favorite=${id}`;
+
+    d2.Api.getApi().post(url);
+};

--- a/src/components/ControlBar/DashboardItemChip.js
+++ b/src/components/ControlBar/DashboardItemChip.js
@@ -4,8 +4,10 @@ import MuiChip from 'material-ui/Chip';
 import Avatar from 'material-ui/Avatar';
 import IconStar from '@material-ui/icons/Star';
 import { Link } from 'react-router-dom';
+import debounce from 'lodash/debounce';
 
 import { colors } from '../../modules/colors';
+import { apiPostDataStatistics } from '../../api/dataStatistics';
 
 const chipTheme = {
     default: {
@@ -58,6 +60,10 @@ const DashboardItemChip = ({ starred, selected, label, dashboardId }) => {
                 textDecoration: 'none',
             }}
             to={`/${dashboardId}`}
+            onClick={debounce(
+                () => apiPostDataStatistics('DASHBOARD_VIEW', dashboardId),
+                500
+            )}
         >
             <MuiChip {...props}>
                 {starred ? avatar(selected) : null}


### PR DESCRIPTION
Posting a dashboard view event to the server when the user clicks on a dashboard link.

By doing this instead of logging all dashboard loads from the url/route we only register "real" views (best effort).