### PR TITLE
fix: use the new visualizations api

### DIFF
--- a/src/modules/itemTypes.js
+++ b/src/modules/itemTypes.js
@@ -60,8 +60,6 @@ export const itemTypeMap = {
     },
     [REPORT_TABLE]: {
         id: REPORT_TABLE,
-        /*        endPointName: 'reportTables',
-        propName: 'reportTable', */
         endPointName: 'visualizations',
         propName: 'visualization',
         pluralTitle: i18n.t('Pivot tables'),
@@ -74,8 +72,6 @@ export const itemTypeMap = {
         id: CHART,
         endPointName: 'visualizations',
         propName: 'visualization',
-        /*        endPointName: 'charts',
-        propName: 'chart', */
         pluralTitle: i18n.t('Charts'),
         domainType: DOMAIN_TYPE_AGGREGATE,
         isVisualizationType: true,

--- a/src/modules/itemTypes.js
+++ b/src/modules/itemTypes.js
@@ -60,8 +60,10 @@ export const itemTypeMap = {
     },
     [REPORT_TABLE]: {
         id: REPORT_TABLE,
-        endPointName: 'reportTables',
-        propName: 'reportTable',
+        /*        endPointName: 'reportTables',
+        propName: 'reportTable', */
+        endPointName: 'visualizations',
+        propName: 'visualization',
         pluralTitle: i18n.t('Pivot tables'),
         domainType: DOMAIN_TYPE_AGGREGATE,
         isVisualizationType: true,
@@ -70,8 +72,10 @@ export const itemTypeMap = {
     },
     [CHART]: {
         id: CHART,
-        endPointName: 'charts',
-        propName: 'chart',
+        endPointName: 'visualizations',
+        propName: 'visualization',
+        /*        endPointName: 'charts',
+        propName: 'chart', */
         pluralTitle: i18n.t('Charts'),
         domainType: DOMAIN_TYPE_AGGREGATE,
         isVisualizationType: true,


### PR DESCRIPTION
This updates the Dashboards' API requests to use the new `visualizations` endpoint instead of the old `reportTables` and `charts`.

* Fixes an issue with Gauge legends not displaying properly (caused by a missing prop on the old endpoint)

![legends bug](https://user-images.githubusercontent.com/12590483/75522455-51fe1400-5a0a-11ea-9e40-3a8aed0c42b4.gif)
