### PR TITLE
chore: pass d2 to ChartPlugin

### DIFF
--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -141,6 +141,7 @@ export class Item extends Component {
     getPluginComponent = () =>
         this.props.item.type === CHART ? (
             <ChartPlugin
+                d2={this.context.d2}
                 config={this.props.visualization}
                 filters={this.props.itemFilter}
                 forDashboard={true}

--- a/src/components/Item/VisualizationItem/__tests__/Item.spec.js
+++ b/src/components/Item/VisualizationItem/__tests__/Item.spec.js
@@ -11,7 +11,7 @@ describe('VisualizationItem/Item', () => {
 
     const canvas = () => {
         if (!shallowItem) {
-            shallowItem = shallow(<Item {...props} />);
+            shallowItem = shallow(<Item {...props} />, { context: { d2: {} } });
         }
         return shallowItem;
     };


### PR DESCRIPTION
The latest ChartPlugin requires d2 as a prop