### PR TITLE
fix: calculate item height accounting for long title [DHIS2-8492]

### DIFF
--- a/src/components/Item/ItemHeader.js
+++ b/src/components/Item/ItemHeader.js
@@ -8,6 +8,9 @@ import DeleteItemButton from './DeleteItemButton';
 
 import classes from './styles/ItemHeader.module.css';
 
+// This is the margin-top + margin-bottom defined in the css file
+export const HEADER_MARGIN_HEIGHT = 12;
+
 const ItemHeader = props => {
     const {
         title,
@@ -15,12 +18,13 @@ const ItemHeader = props => {
         actionButtons,
         itemId,
         acRemoveDashboardItem,
+        forwardedRef,
     } = props;
 
     const handleDeleteItem = () => acRemoveDashboardItem(itemId);
 
     return (
-        <div className={classes.itemHeaderWrap}>
+        <div className={classes.itemHeaderWrap} ref={forwardedRef}>
             <p className={classes.itemTitle}>{title}</p>
             {editMode ? (
                 <div className={classes.itemActionsWrap}>
@@ -41,8 +45,13 @@ ItemHeader.propTypes = {
     acRemoveDashboardItem: PropTypes.func,
     actionButtons: PropTypes.node,
     editMode: PropTypes.bool,
+    forwardedRef: PropTypes.object,
     itemId: PropTypes.string,
     title: PropTypes.string,
+};
+
+ItemHeader.defaultProps = {
+    forwardedRef: {},
 };
 
 const mapStateToProps = state => ({
@@ -53,7 +62,15 @@ const mapDispatchToProps = {
     acRemoveDashboardItem,
 };
 
-export default connect(
+const ConnectedItemHeader = connect(
     mapStateToProps,
     mapDispatchToProps
 )(ItemHeader);
+
+// TODO this is a false positive that is fixed in eslint-plugin-react v7.15
+// github.com/yannickcr/eslint-plugin-react/blob/master/CHANGELOG.md
+/* eslint-disable react/display-name */
+export default React.forwardRef((props, ref) => (
+    <ConnectedItemHeader {...props} forwardedRef={ref} />
+));
+/* eslint-enable react/display-name */

--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -8,7 +8,7 @@ import i18n from '@dhis2/d2-i18n';
 
 import DefaultPlugin from './DefaultPlugin';
 import FatalErrorBoundary from './FatalErrorBoundary';
-import ItemHeader from '../ItemHeader';
+import ItemHeader, { HEADER_MARGIN_HEIGHT } from '../ItemHeader';
 import ItemHeaderButtons from './ItemHeaderButtons';
 import ItemFooter from './ItemFooter';
 import * as pluginManager from './plugin';
@@ -29,8 +29,6 @@ import memoizeOne from '../../../modules/memoizeOne';
 import { colors } from '@dhis2/ui-core';
 import { getVisualizationConfig } from './plugin';
 import LoadingMask from './LoadingMask';
-
-const HEADER_HEIGHT = 45;
 
 const styles = {
     icon: {
@@ -76,12 +74,15 @@ export class Item extends Component {
         this.d2 = context.d2;
 
         this.contentRef = React.createRef();
+        this.headerRef = React.createRef();
 
         this.memoizedApplyFilters = memoizeOne(this.applyFilters);
 
         this.memoizedGetVisualizationConfig = memoizeOne(
             getVisualizationConfig
         );
+
+        this.memoizedGetContentStyle = memoizeOne(this.getContentStyle);
     }
 
     async componentDidMount() {
@@ -171,7 +172,11 @@ export class Item extends Component {
         const props = {
             ...this.props,
             visualization,
-            style: this.getContentStyle(),
+            style: this.memoizedGetContentStyle(
+                this.props.item.originalHeight,
+                this.headerRef.current.clientHeight,
+                this.contentRef ? this.contentRef.offsetHeight : null
+            ),
         };
 
         switch (activeType) {
@@ -275,19 +280,16 @@ export class Item extends Component {
             this.props.visualization
         );
 
-    getContentStyle = () => {
-        const { item, editMode } = this.props;
-        const PADDING_BOTTOM = 4;
+    getContentStyle = (originalHeight, headerHeight, offsetHeight) => {
+        const height = originalHeight - headerHeight - HEADER_MARGIN_HEIGHT;
 
-        return !editMode
-            ? {
-                  height: item.originalHeight - HEADER_HEIGHT - PADDING_BOTTOM,
-              }
-            : {
-                  height: this.contentRef
-                      ? this.contentRef.offsetHeight
-                      : item.originalHeight - HEADER_HEIGHT - PADDING_BOTTOM,
-              };
+        if (!this.props.editMode) {
+            return { height };
+        }
+
+        return {
+            height: offsetHeight || height,
+        };
     };
 
     render() {
@@ -312,6 +314,7 @@ export class Item extends Component {
                     title={pluginManager.getName(item)}
                     itemId={item.id}
                     actionButtons={actionButtons}
+                    ref={this.headerRef}
                 />
                 <FatalErrorBoundary>
                     <div

--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -280,15 +280,12 @@ export class Item extends Component {
             this.props.visualization
         );
 
-    getContentStyle = (originalHeight, headerHeight, offsetHeight) => {
-        const height = originalHeight - headerHeight - HEADER_MARGIN_HEIGHT;
-
-        if (!this.props.editMode) {
-            return { height };
-        }
+    getContentStyle = (originalHeight, headerHeight, measuredHeight) => {
+        const calculatedHeight =
+            originalHeight - headerHeight - HEADER_MARGIN_HEIGHT;
 
         return {
-            height: offsetHeight || height,
+            height: measuredHeight || calculatedHeight,
         };
     };
 

--- a/src/components/Item/VisualizationItem/__tests__/Item.spec.js
+++ b/src/components/Item/VisualizationItem/__tests__/Item.spec.js
@@ -23,6 +23,8 @@ jest.mock('../plugin', () => {
     };
 });
 
+const mockHeaderRef = { clientHeight: 50 };
+
 describe('VisualizationItem/Item', () => {
     let props;
     let shallowItem;
@@ -75,6 +77,8 @@ describe('VisualizationItem/Item', () => {
 
         const component = canvas();
 
+        component.instance().headerRef.current = mockHeaderRef;
+
         component.setState({ configLoaded: true });
 
         const visPlugin = component.find(VisualizationPlugin);
@@ -101,6 +105,7 @@ describe('VisualizationItem/Item', () => {
         };
 
         const component = canvas();
+        component.instance().headerRef.current = mockHeaderRef;
 
         component.setState({ configLoaded: true });
 
@@ -129,6 +134,7 @@ describe('VisualizationItem/Item', () => {
         expect(canvas()).toMatchSnapshot();
 
         const component = canvas();
+        component.instance().headerRef.current = mockHeaderRef;
 
         component.setState({ configLoaded: true });
 

--- a/src/components/Item/VisualizationItem/__tests__/__snapshots__/Item.spec.js.snap
+++ b/src/components/Item/VisualizationItem/__tests__/__snapshots__/Item.spec.js.snap
@@ -53,7 +53,7 @@ ShallowWrapper {
     "nodeType": "function",
     "props": Object {
       "children": Array [
-        <Connect(ItemHeader)
+        <ForwardRef
           actionButtons={
             <ItemHeaderButtons
               activeFooter={false}
@@ -97,7 +97,7 @@ ShallowWrapper {
       Object {
         "instance": null,
         "key": undefined,
-        "nodeType": "class",
+        "nodeType": "function",
         "props": Object {
           "actionButtons": <ItemHeaderButtons
             activeFooter={false}
@@ -128,9 +128,14 @@ ShallowWrapper {
           "itemId": undefined,
           "title": "rainbow",
         },
-        "ref": null,
+        "ref": Object {
+          "current": null,
+        },
         "rendered": null,
-        "type": [Function],
+        "type": Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "render": [Function],
+        },
       },
       Object {
         "instance": null,
@@ -167,7 +172,7 @@ ShallowWrapper {
       "nodeType": "function",
       "props": Object {
         "children": Array [
-          <Connect(ItemHeader)
+          <ForwardRef
             actionButtons={
               <ItemHeaderButtons
                 activeFooter={false}
@@ -211,7 +216,7 @@ ShallowWrapper {
         Object {
           "instance": null,
           "key": undefined,
-          "nodeType": "class",
+          "nodeType": "function",
           "props": Object {
             "actionButtons": <ItemHeaderButtons
               activeFooter={false}
@@ -242,9 +247,14 @@ ShallowWrapper {
             "itemId": undefined,
             "title": "rainbow",
           },
-          "ref": null,
+          "ref": Object {
+            "current": null,
+          },
           "rendered": null,
-          "type": [Function],
+          "type": Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "render": [Function],
+          },
         },
         Object {
           "instance": null,


### PR DESCRIPTION
fixes: https://jira.dhis2.org/browse/DHIS2-8492

Calculate the height of the item based on the header height - which is no longer constant since items now support wrapped titles.

This calculation is the backup value incase the measured height of the chart is not available right away, as in view mode.

In addition, fn getContentStyle was memoized to reduce chart rerenders when items are moved in edit mode.

Before (notice the chart legend is not shown at the bottom):

![image](https://user-images.githubusercontent.com/6113918/77008091-bb46b800-6922-11ea-88e7-eca7edbab717.png)

Fixed:

![image](https://user-images.githubusercontent.com/6113918/77008128-d1ed0f00-6922-11ea-8b58-f5526db03632.png)



