### PR TITLE
WIP: fix: do not rerender visualizations unless they have actually changed

### DIFF
--- a/src/actions/currentVisualizationViews.js
+++ b/src/actions/currentVisualizationViews.js
@@ -1,12 +1,4 @@
-import {
-    ADD_CURRENT_VISUALIZATION_VIEW,
-    SET_CURRENT_VISUALIZATION_VIEW,
-} from '../reducers/currentVisualizationViews';
-
-export const acAddCurrentVisualizationView = value => ({
-    type: ADD_CURRENT_VISUALIZATION_VIEW,
-    value,
-});
+import { SET_CURRENT_VISUALIZATION_VIEW } from '../reducers/currentVisualizationViews';
 
 export const acSetCurrentVisualizationView = value => ({
     type: SET_CURRENT_VISUALIZATION_VIEW,

--- a/src/actions/currentVisualizationViews.js
+++ b/src/actions/currentVisualizationViews.js
@@ -1,0 +1,14 @@
+import {
+    ADD_CURRENT_VISUALIZATION_VIEW,
+    SET_CURRENT_VISUALIZATION_VIEW,
+} from '../reducers/currentVisualizationViews';
+
+export const acAddCurrentVisualizationView = value => ({
+    type: ADD_CURRENT_VISUALIZATION_VIEW,
+    value,
+});
+
+export const acSetCurrentVisualizationView = value => ({
+    type: SET_CURRENT_VISUALIZATION_VIEW,
+    value,
+});

--- a/src/actions/selected.js
+++ b/src/actions/selected.js
@@ -4,7 +4,7 @@ import {
     SET_SELECTED_SHOWDESCRIPTION,
 } from '../reducers/selected';
 import { acAddVisualization } from '../actions/visualizations';
-import { acAddCurrentVisualizationView } from '../actions/currentVisualizationViews';
+import { acSetCurrentVisualizationView } from '../actions/currentVisualizationViews';
 import { sGetSelectedIsLoading } from '../reducers/selected';
 import { sGetUserUsername } from '../reducers/user';
 import { getCustomDashboards, sGetDashboardById } from '../reducers/dashboards';
@@ -15,14 +15,7 @@ import { tGetMessages } from '../components/Item/MessagesItem/actions';
 import { acReceivedSnackbarMessage, acCloseSnackbar } from './snackbar';
 import { storePreferredDashboardId } from '../api/localStorage';
 import { loadingDashboardMsg } from '../components/SnackbarMessage/SnackbarMessage';
-import {
-    REPORT_TABLE,
-    CHART,
-    MAP,
-    EVENT_REPORT,
-    EVENT_CHART,
-    MESSAGES,
-} from '../modules/itemTypes';
+import { MESSAGES, isVisualizationType } from '../modules/itemTypes';
 import { extractFavorite } from '../components/Item/VisualizationItem/plugin';
 import { orObject } from '../modules/util';
 
@@ -85,22 +78,19 @@ export const tSetSelectedDashboardById = id => async (dispatch, getState) => {
 
         // add visualizations to store
         customDashboard.dashboardItems.forEach(item => {
-            switch (item.type) {
-                case REPORT_TABLE:
-                case CHART:
-                case MAP:
-                case EVENT_REPORT:
-                case EVENT_CHART:
-                    dispatch(acAddVisualization(extractFavorite(item)));
-                    dispatch(
-                        acAddCurrentVisualizationView(extractFavorite(item))
-                    );
-                    break;
-                case MESSAGES:
-                    dispatch(tGetMessages(id));
-                    break;
-                default:
-                    break;
+            if (isVisualizationType(item)) {
+                const visualization = extractFavorite(item);
+                dispatch(acAddVisualization(visualization));
+                dispatch(
+                    acSetCurrentVisualizationView(
+                        visualization.id,
+                        visualization
+                    )
+                );
+            }
+
+            if (item.type === MESSAGES) {
+                dispatch(tGetMessages(id));
             }
         });
 

--- a/src/actions/selected.js
+++ b/src/actions/selected.js
@@ -4,6 +4,7 @@ import {
     SET_SELECTED_SHOWDESCRIPTION,
 } from '../reducers/selected';
 import { acAddVisualization } from '../actions/visualizations';
+import { acAddCurrentVisualizationView } from '../actions/currentVisualizationViews';
 import { sGetSelectedIsLoading } from '../reducers/selected';
 import { sGetUserUsername } from '../reducers/user';
 import { getCustomDashboards, sGetDashboardById } from '../reducers/dashboards';
@@ -91,6 +92,9 @@ export const tSetSelectedDashboardById = id => async (dispatch, getState) => {
                 case EVENT_REPORT:
                 case EVENT_CHART:
                     dispatch(acAddVisualization(extractFavorite(item)));
+                    dispatch(
+                        acAddCurrentVisualizationView(extractFavorite(item))
+                    );
                     break;
                 case MESSAGES:
                     dispatch(tGetMessages(id));

--- a/src/actions/visualizations.js
+++ b/src/actions/visualizations.js
@@ -1,19 +1,6 @@
-import {
-    ADD_VISUALIZATION,
-    SET_ACTIVE_VISUALIZATION_TYPE,
-} from '../reducers/visualizations';
+import { ADD_VISUALIZATION } from '../reducers/visualizations';
 
 export const acAddVisualization = value => ({
     type: ADD_VISUALIZATION,
     value,
 });
-
-export const acSetActiveVisualizationType = (id, activeType) => {
-    const action = {
-        type: SET_ACTIVE_VISUALIZATION_TYPE,
-        id,
-        activeType,
-    };
-
-    return action;
-};

--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -144,12 +144,6 @@ export class Item extends Component {
         }
         const style = this.getContentStyle();
 
-        // console.log(
-        //     'current',
-        //     currentVisualizationView.name,
-        //     currentVisualizationView.type
-        // );
-
         switch (this.getActiveType()) {
             case VISUALIZATION:
             case CHART:
@@ -190,13 +184,7 @@ export class Item extends Component {
                     // this is the case of a non map AO passed to the maps plugin
                     // due to a visualization type switch in dashboard item
                     // maps plugin takes care of converting the AO to a suitable format
-                    vis = applyFilters(
-                        {
-                            currentVisualizationView,
-                            itemFilters,
-                        },
-                        itemFilters
-                    );
+                    vis = applyFilters(currentVisualizationView, itemFilters);
                 }
 
                 return (
@@ -234,25 +222,29 @@ export class Item extends Component {
         );
     };
 
-    onSelectActiveType = type => {
-        if (type === this.getActiveType()) {
+    onSelectActiveType = newActiveType => {
+        const currentActiveType = this.getActiveType();
+        if (newActiveType === currentActiveType) {
             return;
         }
 
-        pluginManager.unmount(this.props.item, this.getActiveType());
+        pluginManager.unmount(this.props.item, currentActiveType);
 
-        this.props.onSelectActiveType(this.props.visualization.id, type);
+        this.props.onSelectActiveType(
+            this.props.visualization.id,
+            newActiveType
+        );
 
         const visualization = getVisualizationConfig(
             this.props.visualization,
             this.props.item.type,
-            type
+            newActiveType
         );
 
-        this.props.onSelectVisualizationView(
-            this.props.visualization.id,
-            visualization
-        );
+        this.props.onSelectVisualizationView(this.props.visualization.id, {
+            ...visualization,
+            activeType: newActiveType,
+        });
     };
 
     getActiveType = () =>

--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -131,7 +131,6 @@ export class Item extends Component {
             editMode,
             item,
             classes,
-            visualization,
             currentVisualizationView,
         } = this.props;
 
@@ -165,16 +164,18 @@ export class Item extends Component {
                 if (item.type === MAP) {
                     // apply filters only to thematic and event layers
                     // for maps AO
-                    const mapViews = visualization.mapViews.map(obj => {
-                        if (
-                            obj.layer.includes('thematic') ||
-                            obj.layer.includes('event')
-                        ) {
-                            return applyFilters(obj, itemFilters);
-                        }
+                    const mapViews = currentVisualizationView.mapViews.map(
+                        obj => {
+                            if (
+                                obj.layer.includes('thematic') ||
+                                obj.layer.includes('event')
+                            ) {
+                                return applyFilters(obj, itemFilters);
+                            }
 
-                        return obj;
-                    });
+                            return obj;
+                        }
+                    );
 
                     vis = {
                         ...currentVisualizationView,

--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -26,7 +26,6 @@ import {
 
 import { colors } from '@dhis2/ui-core';
 import memoizeOne from '../../../modules/memoizeOne';
-import { getVisualizationConfig } from './plugin';
 
 const HEADER_HEIGHT = 45;
 
@@ -220,7 +219,7 @@ export class Item extends Component {
 
         pluginManager.unmount(this.props.item, currentActiveType);
 
-        const visualization = getVisualizationConfig(
+        const visualization = pluginManager.getVisualizationConfig(
             this.props.visualization,
             this.props.item.type,
             newActiveType

--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -15,10 +15,7 @@ import * as pluginManager from './plugin';
 import { sGetVisualization } from '../../../reducers/visualizations';
 import { sGetCurrentVisualizationView } from '../../../reducers/currentVisualizationViews';
 import { sGetItemFiltersRoot } from '../../../reducers/itemFilters';
-import {
-    acAddVisualization,
-    acSetActiveVisualizationType,
-} from '../../../actions/visualizations';
+import { acAddVisualization } from '../../../actions/visualizations';
 import { acSetCurrentVisualizationView } from '../../../actions/currentVisualizationViews';
 import {
     VISUALIZATION,
@@ -143,7 +140,9 @@ export class Item extends Component {
         }
         const style = this.getContentStyle();
 
-        switch (this.getActiveType()) {
+        const activeType = this.getActiveType();
+
+        switch (activeType) {
             case VISUALIZATION:
             case CHART:
             case REPORT_TABLE: {
@@ -231,11 +230,6 @@ export class Item extends Component {
 
         pluginManager.unmount(this.props.item, currentActiveType);
 
-        this.props.onSelectActiveType(
-            this.props.visualization.id,
-            newActiveType
-        );
-
         const visualization = getVisualizationConfig(
             this.props.visualization,
             this.props.item.type,
@@ -249,7 +243,9 @@ export class Item extends Component {
     };
 
     getActiveType = () =>
-        this.props.visualization.activeType || this.props.item.type;
+        (this.props.currentVisualizationView &&
+            this.props.currentVisualizationView.activeType) ||
+        this.props.item.type;
 
     pluginIsAvailable = () =>
         pluginManager.pluginIsAvailable(
@@ -315,7 +311,6 @@ Item.propTypes = {
     item: PropTypes.object,
     itemFilters: PropTypes.object,
     visualization: PropTypes.object,
-    onSelectActiveType: PropTypes.func,
     onSelectVisualizationView: PropTypes.func,
     onToggleItemExpanded: PropTypes.func,
     onVisualizationLoaded: PropTypes.func,
@@ -344,8 +339,6 @@ const mapStateToProps = (state, ownProps) => ({
 const mapDispatchToProps = dispatch => ({
     onVisualizationLoaded: visualization =>
         dispatch(acAddVisualization(visualization)),
-    onSelectActiveType: (id, type) =>
-        dispatch(acSetActiveVisualizationType(id, type)),
     onSelectVisualizationView: (id, visualization) => {
         dispatch(acSetCurrentVisualizationView({ id, visualization }));
     },

--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -108,10 +108,12 @@ export class Item extends Component {
     }
 
     async componentDidMount() {
-        const vis = await pluginManager.fetch(this.props.item);
-        // TODO do not call fetch on the pluginManager, do it here as the manager will eventually be removed...
-        this.props.onVisualizationLoaded(vis);
-        this.props.onSelectVisualizationView(this.props.visualization.id, vis);
+        const visualization = await pluginManager.fetch(this.props.item);
+        this.props.onVisualizationLoaded(visualization);
+        this.props.onSelectVisualizationView(
+            this.props.visualization.id,
+            visualization
+        );
 
         this.setState({
             configLoaded: true,
@@ -139,10 +141,9 @@ export class Item extends Component {
             );
         }
         const style = this.getContentStyle();
+        const props = { itemFilters, editMode, item, classes, style };
 
-        const activeType = this.getActiveType();
-
-        switch (activeType) {
+        switch (this.getActiveType()) {
             case VISUALIZATION:
             case CHART:
             case REPORT_TABLE: {
@@ -159,10 +160,9 @@ export class Item extends Component {
                 );
             }
             case MAP: {
-                let vis = currentVisualizationView;
+                let visualization = currentVisualizationView;
                 if (item.type === MAP) {
-                    // apply filters only to thematic and event layers
-                    // for maps AO
+                    // apply filters only to thematic and event layers for map
                     const mapViews = currentVisualizationView.mapViews.map(
                         obj => {
                             if (
@@ -176,40 +176,30 @@ export class Item extends Component {
                         }
                     );
 
-                    vis = {
+                    visualization = {
                         ...currentVisualizationView,
                         mapViews,
                     };
                 } else {
-                    // this is the case of a non map AO passed to the maps plugin
-                    // due to a visualization type switch in dashboard item
-                    // maps plugin takes care of converting the AO to a suitable format
-                    vis = applyFilters(currentVisualizationView, itemFilters);
+                    // Non-map AO passed to the maps plugin. Maps plugin will handle it
+                    visualization = applyFilters(
+                        currentVisualizationView,
+                        itemFilters
+                    );
                 }
 
                 return (
-                    <DefaultPlugin
-                        visualization={vis}
-                        itemFilters={itemFilters}
-                        item={item}
-                        editMode={editMode}
-                        classes={classes}
-                        style={style}
-                    />
+                    <DefaultPlugin {...props} visualization={visualization} />
                 );
             }
             default: {
-                const vis = applyFilters(currentVisualizationView, itemFilters);
+                const visualization = applyFilters(
+                    currentVisualizationView,
+                    itemFilters
+                );
 
                 return (
-                    <DefaultPlugin
-                        visualization={vis}
-                        itemFilters={itemFilters}
-                        item={item}
-                        editMode={editMode}
-                        classes={classes}
-                        style={style}
-                    />
+                    <DefaultPlugin {...props} visualization={visualization} />
                 );
             }
         }

--- a/src/components/Item/VisualizationItem/__tests__/Item.spec.js
+++ b/src/components/Item/VisualizationItem/__tests__/Item.spec.js
@@ -50,6 +50,13 @@ describe('VisualizationItem/Item', () => {
                 columns: [],
                 filters: [],
             },
+            currentVisualizationView: {
+                name: 'vis name',
+                description: 'vis description',
+                rows: [],
+                columns: [],
+                filters: [],
+            },
             onToggleItemExpanded: jest.fn(),
             onVisualizationLoaded: jest.fn(),
         };
@@ -64,7 +71,7 @@ describe('VisualizationItem/Item', () => {
         };
 
         const expectedConfig = {
-            ...props.visualization,
+            ...props.currentVisualizationView,
             filters: [
                 {
                     dimension: 'brilliance',
@@ -91,7 +98,7 @@ describe('VisualizationItem/Item', () => {
         };
 
         const expectedConfig = {
-            ...props.visualization,
+            ...props.currentVisualizationView,
             filters: [
                 {
                     dimension: 'brilliance',
@@ -117,7 +124,7 @@ describe('VisualizationItem/Item', () => {
             name: 'Test evchart',
         };
         const expectedConfig = {
-            ...props.visualization,
+            ...props.currentVisualizationView,
             filters: [
                 {
                     dimension: 'brilliance',

--- a/src/components/Item/VisualizationItem/__tests__/__snapshots__/Item.spec.js.snap
+++ b/src/components/Item/VisualizationItem/__tests__/__snapshots__/Item.spec.js.snap
@@ -5,6 +5,15 @@ ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Item
     classes={Object {}}
+    currentVisualizationView={
+      Object {
+        "columns": Array [],
+        "description": "vis description",
+        "filters": Array [],
+        "name": "vis name",
+        "rows": Array [],
+      }
+    }
     editMode={false}
     item={
       Object {

--- a/src/modules/itemTypes.js
+++ b/src/modules/itemTypes.js
@@ -56,6 +56,7 @@ export const itemTypeMap = {
         pluralTitle: i18n.t('Visualizations'),
         appUrl: id => `dhis-web-data-visualizer/#/${id}`,
         appName: 'Data Visualizer',
+        isVisualizationType: true,
         defaultItemCount: 10,
     },
     [REPORT_TABLE]: {

--- a/src/modules/itemTypes.js
+++ b/src/modules/itemTypes.js
@@ -60,7 +60,7 @@ export const itemTypeMap = {
     },
     [REPORT_TABLE]: {
         id: REPORT_TABLE,
-        endPointName: 'reportTables',
+        endPointName: 'visualizations',
         propName: 'reportTable',
         pluralTitle: i18n.t('Pivot tables'),
         domainType: DOMAIN_TYPE_AGGREGATE,
@@ -70,7 +70,7 @@ export const itemTypeMap = {
     },
     [CHART]: {
         id: CHART,
-        endPointName: 'charts',
+        endPointName: 'visualizations',
         propName: 'chart',
         pluralTitle: i18n.t('Charts'),
         domainType: DOMAIN_TYPE_AGGREGATE,

--- a/src/reducers/__tests__/currentVisualizationViews.spec.js
+++ b/src/reducers/__tests__/currentVisualizationViews.spec.js
@@ -27,7 +27,7 @@ describe('current vis reducer', () => {
         };
 
         const currentState = state;
-        const expectedState = { [visId]: newVis };
+        const expectedState = { ...state, [visId]: newVis };
         const actualState = reducer(currentState, action);
 
         expect(actualState).toEqual(expectedState);

--- a/src/reducers/__tests__/currentVisualizationViews.spec.js
+++ b/src/reducers/__tests__/currentVisualizationViews.spec.js
@@ -1,5 +1,5 @@
 import reducer, {
-    // ADD_CURRENT_VISUALIZATION_VIEW,
+    ADD_CURRENT_VISUALIZATION_VIEW,
     SET_CURRENT_VISUALIZATION_VIEW,
 } from '../currentVisualizationViews';
 
@@ -20,7 +20,7 @@ describe('current vis reducer', () => {
         pinkie: { name: 'pinkie pie', type: 'SINGLE_VALUE' },
     };
 
-    it('should update a visualization with current vis (SET_CURRENT_VISUALIZATION_VIEW)', () => {
+    it('updates a visualization with current vis (SET_CURRENT_VISUALIZATION_VIEW)', () => {
         const action = {
             type: SET_CURRENT_VISUALIZATION_VIEW,
             value: { id: visId, visualization: newVis },

--- a/src/reducers/__tests__/currentVisualizationViews.spec.js
+++ b/src/reducers/__tests__/currentVisualizationViews.spec.js
@@ -1,0 +1,35 @@
+import reducer, {
+    // ADD_CURRENT_VISUALIZATION_VIEW,
+    SET_CURRENT_VISUALIZATION_VIEW,
+} from '../currentVisualizationViews';
+
+describe('current vis reducer', () => {
+    const visId = 'rainbow';
+    const visualization = {
+        name: 'rainbow dash',
+        type: 'LINE',
+    };
+
+    const newVis = {
+        name: 'rainbow dash',
+        type: 'PIVOT',
+    };
+
+    const state = {
+        [visId]: visualization,
+        pinkie: { name: 'pinkie pie', type: 'SINGLE_VALUE' },
+    };
+
+    it('should update a visualization with current vis (SET_CURRENT_VISUALIZATION_VIEW)', () => {
+        const action = {
+            type: SET_CURRENT_VISUALIZATION_VIEW,
+            value: { id: visId, visualization: newVis },
+        };
+
+        const currentState = state;
+        const expectedState = { [visId]: newVis };
+        const actualState = reducer(currentState, action);
+
+        expect(actualState).toEqual(expectedState);
+    });
+});

--- a/src/reducers/__tests__/visualizations.spec.js
+++ b/src/reducers/__tests__/visualizations.spec.js
@@ -1,28 +1,16 @@
 import reducer, {
     DEFAULT_STATE_VISUALIZATIONS,
     ADD_VISUALIZATION,
-    SET_ACTIVE_VISUALIZATION_TYPE,
 } from '../visualizations';
 
 describe('visualizations reducer', () => {
-    const activeType = 'CHART';
-
     const visualization = {
         id: 'abc',
         name: 'funny name',
     };
 
-    const visualizationWithActiveType = {
-        ...visualization,
-        activeType,
-    };
-
     const state = {
         [visualization.id]: visualization,
-    };
-
-    const stateWithActiveType = {
-        [visualization.id]: visualizationWithActiveType,
     };
 
     it('should return the default state', () => {
@@ -40,33 +28,6 @@ describe('visualizations reducer', () => {
 
         const actualState = reducer(DEFAULT_STATE_VISUALIZATIONS, action);
         const expectedState = state;
-
-        expect(actualState).toEqual(expectedState);
-    });
-
-    it('should update a visualization with activeType (SET_ACTIVE_VISUALIZATION_TYPE)', () => {
-        const action = {
-            type: SET_ACTIVE_VISUALIZATION_TYPE,
-            id: visualization.id,
-            activeType,
-        };
-
-        const currentState = state;
-        const expectedState = stateWithActiveType;
-        const actualState = reducer(currentState, action);
-
-        expect(actualState).toEqual(expectedState);
-    });
-
-    it('should update a visualization with removed activeType (SET_ACTIVE_VISUALIZATION_TYPE)', () => {
-        const action = {
-            type: SET_ACTIVE_VISUALIZATION_TYPE,
-            id: visualization.id,
-        };
-
-        const currentState = stateWithActiveType;
-        const expectedState = state;
-        const actualState = reducer(currentState, action);
 
         expect(actualState).toEqual(expectedState);
     });

--- a/src/reducers/currentVisualizationViews.js
+++ b/src/reducers/currentVisualizationViews.js
@@ -3,7 +3,6 @@ import objectClean from 'd2-utilizr/lib/objectClean';
 
 /** @module reducers/currentVisualizationViews */
 
-export const ADD_CURRENT_VISUALIZATION_VIEW = 'ADD_CURRENT_VISUALIZATION_VIEW';
 export const SET_CURRENT_VISUALIZATION_VIEW = 'SET_CURRENT_VISUALIZATION_VIEW';
 
 export const DEFAULT_STATE = {};
@@ -12,18 +11,6 @@ const isEmpty = p => p === undefined || p === null;
 
 export default (state = DEFAULT_STATE, action) => {
     switch (action.type) {
-        case ADD_CURRENT_VISUALIZATION_VIEW: {
-            return {
-                ...state,
-                [action.value.id]: objectClean(
-                    {
-                        ...orObject(state[action.value.id]),
-                        ...action.value,
-                    },
-                    isEmpty
-                ),
-            };
-        }
         case SET_CURRENT_VISUALIZATION_VIEW: {
             return {
                 ...state,

--- a/src/reducers/currentVisualizationViews.js
+++ b/src/reducers/currentVisualizationViews.js
@@ -1,0 +1,51 @@
+import { orObject } from '../modules/util';
+import objectClean from 'd2-utilizr/lib/objectClean';
+
+/** @module reducers/currentVisualizationViews */
+
+export const ADD_CURRENT_VISUALIZATION_VIEW = 'ADD_CURRENT_VISUALIZATION_VIEW';
+export const SET_CURRENT_VISUALIZATION_VIEW = 'SET_CURRENT_VISUALIZATION_VIEW';
+
+export const DEFAULT_STATE = {};
+
+const isEmpty = p => p === undefined || p === null;
+
+export default (state = DEFAULT_STATE, action) => {
+    switch (action.type) {
+        case ADD_CURRENT_VISUALIZATION_VIEW: {
+            return {
+                ...state,
+                [action.value.id]: objectClean(
+                    {
+                        ...orObject(state[action.value.id]),
+                        ...action.value,
+                    },
+                    isEmpty
+                ),
+            };
+        }
+        case SET_CURRENT_VISUALIZATION_VIEW: {
+            return {
+                ...state,
+                [action.value.id]: objectClean(
+                    {
+                        ...orObject(action.value.visualization),
+                    },
+                    isEmpty
+                ),
+            };
+        }
+
+        default:
+            return state;
+    }
+};
+
+// root selector
+export const sGetCurrentVisualizationViewsRoot = state =>
+    state.currentVisualizationViews;
+
+// selectors level 1
+export const sGetCurrentVisualizationView = (state, id) => {
+    return sGetCurrentVisualizationViewsRoot(state)[id];
+};

--- a/src/reducers/currentVisualizationViews.js
+++ b/src/reducers/currentVisualizationViews.js
@@ -46,6 +46,5 @@ export const sGetCurrentVisualizationViewsRoot = state =>
     state.currentVisualizationViews;
 
 // selectors level 1
-export const sGetCurrentVisualizationView = (state, id) => {
-    return sGetCurrentVisualizationViewsRoot(state)[id];
-};
+export const sGetCurrentVisualizationView = (state, id) =>
+    sGetCurrentVisualizationViewsRoot(state)[id];

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -11,6 +11,7 @@ import dashboardsFilter, {
 } from './dashboardsFilter';
 import controlBar from './controlBar';
 import visualizations from './visualizations';
+import currentVisualizationViews from './currentVisualizationViews';
 import editDashboard from './editDashboard';
 import messages from './messages';
 import user from './user';
@@ -32,6 +33,7 @@ export default combineReducers({
     dashboardsFilter,
     controlBar,
     visualizations,
+    currentVisualizationViews,
     messages,
     user,
     editDashboard,

--- a/src/reducers/visualizations.js
+++ b/src/reducers/visualizations.js
@@ -4,7 +4,6 @@ import objectClean from 'd2-utilizr/lib/objectClean';
 /** @module reducers/visualizations */
 
 export const ADD_VISUALIZATION = 'ADD_VISUALIZATION';
-export const SET_ACTIVE_VISUALIZATION_TYPE = 'SET_ACTIVE_VISUALIZATION_TYPE';
 
 export const DEFAULT_STATE_VISUALIZATIONS = {};
 
@@ -24,18 +23,7 @@ export default (state = DEFAULT_STATE_VISUALIZATIONS, action) => {
                 ),
             };
         }
-        case SET_ACTIVE_VISUALIZATION_TYPE: {
-            return {
-                ...state,
-                [action.id]: objectClean(
-                    {
-                        ...orObject(state[action.id]),
-                        activeType: action.activeType,
-                    },
-                    isEmpty
-                ),
-            };
-        }
+
         default:
             return state;
     }


### PR DESCRIPTION
Fixes issue where all charts and tables on the dashboard were rerendering when show/hiding interpretations for one item, or when draggin/resizing an item in edit mode.

A likely reason for this is the useEffect hook in the Visualizer plugin, where, most likely there is a shallow compare of properties (i.e., the visualization property). This object was being considered different than the previous one, so the visualization was rerendered.

The solution here is to store the current view in the redux store, so that the same object is passed to the plugin, unless the view has changed (e.g. toggling to chart/map).  The store now looks a little more like the DV store, in that there is the original visualization, and there is the current view of the visualization.