### PR TITLE
fix: set font-weight to 700 according to spec

### DIFF
--- a/src/components/Item/styles/ItemHeader.module.css
+++ b/src/components/Item/styles/ItemHeader.module.css
@@ -10,7 +10,7 @@
 }
 
 .itemTitle {
-    font-weight: 500;
+    font-weight: 700;
     color: var(--colors-grey800);
     font-size: 14px;
     line-height: 19px;


### PR DESCRIPTION
Change the dashboard item header title font weight from 500 to 700 according to the spec.

Before:
![Screenshot from 2020-03-10 11-45-54](https://user-images.githubusercontent.com/1010094/76305085-c6676b80-62c4-11ea-91b9-37e2e13d4ac3.png)

After:
![Screenshot from 2020-03-10 11-45-37](https://user-images.githubusercontent.com/1010094/76305092-cb2c1f80-62c4-11ea-8e45-27dba43d0822.png)
