### PR TITLE
fix: removes the 'view as' menu from gauge and pie (DHIS2-8455)

### DIFF
--- a/src/components/Item/VisualizationItem/ItemHeaderButtons.js
+++ b/src/components/Item/VisualizationItem/ItemHeaderButtons.js
@@ -1,7 +1,12 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
-import { isSingleValue, isYearOverYear } from '@dhis2/analytics';
+import {
+    isSingleValue,
+    isYearOverYear,
+    VIS_TYPE_GAUGE,
+    VIS_TYPE_PIE,
+} from '@dhis2/analytics';
 import { Button, Menu, MenuItem, Divider, colors } from '@dhis2/ui-core';
 import i18n from '@dhis2/d2-i18n';
 import Popover from '@material-ui/core/Popover';
@@ -61,7 +66,11 @@ const ItemHeaderButtons = props => {
     const handleClose = () => setAnchorEl(null);
 
     const type = visualization.type || item.type;
-    const canViewAs = !isSingleValue(type) && !isYearOverYear(type);
+    const canViewAs =
+        !isSingleValue(type) &&
+        !isYearOverYear(type) &&
+        type != VIS_TYPE_GAUGE &&
+        type != VIS_TYPE_PIE;
 
     const interpretationMenuLabel = props.activeFooter
         ? i18n.t(`Hide interpretations and details`)

--- a/src/components/Item/VisualizationItem/ItemHeaderButtons.js
+++ b/src/components/Item/VisualizationItem/ItemHeaderButtons.js
@@ -69,8 +69,8 @@ const ItemHeaderButtons = props => {
     const canViewAs =
         !isSingleValue(type) &&
         !isYearOverYear(type) &&
-        type != VIS_TYPE_GAUGE &&
-        type != VIS_TYPE_PIE;
+        type !== VIS_TYPE_GAUGE &&
+        type !== VIS_TYPE_PIE;
 
     const interpretationMenuLabel = props.activeFooter
         ? i18n.t(`Hide interpretations and details`)

--- a/src/components/Item/VisualizationItem/assets/icons.js
+++ b/src/components/Item/VisualizationItem/assets/icons.js
@@ -20,7 +20,7 @@ export const SpeechBubble = () => (
         viewBox="0 0 20 20"
         width="20"
         xmlns="http://www.w3.org/2000/svg"
-        style={{ margin: '3px 2px 0 2px' }}
+        style={{ margin: '3px 2px 0 2px' }} // Temporary fix for the misaligned icon, should be removed once the icon is replaced
     >
         <path
             d="m20 2h-16c-1.1 0-1.99.9-1.99 2l-.01 18 4-4h14c1.1 0 2-.9 2-2v-12c0-1.1-.9-2-2-2zm-2 12h-12v-2h12zm0-3h-12v-2h12zm0-3h-12v-2h12z"

--- a/src/components/Item/VisualizationItem/assets/icons.js
+++ b/src/components/Item/VisualizationItem/assets/icons.js
@@ -20,6 +20,7 @@ export const SpeechBubble = () => (
         viewBox="0 0 20 20"
         width="20"
         xmlns="http://www.w3.org/2000/svg"
+        style={{ margin: '3px 2px 0 2px' }}
     >
         <path
             d="m20 2h-16c-1.1 0-1.99.9-1.99 2l-.01 18 4-4h14c1.1 0 2-.9 2-2v-12c0-1.1-.9-2-2-2zm-2 12h-12v-2h12zm0-3h-12v-2h12zm0-3h-12v-2h12z"


### PR DESCRIPTION
**Background:** There's an issue with opening Gauge and Pie (as well as Single Value) charts as a pivot table, as these visualizations don't have category/rows dimensions, which causes 'view as table' to crash. https://jira.dhis2.org/browse/DHIS2-8455

-----------------

**Fix:** Puts Gauge and Pie on the list of visualization types that shouldn't display the 'View as' menu options, together with SV and YoY
Also updates the interpretations icon with a tiny css change to fix its' misalignment. This will be removed once the icon is replaced.

-----------------

Example of visualizations without the menu options present:

Gauge:
![image](https://user-images.githubusercontent.com/12590483/75998288-df58d100-5f00-11ea-9225-c8e4f7a05ba8.png)

Pie:
![image](https://user-images.githubusercontent.com/12590483/75998355-00212680-5f01-11ea-8584-20a1ad3d7d0f.png)

-----------------

Icon alignment:

![image](https://user-images.githubusercontent.com/12590483/76067733-2b068b80-5f90-11ea-97bf-46ba37811129.png)
