### PR TITLE
Fixing visualization type switch for dashboard items

### DIFF
--- a/src/components/Item/VisualizationItem/__tests__/Item.spec.js
+++ b/src/components/Item/VisualizationItem/__tests__/Item.spec.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { CHART, REPORT_TABLE } from '../../../../modules/itemTypes';
+import { REPORT_TABLE } from '../../../../modules/itemTypes';
 import { Item } from '../Item';
 import DefaultPlugin from '../DefaultPlugin';
-import ChartPlugin from 'data-visualizer-plugin';
 
 describe('VisualizationItem/Item', () => {
     let props;
@@ -37,28 +36,30 @@ describe('VisualizationItem/Item', () => {
         shallowItem = undefined;
     });
 
-    it('renders a ChartPlugin when a chart item is passed', () => {
-        props.visualization = {
-            name: 'Test chart',
-            description: 'Test chart mock',
-        };
-        props.item = {
-            type: CHART,
-            id: 'testItem1',
-            chart: {
-                id: 'chart1',
-                name: 'Test chart',
-            },
-        };
-
-        const chartPlugin = canvas().find(ChartPlugin);
-
-        expect(chartPlugin.exists()).toBeTruthy();
-
-        expect(chartPlugin.prop('config')).toEqual(props.visualization);
-        expect(chartPlugin.prop('filters')).toEqual(props.itemFilter);
-        expect(chartPlugin.prop('forDashboard')).toBeTruthy();
-    });
+    // TODO uncomment this test once we implement data fetching on app level
+    // and pass complete analytical objects to plugins.
+    // it('renders a ChartPlugin when a chart item is passed', () => {
+    //     props.visualization = {
+    //         name: 'Test chart',
+    //         description: 'Test chart mock',
+    //     };
+    //     props.item = {
+    //         type: CHART,
+    //         id: 'testItem1',
+    //         chart: {
+    //             id: 'chart1',
+    //             name: 'Test chart',
+    //         },
+    //     };
+    //
+    //     const chartPlugin = canvas().find(ChartPlugin);
+    //
+    //     expect(chartPlugin.exists()).toBeTruthy();
+    //
+    //     expect(chartPlugin.prop('config')).toEqual(props.visualization);
+    //     expect(chartPlugin.prop('filters')).toEqual(props.itemFilter);
+    //     expect(chartPlugin.prop('forDashboard')).toBeTruthy();
+    // });
 
     it('renders a DefaultPlugin when a item different from chart is passed', () => {
         props.visualization = {


### PR DESCRIPTION
Fixes [DHIS2-5997](https://jira.dhis2.org/browse/DHIS2-5997).

This PR fixes visualization type change feature by using old plugin component `DefaultPlugin.js`.

The reason for switching to the old plugin is that we will fetch data on app level and pass complete analytic objects (AO) to plugins for rendering. This will reduce number of network requests and allow to correctly use `ChartPlugin` component.