### PR TITLE
chore: replace old material-ui IconButton

### DIFF
--- a/src/components/Item/ListItem/Item.js
+++ b/src/components/Item/ListItem/Item.js
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { List, ListItem as MUIListItem } from 'material-ui/List';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '@material-ui/core/IconButton';
 import DeleteIcon from '@material-ui/icons/Delete';
 
 import Line from '../../../widgets/Line';
@@ -44,18 +44,19 @@ const ListItem = (props, context) => {
                     padding: '0 12px',
                     height: 20,
                 }}
-                iconStyle={{
-                    width: 20,
-                    height: 20,
-                    fill: colors.red,
-                }}
                 onClick={removeContent(
                     tRemoveListItemContent,
                     item,
                     contentItem
                 )}
             >
-                <DeleteIcon />
+                <DeleteIcon
+                    style={{
+                        width: 20,
+                        height: 20,
+                        fill: colors.red,
+                    }}
+                />
             </IconButton>
         );
 


### PR DESCRIPTION
To view and try the button:
Open a dashboard in edit view. Click to add the "DHIS 2 Home Page" resource. A new item should be added. In that item, there are 2 red trash bin icons: one for the whole item, and one for the "Home Page" in the item. It is the second red trash bin that this PR has changed.