### PR TITLE
fix: fall back to old types for visualizations

### DIFF
--- a/src/modules/itemTypes.js
+++ b/src/modules/itemTypes.js
@@ -13,6 +13,7 @@ import NotInterestedIcon from '@material-ui/icons/NotInterested';
 import { getBaseUrl } from './util';
 
 // Item types
+export const VISUALIZATION = 'VISUALIZATION';
 export const REPORT_TABLE = 'REPORT_TABLE';
 export const CHART = 'CHART';
 export const MAP = 'MAP';

--- a/src/reducers/dashboards.js
+++ b/src/reducers/dashboards.js
@@ -9,6 +9,9 @@ import {
     isSpacerType,
     isTextType,
     emptyTextItemContent,
+    REPORT_TABLE,
+    CHART,
+    VISUALIZATION,
 } from '../modules/itemTypes';
 
 export const SET_DASHBOARDS = 'SET_DASHBOARDS';
@@ -168,7 +171,18 @@ export const sGetDashboardsSortedByStarred = state => [
 export const getCustomDashboards = data => {
     const uiItems = items =>
         items.map(item => {
-            const type = isSpacerType(item) ? SPACER : item.type;
+            let type = isSpacerType(item) ? SPACER : item.type;
+
+            // TODO: temporary fix before 2.34 epic branch is merged
+            // if "VISUALIZATION", reset to "REPORT_TABLE" or "CHART"
+            if (type === VISUALIZATION) {
+                type = item.reportTable
+                    ? REPORT_TABLE
+                    : item.chart
+                    ? CHART
+                    : type;
+            }
+
             const text = isTextType(item)
                 ? item.text === emptyTextItemContent
                     ? ''


### PR DESCRIPTION
Pivot tables and charts now get type = VISUALIZATION from the backend. Remapping dashboard item visualizations back to REPORT_TABLE and CHART to make it work until 2.34 epic branch is merged.