### PR TITLE
fix: add title proptype for item header

### DIFF
--- a/src/components/Item/ItemHeader.js
+++ b/src/components/Item/ItemHeader.js
@@ -22,7 +22,7 @@ const ItemHeader = props => {
 ItemHeader.propTypes = {
     actionButtons: PropTypes.node,
     editMode: PropTypes.bool,
-    title: PropTypes.object,
+    title: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
 };
 
 export default ItemHeader;


### PR DESCRIPTION
Currently "title" for ItemHeader has prop type "string", but for visualization items the passed in title is a component -> console errors. Adding "object" as prop type for now to avoid having to refactor the whole item header right now.