### PR TITLE
fix: cli-style commit hooks

### DIFF
--- a/.huskyrc.js
+++ b/.huskyrc.js
@@ -1,0 +1,11 @@
+const { config } = require('@dhis2/cli-style');
+const husky = require(config.husky);
+
+const tasks = arr => arr.join(' && ');
+
+module.exports = {
+    hooks: {
+        ...husky.hooks,
+        'pre-commit': tasks(['yarn validate-commit']),
+    },
+};

--- a/.huskyrc.js
+++ b/.huskyrc.js
@@ -1,11 +1,10 @@
 const { config } = require('@dhis2/cli-style');
 const husky = require(config.husky);
 
-const tasks = arr => arr.join(' && ');
-
 module.exports = {
     hooks: {
         ...husky.hooks,
-        'pre-commit': tasks(['yarn validate-commit']),
+        'pre-commit': 'yarn validate-commit',
+        'pre-push': 'yarn validate-push',
     },
 };

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+/node_modules/*
+/i18n/*
+/public/*

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
         "analyze": "source-map-explorer 'build/static/js/*.js'",
         "prestart": "npm run extract-pot && npm run localize && npm run manifest",
         "start": "react-scripts start",
-        "lint": "eslint -c .eslintrc.js src",
+        "lint": "d2-style js check || d2-style text check",
+        "format": "d2-style js apply || d2-style text apply",
         "coverage": "npm test -- --coverage",
         "prebuild": "rm -rf build && mkdir build && npm run manifest && npm run localize",
         "build": "PUBLIC_URL=. react-scripts build",
@@ -52,12 +53,8 @@
         "eject": "react-scripts eject",
         "manifest": "d2-manifest package.json ./public/manifest.webapp --manifest.activities.dhis.href=${REACT_APP_DHIS2_BASE_URL:=..}",
         "extract-pot": "d2-i18n-extract -p src/ -o i18n/",
-        "localize": "d2-i18n-generate -n dashboards-app -p ./i18n/ -o ./src/locales/"
-    },
-    "husky": {
-        "hooks": {
-            "pre-commit": "yarn extract-pot && CI=true yarn test && git add ./i18n/"
-        }
+        "localize": "d2-i18n-generate -n dashboards-app -p ./i18n/ -o ./src/locales/",
+        "validate-commit": "d2-style js check --staged && d2-style text check --staged && yarn extract-pot && CI=true yarn test && git add ./i18n/"
     },
     "manifest.webapp": {
         "name": "Dashboards app",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
         "manifest": "d2-manifest package.json ./public/manifest.webapp --manifest.activities.dhis.href=${REACT_APP_DHIS2_BASE_URL:=..}",
         "extract-pot": "d2-i18n-extract -p src/ -o i18n/",
         "localize": "d2-i18n-generate -n dashboards-app -p ./i18n/ -o ./src/locales/",
-        "validate-commit": "d2-style js check --staged && d2-style text check --staged && yarn extract-pot && CI=true yarn test && git add ./i18n/"
+        "validate-commit": "d2-style js check --staged && d2-style text check --staged && yarn extract-pot && git add ./i18n/",
+        "validate-push": "CI=true yarn test"
     },
     "manifest.webapp": {
         "name": "Dashboards app",


### PR DESCRIPTION
🎉 Adds commit hooks using [cli-style](https://github.com/dhis2/cli-style) and Husky 💻 🚀 

🔨 Before commit, the following will be run and validated:
1. JS code using `d2-style js check --staged`
1. Text using `d2-style text check --staged`
1. Commit message

🔨 Before push, the following will be run and validated:
1. Test suite

💡  A _dry run_ of the commit validation can be run using `yarn validate-commit`.
💡  A _dry run_ of the push validation can be run using `yarn validate-push`.
