### PR TITLE
fix: hide vis action buttons for single value charts

### DIFF
--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -254,21 +254,20 @@ export class Item extends Component {
         );
     };
 
-    getActionButtons = () => {
-        const { item, visualization } = this.props;
-
-        return pluginManager.pluginIsAvailable(item, visualization) &&
-            !this.props.editMode ? (
+    getActionButtons = () =>
+        pluginManager.pluginIsAvailable(
+            this.props.item,
+            this.props.visualization
+        ) && !this.props.editMode ? (
             <VisualizationItemHeaderButtons
-                item={item}
-                visualization={visualization}
+                item={this.props.item}
+                visualization={this.props.visualization}
                 activeFooter={this.state.showFooter}
                 activeType={this.getActiveType()}
                 onSelectVisualization={this.onSelectVisualization}
                 onToggleFooter={this.onToggleFooter}
             />
         ) : null;
-    };
 
     getContentStyle = () => {
         const { item, editMode } = this.props;

--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -235,7 +235,7 @@ export class Item extends Component {
         const itemName = pluginManager.getName(item);
 
         return (
-            <div style={{ display: 'flex', alignItems: 'center' }}>
+            <div style={{ display: 'flex' }}>
                 <span className={classes.title} title={itemName}>
                     {itemName}
                 </span>

--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -19,7 +19,13 @@ import {
     acReceivedVisualization,
     acReceivedActiveVisualization,
 } from '../../../actions/selected';
-import { CHART, MAP, itemTypeMap } from '../../../modules/itemTypes';
+import {
+    CHART,
+    MAP,
+    itemTypeMap,
+    CHART_TYPE_SINGLE_VALUE,
+    VISUALIZATION_TYPE_CHART,
+} from '../../../modules/itemTypes';
 import { colors } from '@dhis2/ui-core';
 import memoizeOne from '../../../modules/memoizeOne';
 import { getVisualizationConfig } from './plugin';
@@ -248,19 +254,21 @@ export class Item extends Component {
         );
     };
 
-    getActionButtons = () =>
-        pluginManager.pluginIsAvailable(
-            this.props.item,
-            this.props.visualization
-        ) && !this.props.editMode ? (
+    getActionButtons = () => {
+        const { item, visualization } = this.props;
+
+        return pluginManager.pluginIsAvailable(item, visualization) &&
+            !this.props.editMode ? (
             <VisualizationItemHeaderButtons
-                item={this.props.item}
+                item={item}
+                visualization={visualization}
                 activeFooter={this.state.showFooter}
                 activeType={this.getActiveType()}
                 onSelectVisualization={this.onSelectVisualization}
                 onToggleFooter={this.onToggleFooter}
             />
         ) : null;
+    };
 
     getContentStyle = () => {
         const { item, editMode } = this.props;

--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -19,13 +19,7 @@ import {
     acReceivedVisualization,
     acReceivedActiveVisualization,
 } from '../../../actions/selected';
-import {
-    CHART,
-    MAP,
-    itemTypeMap,
-    CHART_TYPE_SINGLE_VALUE,
-    VISUALIZATION_TYPE_CHART,
-} from '../../../modules/itemTypes';
+import { CHART, MAP, itemTypeMap } from '../../../modules/itemTypes';
 import { colors } from '@dhis2/ui-core';
 import memoizeOne from '../../../modules/memoizeOne';
 import { getVisualizationConfig } from './plugin';

--- a/src/components/Item/VisualizationItem/ItemHeaderButtons.js
+++ b/src/components/Item/VisualizationItem/ItemHeaderButtons.js
@@ -86,6 +86,7 @@ export const getItemTypeId = (itemTypeMap, visualizationType, domainType) => {
     return item.id;
 };
 
+// TODO: Import this from @dhis2/analytics when available
 const isSingleValue = (itemType, chartType) =>
     itemType === VISUALIZATION_TYPE_CHART &&
     chartType === CHART_TYPE_SINGLE_VALUE;

--- a/src/components/Item/VisualizationItem/ItemHeaderButtons.js
+++ b/src/components/Item/VisualizationItem/ItemHeaderButtons.js
@@ -147,10 +147,6 @@ class VisualizationItemHeaderButtons extends Component {
                 getItemTypeId(itemTypeMap, VISUALIZATION_TYPE_MAP, domainType)
             );
 
-        const tableButtonStyle = tableBtnStyle(activeType, disabled);
-        const chartButtonStyle = chartBtnStyle(activeType, disabled);
-        const mapButtonStyle = mapBtnStyle(activeType, disabled);
-
         // disable toggle buttons
         let disabled = false;
 
@@ -159,6 +155,10 @@ class VisualizationItemHeaderButtons extends Component {
                 disabled = true;
             }
         }
+
+        const tableButtonStyle = tableBtnStyle(activeType, disabled);
+        const chartButtonStyle = chartBtnStyle(activeType, disabled);
+        const mapButtonStyle = mapBtnStyle(activeType, disabled);
 
         return (
             <div style={{ marginLeft: 10 }}>

--- a/src/components/Item/VisualizationItem/ItemHeaderButtons.js
+++ b/src/components/Item/VisualizationItem/ItemHeaderButtons.js
@@ -17,6 +17,7 @@ import {
     EVENT_CHART,
     EVENT_REPORT,
     DOMAIN_TYPE_AGGREGATE,
+    CHART_TYPE_SINGLE_VALUE,
 } from '../../../modules/itemTypes';
 import { colors, theme } from '@dhis2/ui-core';
 
@@ -85,15 +86,48 @@ export const getItemTypeId = (itemTypeMap, visualizationType, domainType) => {
     return item.id;
 };
 
+const isSingleValue = (itemType, chartType) =>
+    itemType === VISUALIZATION_TYPE_CHART &&
+    chartType === CHART_TYPE_SINGLE_VALUE;
+
 class VisualizationItemHeaderButtons extends Component {
-    render() {
+    renderInterpretationButton() {
+        const { activeFooter, onToggleFooter } = this.props;
+
+        const toggleFooterBase = activeFooter ? activeStyle : baseStyle;
+
+        const toggleFooter = {
+            ...toggleFooterBase,
+            container: {
+                ...toggleFooterBase.container,
+                ...style.toggleFooterPadding,
+                ...style.border,
+            },
+        };
+
+        return (
+            <Fragment>
+                <ItemHeaderButton
+                    style={toggleFooter.container}
+                    onClick={onToggleFooter}
+                >
+                    <MessageIcon style={toggleFooter.icon} />
+                </ItemHeaderButton>
+            </Fragment>
+        );
+    }
+
+    renderVisualizationButtons() {
         const {
             item,
+            visualization,
             onSelectVisualization,
-            activeFooter,
             activeType,
-            onToggleFooter,
         } = this.props;
+
+        if (isSingleValue(item.type, visualization.type)) {
+            return null;
+        }
 
         const domainType = itemTypeMap[item.type].domainType;
 
@@ -112,16 +146,9 @@ class VisualizationItemHeaderButtons extends Component {
                 getItemTypeId(itemTypeMap, VISUALIZATION_TYPE_MAP, domainType)
             );
 
-        const toggleFooterBase = activeFooter ? activeStyle : baseStyle;
-
-        const toggleFooter = {
-            ...toggleFooterBase,
-            container: {
-                ...toggleFooterBase.container,
-                ...style.toggleFooterPadding,
-                ...style.border,
-            },
-        };
+        const tableButtonStyle = tableBtnStyle(activeType, disabled);
+        const chartButtonStyle = chartBtnStyle(activeType, disabled);
+        const mapButtonStyle = mapBtnStyle(activeType, disabled);
 
         // disable toggle buttons
         let disabled = false;
@@ -132,20 +159,8 @@ class VisualizationItemHeaderButtons extends Component {
             }
         }
 
-        const tableButtonStyle = tableBtnStyle(activeType, disabled);
-        const chartButtonStyle = chartBtnStyle(activeType, disabled);
-        const mapButtonStyle = mapBtnStyle(activeType, disabled);
-
         return (
-            <Fragment>
-                <div style={{ marginRight: 10 }}>
-                    <ItemHeaderButton
-                        style={toggleFooter.container}
-                        onClick={onToggleFooter}
-                    >
-                        <MessageIcon style={toggleFooter.icon} />
-                    </ItemHeaderButton>
-                </div>
+            <div style={{ marginLeft: 10 }}>
                 <div style={style.border}>
                     <ItemHeaderButton
                         disabled={disabled}
@@ -171,6 +186,15 @@ class VisualizationItemHeaderButtons extends Component {
                         </ItemHeaderButton>
                     ) : null}
                 </div>
+            </div>
+        );
+    }
+
+    render() {
+        return (
+            <Fragment>
+                {this.renderInterpretationButton()}
+                {this.renderVisualizationButtons()}
             </Fragment>
         );
     }

--- a/src/components/Item/VisualizationItem/__tests__/ItemHeaderButtons.spec.js
+++ b/src/components/Item/VisualizationItem/__tests__/ItemHeaderButtons.spec.js
@@ -9,6 +9,9 @@ it('renders correctly', () => {
                 type: 'CHART',
                 chart: { type: 'NOT_YOY', domainType: 'AGGREGATE' },
             }}
+            visualization={{
+                type: 'SINGLE_VALUE',
+            }}
             onSelectVisualization={Function.prototype}
             activeFooter={false}
             activeType={'CHART'}

--- a/src/components/Item/VisualizationItem/__tests__/__snapshots__/Item.spec.js.snap
+++ b/src/components/Item/VisualizationItem/__tests__/__snapshots__/Item.spec.js.snap
@@ -70,6 +70,15 @@ ShallowWrapper {
               }
               onSelectVisualization={[Function]}
               onToggleFooter={[Function]}
+              visualization={
+                Object {
+                  "columns": Array [],
+                  "description": "Test pivot mock",
+                  "filters": Array [],
+                  "name": "Test pivot",
+                  "rows": Array [],
+                }
+              }
             />
           }
           editMode={false}
@@ -128,6 +137,15 @@ ShallowWrapper {
             }
             onSelectVisualization={[Function]}
             onToggleFooter={[Function]}
+            visualization={
+              Object {
+                "columns": Array [],
+                "description": "Test pivot mock",
+                "filters": Array [],
+                "name": "Test pivot",
+                "rows": Array [],
+              }
+            }
           />,
           "editMode": false,
           "title": <div
@@ -199,6 +217,15 @@ ShallowWrapper {
                 }
                 onSelectVisualization={[Function]}
                 onToggleFooter={[Function]}
+                visualization={
+                  Object {
+                    "columns": Array [],
+                    "description": "Test pivot mock",
+                    "filters": Array [],
+                    "name": "Test pivot",
+                    "rows": Array [],
+                  }
+                }
               />
             }
             editMode={false}
@@ -257,6 +284,15 @@ ShallowWrapper {
               }
               onSelectVisualization={[Function]}
               onToggleFooter={[Function]}
+              visualization={
+                Object {
+                  "columns": Array [],
+                  "description": "Test pivot mock",
+                  "filters": Array [],
+                  "name": "Test pivot",
+                  "rows": Array [],
+                }
+              }
             />,
             "editMode": false,
             "title": <div

--- a/src/components/Item/VisualizationItem/__tests__/__snapshots__/Item.spec.js.snap
+++ b/src/components/Item/VisualizationItem/__tests__/__snapshots__/Item.spec.js.snap
@@ -86,7 +86,6 @@ ShallowWrapper {
             <div
               style={
                 Object {
-                  "alignItems": "center",
                   "display": "flex",
                 }
               }
@@ -151,7 +150,6 @@ ShallowWrapper {
           "title": <div
             style={
               Object {
-                "alignItems": "center",
                 "display": "flex",
               }
             }
@@ -233,7 +231,6 @@ ShallowWrapper {
               <div
                 style={
                   Object {
-                    "alignItems": "center",
                     "display": "flex",
                   }
                 }
@@ -298,7 +295,6 @@ ShallowWrapper {
             "title": <div
               style={
                 Object {
-                  "alignItems": "center",
                   "display": "flex",
                 }
               }

--- a/src/components/Item/VisualizationItem/__tests__/__snapshots__/ItemHeaderButtons.spec.js.snap
+++ b/src/components/Item/VisualizationItem/__tests__/__snapshots__/ItemHeaderButtons.spec.js.snap
@@ -17,6 +17,11 @@ ShallowWrapper {
     }
     onSelectVisualization={[Function]}
     onToggleFooter={[Function]}
+    visualization={
+      Object {
+        "type": "SINGLE_VALUE",
+      }
+    }
   >
     My Little Pony
   </VisualizationItemHeaderButtons>,
@@ -35,13 +40,7 @@ ShallowWrapper {
     "nodeType": "function",
     "props": Object {
       "children": Array [
-        <div
-          style={
-            Object {
-              "marginRight": 10,
-            }
-          }
-        >
+        <React.Fragment>
           <ItemHeaderButton
             onClick={[Function]}
             style={
@@ -62,74 +61,8 @@ ShallowWrapper {
               }
             />
           </ItemHeaderButton>
-        </div>,
-        <div
-          style={
-            Object {
-              "border": "1px solid #f3f5f7",
-              "borderRadius": "2px",
-            }
-          }
-        >
-          <ItemHeaderButton
-            disabled={false}
-            onClick={[Function]}
-            style={
-              Object {
-                "padding": "5px 6px 3px 6px",
-              }
-            }
-          >
-            <pure(ViewListIcon)
-              style={
-                Object {
-                  "fill": "#a0adba",
-                  "height": "24px",
-                  "width": "24px",
-                }
-              }
-            />
-          </ItemHeaderButton>
-          <ItemHeaderButton
-            disabled={false}
-            onClick={[Function]}
-            style={
-              Object {
-                "backgroundColor": "#e3f2fd",
-                "padding": "5px 6px 3px 6px",
-              }
-            }
-          >
-            <pure(InsertChartIcon)
-              style={
-                Object {
-                  "fill": "#0d47a1",
-                  "height": "24px",
-                  "width": "24px",
-                }
-              }
-            />
-          </ItemHeaderButton>
-          <ItemHeaderButton
-            disabled={false}
-            onClick={[Function]}
-            style={
-              Object {
-                "padding": "5px 6px 3px 6px",
-              }
-            }
-          >
-            <pure(PublicIcon)
-              style={
-                Object {
-                  "fill": "#a0adba",
-                  "height": "24px",
-                  "width": "24px",
-                }
-              }
-            />
-          </ItemHeaderButton>
-        </div>,
+        </React.Fragment>,
+        null,
       ],
     },
     "ref": null,
@@ -137,7 +70,7 @@ ShallowWrapper {
       Object {
         "instance": null,
         "key": undefined,
-        "nodeType": "host",
+        "nodeType": "function",
         "props": Object {
           "children": <ItemHeaderButton
             onClick={[Function]}
@@ -159,9 +92,6 @@ ShallowWrapper {
               }
             />
           </ItemHeaderButton>,
-          "style": Object {
-            "marginRight": 10,
-          },
         },
         "ref": null,
         "rendered": Object {
@@ -203,198 +133,9 @@ ShallowWrapper {
           },
           "type": [Function],
         },
-        "type": "div",
+        "type": Symbol(react.fragment),
       },
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "host",
-        "props": Object {
-          "children": Array [
-            <ItemHeaderButton
-              disabled={false}
-              onClick={[Function]}
-              style={
-                Object {
-                  "padding": "5px 6px 3px 6px",
-                }
-              }
-            >
-              <pure(ViewListIcon)
-                style={
-                  Object {
-                    "fill": "#a0adba",
-                    "height": "24px",
-                    "width": "24px",
-                  }
-                }
-              />
-            </ItemHeaderButton>,
-            <ItemHeaderButton
-              disabled={false}
-              onClick={[Function]}
-              style={
-                Object {
-                  "backgroundColor": "#e3f2fd",
-                  "padding": "5px 6px 3px 6px",
-                }
-              }
-            >
-              <pure(InsertChartIcon)
-                style={
-                  Object {
-                    "fill": "#0d47a1",
-                    "height": "24px",
-                    "width": "24px",
-                  }
-                }
-              />
-            </ItemHeaderButton>,
-            <ItemHeaderButton
-              disabled={false}
-              onClick={[Function]}
-              style={
-                Object {
-                  "padding": "5px 6px 3px 6px",
-                }
-              }
-            >
-              <pure(PublicIcon)
-                style={
-                  Object {
-                    "fill": "#a0adba",
-                    "height": "24px",
-                    "width": "24px",
-                  }
-                }
-              />
-            </ItemHeaderButton>,
-          ],
-          "style": Object {
-            "border": "1px solid #f3f5f7",
-            "borderRadius": "2px",
-          },
-        },
-        "ref": null,
-        "rendered": Array [
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "function",
-            "props": Object {
-              "children": <pure(ViewListIcon)
-                style={
-                  Object {
-                    "fill": "#a0adba",
-                    "height": "24px",
-                    "width": "24px",
-                  }
-                }
-              />,
-              "disabled": false,
-              "onClick": [Function],
-              "style": Object {
-                "padding": "5px 6px 3px 6px",
-              },
-            },
-            "ref": null,
-            "rendered": Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "class",
-              "props": Object {
-                "style": Object {
-                  "fill": "#a0adba",
-                  "height": "24px",
-                  "width": "24px",
-                },
-              },
-              "ref": null,
-              "rendered": null,
-              "type": [Function],
-            },
-            "type": [Function],
-          },
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "function",
-            "props": Object {
-              "children": <pure(InsertChartIcon)
-                style={
-                  Object {
-                    "fill": "#0d47a1",
-                    "height": "24px",
-                    "width": "24px",
-                  }
-                }
-              />,
-              "disabled": false,
-              "onClick": [Function],
-              "style": Object {
-                "backgroundColor": "#e3f2fd",
-                "padding": "5px 6px 3px 6px",
-              },
-            },
-            "ref": null,
-            "rendered": Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "class",
-              "props": Object {
-                "style": Object {
-                  "fill": "#0d47a1",
-                  "height": "24px",
-                  "width": "24px",
-                },
-              },
-              "ref": null,
-              "rendered": null,
-              "type": [Function],
-            },
-            "type": [Function],
-          },
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "function",
-            "props": Object {
-              "children": <pure(PublicIcon)
-                style={
-                  Object {
-                    "fill": "#a0adba",
-                    "height": "24px",
-                    "width": "24px",
-                  }
-                }
-              />,
-              "disabled": false,
-              "onClick": [Function],
-              "style": Object {
-                "padding": "5px 6px 3px 6px",
-              },
-            },
-            "ref": null,
-            "rendered": Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "class",
-              "props": Object {
-                "style": Object {
-                  "fill": "#a0adba",
-                  "height": "24px",
-                  "width": "24px",
-                },
-              },
-              "ref": null,
-              "rendered": null,
-              "type": [Function],
-            },
-            "type": [Function],
-          },
-        ],
-        "type": "div",
-      },
+      null,
     ],
     "type": Symbol(react.fragment),
   },
@@ -405,13 +146,7 @@ ShallowWrapper {
       "nodeType": "function",
       "props": Object {
         "children": Array [
-          <div
-            style={
-              Object {
-                "marginRight": 10,
-              }
-            }
-          >
+          <React.Fragment>
             <ItemHeaderButton
               onClick={[Function]}
               style={
@@ -432,74 +167,8 @@ ShallowWrapper {
                 }
               />
             </ItemHeaderButton>
-          </div>,
-          <div
-            style={
-              Object {
-                "border": "1px solid #f3f5f7",
-                "borderRadius": "2px",
-              }
-            }
-          >
-            <ItemHeaderButton
-              disabled={false}
-              onClick={[Function]}
-              style={
-                Object {
-                  "padding": "5px 6px 3px 6px",
-                }
-              }
-            >
-              <pure(ViewListIcon)
-                style={
-                  Object {
-                    "fill": "#a0adba",
-                    "height": "24px",
-                    "width": "24px",
-                  }
-                }
-              />
-            </ItemHeaderButton>
-            <ItemHeaderButton
-              disabled={false}
-              onClick={[Function]}
-              style={
-                Object {
-                  "backgroundColor": "#e3f2fd",
-                  "padding": "5px 6px 3px 6px",
-                }
-              }
-            >
-              <pure(InsertChartIcon)
-                style={
-                  Object {
-                    "fill": "#0d47a1",
-                    "height": "24px",
-                    "width": "24px",
-                  }
-                }
-              />
-            </ItemHeaderButton>
-            <ItemHeaderButton
-              disabled={false}
-              onClick={[Function]}
-              style={
-                Object {
-                  "padding": "5px 6px 3px 6px",
-                }
-              }
-            >
-              <pure(PublicIcon)
-                style={
-                  Object {
-                    "fill": "#a0adba",
-                    "height": "24px",
-                    "width": "24px",
-                  }
-                }
-              />
-            </ItemHeaderButton>
-          </div>,
+          </React.Fragment>,
+          null,
         ],
       },
       "ref": null,
@@ -507,7 +176,7 @@ ShallowWrapper {
         Object {
           "instance": null,
           "key": undefined,
-          "nodeType": "host",
+          "nodeType": "function",
           "props": Object {
             "children": <ItemHeaderButton
               onClick={[Function]}
@@ -529,9 +198,6 @@ ShallowWrapper {
                 }
               />
             </ItemHeaderButton>,
-            "style": Object {
-              "marginRight": 10,
-            },
           },
           "ref": null,
           "rendered": Object {
@@ -573,198 +239,9 @@ ShallowWrapper {
             },
             "type": [Function],
           },
-          "type": "div",
+          "type": Symbol(react.fragment),
         },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "host",
-          "props": Object {
-            "children": Array [
-              <ItemHeaderButton
-                disabled={false}
-                onClick={[Function]}
-                style={
-                  Object {
-                    "padding": "5px 6px 3px 6px",
-                  }
-                }
-              >
-                <pure(ViewListIcon)
-                  style={
-                    Object {
-                      "fill": "#a0adba",
-                      "height": "24px",
-                      "width": "24px",
-                    }
-                  }
-                />
-              </ItemHeaderButton>,
-              <ItemHeaderButton
-                disabled={false}
-                onClick={[Function]}
-                style={
-                  Object {
-                    "backgroundColor": "#e3f2fd",
-                    "padding": "5px 6px 3px 6px",
-                  }
-                }
-              >
-                <pure(InsertChartIcon)
-                  style={
-                    Object {
-                      "fill": "#0d47a1",
-                      "height": "24px",
-                      "width": "24px",
-                    }
-                  }
-                />
-              </ItemHeaderButton>,
-              <ItemHeaderButton
-                disabled={false}
-                onClick={[Function]}
-                style={
-                  Object {
-                    "padding": "5px 6px 3px 6px",
-                  }
-                }
-              >
-                <pure(PublicIcon)
-                  style={
-                    Object {
-                      "fill": "#a0adba",
-                      "height": "24px",
-                      "width": "24px",
-                    }
-                  }
-                />
-              </ItemHeaderButton>,
-            ],
-            "style": Object {
-              "border": "1px solid #f3f5f7",
-              "borderRadius": "2px",
-            },
-          },
-          "ref": null,
-          "rendered": Array [
-            Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "function",
-              "props": Object {
-                "children": <pure(ViewListIcon)
-                  style={
-                    Object {
-                      "fill": "#a0adba",
-                      "height": "24px",
-                      "width": "24px",
-                    }
-                  }
-                />,
-                "disabled": false,
-                "onClick": [Function],
-                "style": Object {
-                  "padding": "5px 6px 3px 6px",
-                },
-              },
-              "ref": null,
-              "rendered": Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "class",
-                "props": Object {
-                  "style": Object {
-                    "fill": "#a0adba",
-                    "height": "24px",
-                    "width": "24px",
-                  },
-                },
-                "ref": null,
-                "rendered": null,
-                "type": [Function],
-              },
-              "type": [Function],
-            },
-            Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "function",
-              "props": Object {
-                "children": <pure(InsertChartIcon)
-                  style={
-                    Object {
-                      "fill": "#0d47a1",
-                      "height": "24px",
-                      "width": "24px",
-                    }
-                  }
-                />,
-                "disabled": false,
-                "onClick": [Function],
-                "style": Object {
-                  "backgroundColor": "#e3f2fd",
-                  "padding": "5px 6px 3px 6px",
-                },
-              },
-              "ref": null,
-              "rendered": Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "class",
-                "props": Object {
-                  "style": Object {
-                    "fill": "#0d47a1",
-                    "height": "24px",
-                    "width": "24px",
-                  },
-                },
-                "ref": null,
-                "rendered": null,
-                "type": [Function],
-              },
-              "type": [Function],
-            },
-            Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "function",
-              "props": Object {
-                "children": <pure(PublicIcon)
-                  style={
-                    Object {
-                      "fill": "#a0adba",
-                      "height": "24px",
-                      "width": "24px",
-                    }
-                  }
-                />,
-                "disabled": false,
-                "onClick": [Function],
-                "style": Object {
-                  "padding": "5px 6px 3px 6px",
-                },
-              },
-              "ref": null,
-              "rendered": Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "class",
-                "props": Object {
-                  "style": Object {
-                    "fill": "#a0adba",
-                    "height": "24px",
-                    "width": "24px",
-                  },
-                },
-                "ref": null,
-                "rendered": null,
-                "type": [Function],
-              },
-              "type": [Function],
-            },
-          ],
-          "type": "div",
-        },
+        null,
       ],
       "type": Symbol(react.fragment),
     },

--- a/src/modules/itemTypes.js
+++ b/src/modules/itemTypes.js
@@ -35,7 +35,7 @@ export const VISUALIZATION_TYPE_TABLE = 'TABLE';
 export const VISUALIZATION_TYPE_CHART = 'CHART';
 export const VISUALIZATION_TYPE_MAP = 'MAP';
 
-// Chart type (separate module when moved from data visualizer app)
+// TODO: Import this from @dhis2/analytics when available
 export const CHART_TYPE_SINGLE_VALUE = 'SINGLE_VALUE';
 
 // Dashboard helpers

--- a/src/modules/itemTypes.js
+++ b/src/modules/itemTypes.js
@@ -35,6 +35,10 @@ export const VISUALIZATION_TYPE_TABLE = 'TABLE';
 export const VISUALIZATION_TYPE_CHART = 'CHART';
 export const VISUALIZATION_TYPE_MAP = 'MAP';
 
+// Chart type (separate module when moved from data visualizer app)
+export const CHART_TYPE_SINGLE_VALUE = 'SINGLE_VALUE';
+
+// Dashboard helpers
 export const spacerContent = 'SPACER_ITEM_FOR_DASHBOARD_LAYOUT_CONVENIENCE';
 export const emptyTextItemContent = 'TEXT_ITEM_WITH_NO_CONTENT';
 export const isSpacerType = item =>


### PR DESCRIPTION
Separates interpretation and vis action buttons inside the VisualizationItemHeaderButtons component to be able to conditionally render only the interpretation button (hiding the vis buttons for single value charts).

Also fixes the problem where the bottom pixel row of the AO title gets cut off.