### PR TITLE
fix(TextItem): use all the vertical space for the input

### DIFF
--- a/src/Item/TextItem/Item.js
+++ b/src/Item/TextItem/Item.js
@@ -83,9 +83,6 @@ const mapStateToProps = (state, ownProps) => {
     };
 };
 
-export default connect(
-    mapStateToProps,
-    {
-        acUpdateDashboardItem,
-    }
-)(TextItem);
+export default connect(mapStateToProps, {
+    acUpdateDashboardItem,
+})(TextItem);

--- a/src/Item/TextItem/Item.js
+++ b/src/Item/TextItem/Item.js
@@ -58,7 +58,6 @@ const TextItem = props => {
                         value={text}
                         multiline
                         rows={1}
-                        rowsMax={8}
                         fullWidth
                         style={style.textField}
                         placeholder={i18n.t('Add text here')}
@@ -84,6 +83,9 @@ const mapStateToProps = (state, ownProps) => {
     };
 };
 
-export default connect(mapStateToProps, {
-    acUpdateDashboardItem,
-})(TextItem);
+export default connect(
+    mapStateToProps,
+    {
+        acUpdateDashboardItem,
+    }
+)(TextItem);


### PR DESCRIPTION
Fixes DHIS2-6599.

(cherry picked from commit 9419d281f477ce61b75352f1d1ef7ef1c152b0a3)