### PR TITLE
chore: replace old MUI Snackbar component with new MUI

### DIFF
--- a/src/components/SnackbarMessage/SnackbarMessage.js
+++ b/src/components/SnackbarMessage/SnackbarMessage.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import Snackbar from 'material-ui/Snackbar';
+import Snackbar from '@material-ui/core/Snackbar';
 
 import { sGetSnackbar } from '../../reducers/snackbar';
 import { acCloseSnackbar } from '../../actions/snackbar';
@@ -27,7 +27,7 @@ export const SnackbarMessage = props => {
             open={props.snackbarOpen}
             message={<SnackbarMessageContent message={props.snackbarMessage} />}
             autoHideDuration={props.snackbarDuration}
-            onRequestClose={props.onCloseSnackbar}
+            onClose={props.onCloseSnackbar}
         />
     );
 };

--- a/src/components/SnackbarMessage/__tests__/SnackbarMessage.spec.js
+++ b/src/components/SnackbarMessage/__tests__/SnackbarMessage.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import Snackbar from 'material-ui/Snackbar';
+import Snackbar from '@material-ui/core/Snackbar';
 import { SnackbarMessage } from '../SnackbarMessage';
 
 describe('SnackbarMessage', () => {


### PR DESCRIPTION
As a quick test, open the dashboard, then throttle the network connection to Slow 3G, then switch to another dashboard. The snackbar should appear at the bottom of the viewport.