### PR TITLE
chore: replace old mui in the dashboard ListItem

### DIFF
--- a/src/components/Item/ListItem/Item.js
+++ b/src/components/Item/ListItem/Item.js
@@ -2,14 +2,11 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { colors } from '@dhis2/ui-core';
+import DescriptionIcon from '../../../icons/Description';
 
 import DeleteIcon from '../../../icons/Delete';
 import Line from '../../../widgets/Line';
-import {
-    itemTypeMap,
-    getItemUrl,
-    getItemIcon,
-} from '../../../modules/itemTypes';
+import { itemTypeMap, getItemUrl } from '../../../modules/itemTypes';
 import { orArray } from '../../../modules/util';
 import { tRemoveListItemContent } from './actions';
 import ItemHeader from '../ItemHeader';
@@ -59,8 +56,6 @@ const ListItem = (props, context) => {
         );
     };
 
-    const ItemIcon = getItemIcon(item.type);
-
     return (
         <Fragment>
             <ItemHeader title={getItemTitle(item)} />
@@ -69,7 +64,7 @@ const ListItem = (props, context) => {
                 <ul className={classes.list}>
                     {contentItems.map(contentItem => (
                         <li className={classes.item} key={contentItem.id}>
-                            <ItemIcon className={classes.itemicon} />
+                            <DescriptionIcon className={classes.itemicon} />
                             {getLink(contentItem)}
                         </li>
                     ))}

--- a/src/components/Item/ListItem/Item.js
+++ b/src/components/Item/ListItem/Item.js
@@ -41,7 +41,7 @@ const ListItem = (props, context) => {
                     contentItem
                 )}
             >
-                <DeleteIcon style={{ verticalAlign: 'bottom' }} />
+                <DeleteIcon className={classes.deleteicon} />
             </button>
         );
 

--- a/src/components/Item/ListItem/Item.js
+++ b/src/components/Item/ListItem/Item.js
@@ -1,10 +1,9 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { List, ListItem as MUIListItem } from 'material-ui/List';
-import IconButton from '@material-ui/core/IconButton';
-import DeleteIcon from '@material-ui/icons/Delete';
+import { colors } from '@dhis2/ui-core';
 
+import DeleteIcon from '../../../icons/Delete';
 import Line from '../../../widgets/Line';
 import {
     itemTypeMap,
@@ -13,12 +12,10 @@ import {
 } from '../../../modules/itemTypes';
 import { orArray } from '../../../modules/util';
 import { tRemoveListItemContent } from './actions';
-import { colors } from '../../../modules/colors';
 import ItemHeader from '../ItemHeader';
+import classes from './Item.module.css';
 
-const getItemTitle = item => {
-    return itemTypeMap[item.type].pluralTitle;
-};
+const getItemTitle = item => itemTypeMap[item.type].pluralTitle;
 
 const getContentItems = item =>
     orArray(item[itemTypeMap[item.type].propName]).filter(
@@ -32,44 +29,33 @@ const removeContent = (handler, item, contentToRemove) => () => {
 
 const ListItem = (props, context) => {
     const { item, editMode, tRemoveListItemContent } = props;
-
-    // avoid showing duplicates
     const contentItems = getContentItems(item);
 
-    const primaryText = contentItem => {
+    const getLink = contentItem => {
         const deleteButton = (
-            <IconButton
-                style={{
-                    verticalAlign: 'text-bottom',
-                    padding: '0 12px',
-                    height: 20,
-                }}
+            <button
+                className={classes.deletebutton}
                 onClick={removeContent(
                     tRemoveListItemContent,
                     item,
                     contentItem
                 )}
             >
-                <DeleteIcon
-                    style={{
-                        width: 20,
-                        height: 20,
-                        fill: colors.red,
-                    }}
-                />
-            </IconButton>
+                <DeleteIcon style={{ verticalAlign: 'bottom' }} />
+            </button>
         );
 
         return (
-            <div>
+            <Fragment>
                 <a
-                    style={{ textDecoration: 'none' }}
+                    className={classes.link}
+                    style={{ color: colors.grey900 }}
                     href={getItemUrl(item.type, contentItem, context.d2)}
                 >
                     {contentItem.name}
                 </a>
                 {editMode ? deleteButton : null}
-            </div>
+            </Fragment>
         );
     };
 
@@ -79,17 +65,16 @@ const ListItem = (props, context) => {
         <Fragment>
             <ItemHeader title={getItemTitle(item)} />
             <Line />
-            <List className="dashboard-item-content">
-                {contentItems.map(contentItem => (
-                    <MUIListItem
-                        key={contentItem.id}
-                        primaryText={primaryText(contentItem)}
-                        leftIcon={<ItemIcon style={{ margin: 0 }} />}
-                        disabled={true}
-                        innerDivStyle={{ padding: '4px 4px 4px 32px' }}
-                    />
-                ))}
-            </List>
+            <div className="dashboard-item-content">
+                <ul className={classes.list}>
+                    {contentItems.map(contentItem => (
+                        <li className={classes.item} key={contentItem.id}>
+                            <ItemIcon className={classes.itemicon} />
+                            {getLink(contentItem)}
+                        </li>
+                    ))}
+                </ul>
+            </div>
         </Fragment>
     );
 };
@@ -98,11 +83,9 @@ ListItem.contextTypes = {
     d2: PropTypes.object,
 };
 
-const ListItemContainer = connect(
+export default connect(
     null,
     {
         tRemoveListItemContent,
     }
 )(ListItem);
-
-export default ListItemContainer;

--- a/src/components/Item/ListItem/Item.module.css
+++ b/src/components/Item/ListItem/Item.module.css
@@ -8,6 +8,8 @@
 
 .itemicon {
     vertical-align: text-bottom;
+    width: 18px;
+    height: 18px;
 }
 
 .link {

--- a/src/components/Item/ListItem/Item.module.css
+++ b/src/components/Item/ListItem/Item.module.css
@@ -1,0 +1,34 @@
+.list {
+    margin-top: 10px;
+}
+
+.item {
+    margin-bottom: 8px;
+}
+
+.itemicon {
+    vertical-align: text-bottom;
+}
+
+.link {
+    font-size: 14px;
+    margin-left: 5px;
+    text-decoration: underline;
+}
+
+.deleteicon {
+    vertical-align: text-bottom;
+}
+
+.deletebutton {
+    border: none;
+    border-radius: 50%;
+    cursor: pointer;
+    margin-left: 5px;
+    padding: 0px 5px;
+    vertical-align: text-bottom;
+}
+
+.deletebutton:focus {
+    outline: none;
+}

--- a/src/icons/AddCircle.js
+++ b/src/icons/AddCircle.js
@@ -1,12 +1,12 @@
 import React from 'react';
-import { colors } from '../modules/colors';
+import { colors } from '@dhis2/ui-core';
 
 const AddCircleIcon = () => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
         width="32"
         height="32"
-        fill={colors.mediumGreen}
+        fill={colors.teal600}
         viewBox="0 0 24 24"
     >
         <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm4 11h-3v3c0 .55-.45 1-1 1s-1-.45-1-1v-3H8c-.55 0-1-.45-1-1s.45-1 1-1h3V8c0-.55.45-1 1-1s1 .45 1 1v3h3c.55 0 1 .45 1 1s-.45 1-1 1z" />

--- a/src/icons/Delete.js
+++ b/src/icons/Delete.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { colors } from '@dhis2/ui-core';
+
+const DeleteIcon = ({ className }) => (
+    <svg
+        className={className}
+        xmlns="http://www.w3.org/2000/svg"
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill={colors.red500}
+    >
+        <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z" />
+        <path d="M0 0h24v24H0z" fill="none" />
+    </svg>
+);
+
+export default DeleteIcon;

--- a/src/icons/Description.js
+++ b/src/icons/Description.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { colors } from '@dhis2/ui-core';
+
+const DescriptionIcon = ({ className }) => (
+    <svg
+        className={className}
+        xmlns="http://www.w3.org/2000/svg"
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill={colors.grey500}
+    >
+        <path d="M0 0h24v24H0z" fill="none" />
+        <path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z" />
+    </svg>
+);
+
+export default DescriptionIcon;

--- a/src/icons/Description.js
+++ b/src/icons/Description.js
@@ -5,8 +5,6 @@ const DescriptionIcon = ({ className }) => (
     <svg
         className={className}
         xmlns="http://www.w3.org/2000/svg"
-        width="18"
-        height="18"
         viewBox="0 0 24 24"
         fill={colors.grey500}
     >

--- a/src/modules/itemTypes.js
+++ b/src/modules/itemTypes.js
@@ -3,7 +3,7 @@ import TableIcon from '@material-ui/icons/ViewList';
 import ChartIcon from '@material-ui/icons/InsertChart';
 import MapIcon from '@material-ui/icons/Public';
 import ExtensionIcon from '@material-ui/icons/Extension';
-import DescriptionIcon from '../icons/Description';
+import DescriptionIcon from '@material-ui/icons/Description';
 import PersonIcon from '@material-ui/icons/Person';
 import FontDownloadIcon from '@material-ui/icons/FontDownload';
 import EmailIcon from '@material-ui/icons/Email';

--- a/src/modules/itemTypes.js
+++ b/src/modules/itemTypes.js
@@ -3,7 +3,7 @@ import TableIcon from '@material-ui/icons/ViewList';
 import ChartIcon from '@material-ui/icons/InsertChart';
 import MapIcon from '@material-ui/icons/Public';
 import ExtensionIcon from '@material-ui/icons/Extension';
-import DescriptionIcon from '@material-ui/icons/Description';
+import DescriptionIcon from '../icons/Description';
 import PersonIcon from '@material-ui/icons/Person';
 import FontDownloadIcon from '@material-ui/icons/FontDownload';
 import EmailIcon from '@material-ui/icons/Email';


### PR DESCRIPTION
Changes included:
- remove old mui List and ListItem, replace with html `<ul> <li>`
- for icons, use svg directly from material.io (this gets us around a css specificity issue with material-ui)
- use the colors from @dhis2/ui-core instead of the outdated dashboards colors file