### PR TITLE
fix: Remove scrollbar in pivot table items in dashboard edit mode

### DIFF
--- a/src/components/Item/Item.js
+++ b/src/components/Item/Item.js
@@ -7,7 +7,6 @@ import ListItem from './ListItem/Item';
 import TextItem from './TextItem/Item';
 import AppItem from './AppItem/Item';
 import SpacerItem from './SpacerItem/Item';
-import ProgressiveLoadingContainer from './ProgressiveLoadingContainer';
 import {
     APP,
     REPORT_TABLE,
@@ -53,17 +52,13 @@ export const Item = props => {
     const GridItem = getGridItem(props.item.type);
 
     return (
-        <ProgressiveLoadingContainer>
-            <GridItem
-                item={props.item}
-                editMode={props.editMode}
-                itemFilters={
-                    props.editMode
-                        ? DEFAULT_STATE_ITEM_FILTERS
-                        : props.itemFilters
-                }
-                onToggleItemExpanded={props.onToggleItemExpanded}
-            />
-        </ProgressiveLoadingContainer>
+        <GridItem
+            item={props.item}
+            editMode={props.editMode}
+            itemFilters={
+                props.editMode ? DEFAULT_STATE_ITEM_FILTERS : props.itemFilters
+            }
+            onToggleItemExpanded={props.onToggleItemExpanded}
+        />
     );
 };

--- a/src/components/ItemGrid/ItemGrid.js
+++ b/src/components/ItemGrid/ItemGrid.js
@@ -38,6 +38,7 @@ import {
     sGetDashboardById,
     sGetDashboardItems,
 } from '../../reducers/dashboards';
+import ProgressiveLoadingContainer from '../Item/ProgressiveLoadingContainer';
 
 // Component
 
@@ -137,7 +138,10 @@ export class ItemGrid extends Component {
                         ].join(' ');
 
                         return (
-                            <div key={item.i} className={itemClassNames}>
+                            <ProgressiveLoadingContainer
+                                key={item.i}
+                                className={itemClassNames}
+                            >
                                 {edit ? (
                                     <DeleteItemButton
                                         onClick={this.onRemoveItemWrapper(
@@ -152,7 +156,7 @@ export class ItemGrid extends Component {
                                         this.onToggleItemExpanded
                                     }
                                 />
-                            </div>
+                            </ProgressiveLoadingContainer>
                         );
                     })}
                 </ReactGridLayout>


### PR DESCRIPTION
Fixes [DHIS2-6596](https://jira.dhis2.org/browse/DHIS2-6596).

Applying `ProgressiveLoaderContainer` to `Item/Item` instead of `Item/VisualizationItem/Item` component removes redundant div causing incorrect styles and scroll bar in pivot tables.