### PR TITLE
fix: upgrade d2 to 31.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "@dhis2/ui-widgets": "^2.0.5",
         "@material-ui/core": "^3.9.2",
         "@material-ui/icons": "^3.0.2",
-        "d2": "^31.6.0",
+        "d2": "^31.8.1",
         "d2-utilizr": "^0.2.16",
         "i18next": "^15.0.6",
         "lodash": "^4.17.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4274,7 +4274,7 @@ d2-utilizr@^0.2.15, d2-utilizr@^0.2.16:
     lodash.isset "^4.3.0"
     lodash.isstring "^4.0.1"
 
-d2@^31.6.0:
+d2@^31.8.1:
   version "31.8.1"
   resolved "https://registry.yarnpkg.com/d2/-/d2-31.8.1.tgz#017372001f9c8d3379a74c71c0382c98e9d2fc26"
   integrity sha512-UpS2gv3DS4Bg7MrQTMNkYv5cXJ0k9jsujgw/p4Ex+el3gzslTf7fTH2n4gIZt42+l1tKmrs/R7yiJPov5Cax3w==


### PR DESCRIPTION
Not much of a change here. Dashboards was already using the latest d2. But now it is official in package.json