### PR TITLE
Posting data statistics when dashboards are selected (v29)

### DIFF
--- a/src/ControlBarContainer/DashboardsBar.js
+++ b/src/ControlBarContainer/DashboardsBar.js
@@ -1,8 +1,9 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-
 import ControlBar from 'd2-ui/lib/controlbar/ControlBar';
 import arraySort from 'd2-utilizr/lib/arraySort';
+import debounce from 'lodash/debounce';
+
 import Chip from './DashboardItemChip';
 import D2IconButton from '../widgets/D2IconButton';
 import Filter from './Filter';
@@ -20,6 +21,7 @@ import { orObject, orArray } from '../util';
 import { sGetSelectedId } from '../reducers/selected';
 import { apiPostControlBarRows } from '../api/controlBar';
 import { colors } from '../colors';
+import { apiPostDataStatistics } from '../api/dataStatistics';
 
 export const MIN_ROW_COUNT = 1;
 export const MAX_ROW_COUNT = 10;
@@ -72,6 +74,16 @@ export class DashboardsBar extends Component {
 
         this.setState({ rows, isMaxHeight: !this.state.isMaxHeight });
     };
+
+    getPostDataStatisticsFn = id => () =>
+        apiPostDataStatistics('DASHBOARD_VIEW', id);
+
+    getDashboardSelectHandler = (id, name, onClick) => () =>
+        id &&
+        (() => {
+            onClick(id, name);
+            debounce(this.getPostDataStatisticsFn(id), 500)();
+        })();
 
     render() {
         const {

--- a/src/ControlBarContainer/DashboardsBar.js
+++ b/src/ControlBarContainer/DashboardsBar.js
@@ -26,9 +26,6 @@ import { apiPostDataStatistics } from '../api/dataStatistics';
 export const MIN_ROW_COUNT = 1;
 export const MAX_ROW_COUNT = 10;
 
-const onDashboardSelectWrapper = (id, name, onClick) => () =>
-    id && onClick(id, name);
-
 export class DashboardsBar extends Component {
     state = {
         rows: MIN_ROW_COUNT,
@@ -129,7 +126,7 @@ export class DashboardsBar extends Component {
                             <Filter
                                 name={name}
                                 onChangeName={onChangeFilterName}
-                                onKeypressEnter={onDashboardSelectWrapper(
+                                onKeypressEnter={this.getDashboardSelectHandler(
                                     orObject(orArray(dashboards)[0]).id,
                                     orObject(orArray(dashboards)[0])
                                         .displayName,
@@ -144,7 +141,7 @@ export class DashboardsBar extends Component {
                             label={dashboard.displayName}
                             starred={dashboard.starred}
                             selected={dashboard.id === selectedId}
-                            onClick={onDashboardSelectWrapper(
+                            onClick={this.getDashboardSelectHandler(
                                 dashboard.id,
                                 dashboard.displayName,
                                 onSelectDashboard

--- a/src/Item/MessagesItem/Item.js
+++ b/src/Item/MessagesItem/Item.js
@@ -130,9 +130,8 @@ class MessagesItem extends Component {
                 <li style={listItemStyle} key={msg.id}>
                     <div>
                         <div style={style.author}>
-                            {msg.userFirstname} {msg.userSurname} ({
-                                msg.messageCount
-                            })
+                            {msg.userFirstname} {msg.userSurname} (
+                            {msg.messageCount})
                         </div>
                         <div style={style.date}>
                             {formatDate(msg.lastUpdated, this.state.uiLocale)}

--- a/src/api/dataStatistics.js
+++ b/src/api/dataStatistics.js
@@ -1,0 +1,8 @@
+import { getInstance } from 'd2/lib/d2';
+
+export const apiPostDataStatistics = async (eventType, id) => {
+    const d2 = await getInstance();
+    const url = `dataStatistics?eventType=${eventType}&favorite=${id}`;
+
+    d2.Api.getApi().post(url);
+};


### PR DESCRIPTION
Wraps the current dashboard select handler with another function that posts data statistics.

Debouncing 500ms to avoid logging double-clicks etc.