### PR TITLE
fix: Incorrect analytical object request (some fields are missing)

### DIFF
--- a/src/api/metadata.js
+++ b/src/api/metadata.js
@@ -13,6 +13,7 @@ export const getIdNameFields = ({ rename } = {}) => [
 export const getItemFields = () => [
     'dimensionItem~rename(id)',
     'displayName~rename(name)',
+    'dimensionItemType',
 ];
 
 // Dimension
@@ -20,6 +21,7 @@ export const getDimensionFields = ({ withItems }) =>
     arrayClean([
         'dimension',
         'legendSet[id]',
+        'filter',
         withItems ? `items[${getItemFields().join(',')}]` : ``,
     ]);
 


### PR DESCRIPTION
Fixes [DHIS2-6699](https://jira.dhis2.org/browse/DHIS2-6699).

**Problem**
Some fields are missing in AO request which causes incorrect analytics request.
E.g. in "Cases Malaria" dashboard (/dhis-web-dashboard/#/JW7RlN5xafN) there is a map named "Malaria: Cases Female <5y Sierra Leone clustered".

This map shows some polygons which should not be there due to the event filters applied (polygons are not available in standard Sierra Leone demo db, to see those you should have [DB pre-populated with event polygons](https://drive.google.com/open?id=1d8DdYkqk9-eV9vdEcN662kAzFeCzhYbt)).

**Solution**
Append missing fields to AO request (`filter` for dimension fields & `dimensionItemType` for item fields).