### PR TITLE
chore: use node lts version in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-    - '8'
+    - 'lts/*'
 env:
     global:
         - NODE_OPTIONS=--max_old_space_size=8192


### PR DESCRIPTION
Use the recommended version of node when building