### PR TITLE
fix: Optimise item grid component to avoid unnecessary re-renders

### DIFF
--- a/src/components/ItemGrid/ItemGrid.js
+++ b/src/components/ItemGrid/ItemGrid.js
@@ -69,7 +69,10 @@ export class ItemGrid extends Component {
 
     shouldComponentUpdate(nextProps, nextState) {
         return (
-            !isEqual(this.props.dashboardItems, nextProps.dashboardItems) ||
+            !isEqual(
+                this.props.dashboardItems.length,
+                nextProps.dashboardItems.length
+            ) ||
             !isEqual(this.props.edit, nextProps.edit) ||
             !isEqual(this.props.isLoading, nextProps.isLoading) ||
             !isEqual(this.state.expandedItems, nextState.expandedItems)

--- a/src/components/ItemGrid/ItemGrid.js
+++ b/src/components/ItemGrid/ItemGrid.js
@@ -66,6 +66,15 @@ export class ItemGrid extends Component {
         this.props.acRemoveDashboardItem(clickedId);
     };
 
+    shouldComponentUpdate(nextProps) {
+        return (
+            nextProps.dashboardItems.length !==
+                this.props.dashboardItems.length ||
+            nextProps.edit !== this.props.edit ||
+            nextProps.isLoading !== this.props.isLoading
+        );
+    }
+
     componentWillReceiveProps(nextProps) {
         if (nextProps.edit) {
             this.setState({ expandedItems: {} });
@@ -166,10 +175,14 @@ export class ItemGrid extends Component {
 }
 
 ItemGrid.propTypes = {
+    edit: PropTypes.bool,
+    isLoading: PropTypes.bool,
     dashboardItems: PropTypes.array,
 };
 
 ItemGrid.defaultProps = {
+    edit: false,
+    isLoading: false,
     dashboardItems: [],
 };
 

--- a/src/components/ItemGrid/ItemGrid.js
+++ b/src/components/ItemGrid/ItemGrid.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import i18n from '@dhis2/d2-i18n';
 import ReactGridLayout from 'react-grid-layout';
+import isEqual from 'lodash/isEqual';
 
 import {
     acUpdateDashboardLayout,
@@ -66,12 +67,12 @@ export class ItemGrid extends Component {
         this.props.acRemoveDashboardItem(clickedId);
     };
 
-    shouldComponentUpdate(nextProps) {
+    shouldComponentUpdate(nextProps, nextState) {
         return (
-            nextProps.dashboardItems.length !==
-                this.props.dashboardItems.length ||
-            nextProps.edit !== this.props.edit ||
-            nextProps.isLoading !== this.props.isLoading
+            !isEqual(this.props.dashboardItems, nextProps.dashboardItems) ||
+            !isEqual(this.props.edit, nextProps.edit) ||
+            !isEqual(this.props.isLoading, nextProps.isLoading) ||
+            !isEqual(this.state.expandedItems, nextState.expandedItems)
         );
     }
 


### PR DESCRIPTION
Fixes [DHIS2-6597](https://jira.dhis2.org/browse/DHIS2-6597).

#### Problem:
Chart items re-render in dashboards app even if props stay the same (triggers by editing text item).

#### Previous proposal:
Make props deep comparison in [Chart plugin](https://github.com/dhis2/data-visualizer-app/pull/254).

#### New proposal:
Use `shouldComponentUpdate` function in `ItemGrid` component to determine if it should re-render the grid.

Apply comparison checks to following props:
- `dashboardItems`
- `edit`
- `isLoading`