### PR TITLE
fix: Chart items do not resize properly in edit mode

### DIFF
--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -263,11 +263,12 @@ export class Item extends Component {
     getContentStyle = () => {
         const { item, editMode } = this.props;
         const PADDING_BOTTOM = 4;
+
         return !editMode
             ? {
                   height: item.originalHeight - HEADER_HEIGHT - PADDING_BOTTOM,
               }
-            : null;
+            : { height: '100%' };
     };
 
     render() {


### PR DESCRIPTION
Fixes [DHIS2-6598](https://jira.dhis2.org/browse/DHIS2-6598).

**Problem**
Charts do not resize properly in dashboard edit mode

**Solution**
Apply 100% height to chart items in edit mode.