### PR TITLE
Fix: visualization item drop down crash

### DIFF
--- a/src/Item/PluginItem/ItemFooter.js
+++ b/src/Item/PluginItem/ItemFooter.js
@@ -39,9 +39,11 @@ const ItemDescription = ({ description }) => {
     return (
         <div style={style.descriptionContainer}>
             <h3 style={style.descriptionTitle}>Description</h3>
-            <RichTextParser style={style.descriptionText}>
-                {description}
-            </RichTextParser>
+            {!!description && (
+                <RichTextParser style={style.descriptionText}>
+                    {description}
+                </RichTextParser>
+            )}
         </div>
     );
 };


### PR DESCRIPTION
This PR includes validating that the description exist before passing it to the rich text parser.
The crash are caused when opening a visualization without an existing description.