### PR TITLE
fix(TextItem): use all the vertical space for the input

### DIFF
--- a/src/components/Item/TextItem/Item.js
+++ b/src/components/Item/TextItem/Item.js
@@ -64,7 +64,6 @@ const TextItem = props => {
                             value={text}
                             multiline
                             rows={1}
-                            rowsMax={8}
                             fullWidth
                             style={style.textField}
                             placeholder={i18n.t('Add text here')}


### PR DESCRIPTION
Fixes DHIS2-6599.

(cherry picked from commit 9419d281f477ce61b75352f1d1ef7ef1c152b0a3)