### PR TITLE
Fix dashboard search bug

### DIFF
--- a/src/components/ControlBar/DashboardsBar.js
+++ b/src/components/ControlBar/DashboardsBar.js
@@ -74,6 +74,10 @@ export class DashboardsBar extends Component {
     };
 
     onSelectDashboard = () => {
+        if (!this.props.dashboards.length) {
+            return;
+        }
+
         this.props.history.push(`/${this.props.dashboards[0].id}`);
 
         this.getPostDataStatisticsFn(this.props.selectedId)();


### PR DESCRIPTION
When list of dashboards is empty, don't try to redirect to the first one.