### PR TITLE
chore: replace old MUI divider component with new MUI

### DIFF
--- a/src/components/ItemSelect/ItemSelectList.js
+++ b/src/components/ItemSelect/ItemSelectList.js
@@ -2,7 +2,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import i18n from '@dhis2/d2-i18n';
-import Divider from 'material-ui/Divider';
+import Divider from '@material-ui/core/Divider';
 import { List, ListItem } from 'material-ui/List';
 import Button from '@dhis2/d2-ui-core/button/Button';
 import LaunchIcon from '@material-ui/icons/Launch';

--- a/src/components/ItemSelect/ItemSelectSingle.js
+++ b/src/components/ItemSelect/ItemSelectSingle.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
-import Divider from 'material-ui/Divider';
+import Divider from '@material-ui/core/Divider';
 import { List, ListItem } from 'material-ui/List';
 import Button from '@dhis2/d2-ui-core/button/Button';
 import { getItemIcon } from '../../modules/itemTypes';


### PR DESCRIPTION
This is part of the gradual process of removing Material-ui 0.20 from dashboards-app