### PR TITLE
fix: make dashboard items draggable again by passing down event props

### DIFF
--- a/src/components/Item/ProgressiveLoadingContainer.js
+++ b/src/components/Item/ProgressiveLoadingContainer.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import debounce from 'lodash/debounce';
+import pick from 'lodash/pick';
 
 const defaultDebounceMs = 100;
 const defaultBufferFactor = 0.25;
@@ -66,14 +67,22 @@ class ProgressiveLoadingContainer extends Component {
     }
 
     render() {
-        const { children, className, style } = this.props;
+        const { children, style, className, ...props } = this.props;
         const { shouldLoad } = this.state;
+
+        const eventProps = pick(props, [
+            'onMouseDown',
+            'onTouchStart',
+            'onMouseUp',
+            'onTouchEnd',
+        ]);
 
         return (
             <div
                 ref={ref => (this.containerRef = ref)}
                 style={style}
                 className={className}
+                {...eventProps}
             >
                 {shouldLoad && children}
             </div>

--- a/src/components/Item/ProgressiveLoadingContainer.js
+++ b/src/components/Item/ProgressiveLoadingContainer.js
@@ -67,7 +67,7 @@ class ProgressiveLoadingContainer extends Component {
     }
 
     render() {
-        const { children, style, className, ...props } = this.props;
+        const { children, className, style, ...props } = this.props;
         const { shouldLoad } = this.state;
 
         const eventProps = pick(props, [


### PR DESCRIPTION
Fixes https://jira.dhis2.org/browse/DHIS2-8091.

- Not destructuring "debounceMs" and "bufferFactor" from props to avoid unused variables
- Picking only the event props from props to avoid passing the above props to the dom element