### PR TITLE
fix: set focus properties so textfield maintains focus when popover opens - v32

### DIFF
--- a/src/components/ItemSelect/ItemSelect.js
+++ b/src/components/ItemSelect/ItemSelect.js
@@ -168,6 +168,8 @@ class ItemSelect extends React.Component {
                     transformOrigin={{ horizontal: 'left', vertical: 'top' }}
                     style={{ height: '70vh' }}
                     PaperProps={{ style: { width: '700px' } }}
+                    disableAutoFocus={true}
+                    disableRestoreFocus={true}
                 >
                     {this.popoverChildren(this.state.items)}
                 </Popover>


### PR DESCRIPTION
Fixes [DHIS2-6751]

Set the following Material-ui modal properties:

* disableAutoFocus: maintain focus in filter text field when item select Popover opens
* disableRestoreFocus: remove focus from filter text field when Popover closes (to match pre-existing behaviour)