### PR TITLE
refactor: consolidate item conversion functionality [TECH-335]

### DIFF
--- a/src/actions/editDashboard.js
+++ b/src/actions/editDashboard.js
@@ -15,13 +15,8 @@ import { sGetEditDashboardRoot } from '../reducers/editDashboard';
 import { updateDashboard, postDashboard } from '../api/editDashboard';
 import { tSetSelectedDashboardById } from '../actions/selected';
 import { NEW_ITEM_SHAPE } from '../components/ItemGrid/gridUtil';
-import {
-    itemTypeMap,
-    isSpacerType,
-    TEXT,
-    emptyTextItemContent,
-    isTextType,
-} from '../modules/itemTypes';
+import { itemTypeMap } from '../modules/itemTypes';
+import { convertUiItemsToBackend } from '../modules/uiBackendItemConverter';
 
 const onError = error => {
     console.log('Error (Saving Dashboard): ', error);
@@ -96,23 +91,9 @@ export const acRemoveDashboardItem = value => ({
 export const tSaveDashboard = () => async (dispatch, getState) => {
     const dashboard = sGetEditDashboardRoot(getState());
 
-    const dashboardItems = dashboard.dashboardItems.map(item => {
-        const text = isTextType(item)
-            ? item.text || emptyTextItemContent
-            : null;
-
-        const type = isSpacerType(item) ? TEXT : item.type;
-
-        return {
-            ...item,
-            ...(text ? { text } : {}),
-            type,
-        };
-    });
-
     const dashboardToSave = {
         ...dashboard,
-        dashboardItems,
+        dashboardItems: convertUiItemsToBackend(dashboard.dashboardItems),
     };
 
     try {

--- a/src/components/ItemSelector/selectableItems.js
+++ b/src/components/ItemSelector/selectableItems.js
@@ -1,6 +1,5 @@
 import i18n from '@dhis2/d2-i18n';
 import {
-    spacerContent,
     VISUALIZATION,
     MAP,
     EVENT_CHART,
@@ -13,6 +12,7 @@ import {
     TEXT,
     SPACER,
 } from '../../modules/itemTypes';
+// import { spacerContent } from '../../modules/uiBackendItemConverter';
 
 export const singleItems = [
     {
@@ -32,7 +32,7 @@ export const singleItems = [
             {
                 type: SPACER,
                 name: i18n.t('Spacer'),
-                content: spacerContent,
+                content: '',
             },
         ],
     },

--- a/src/components/ItemSelector/selectableItems.js
+++ b/src/components/ItemSelector/selectableItems.js
@@ -12,7 +12,6 @@ import {
     TEXT,
     SPACER,
 } from '../../modules/itemTypes';
-// import { spacerContent } from '../../modules/uiBackendItemConverter';
 
 export const singleItems = [
     {

--- a/src/modules/__tests__/uiBackendItemConverter.spec.js
+++ b/src/modules/__tests__/uiBackendItemConverter.spec.js
@@ -1,0 +1,102 @@
+import {
+    convertBackendItemsToUi,
+    convertUiItemsToBackend,
+    spacerContent,
+    emptyTextItemContent,
+} from '../uiBackendItemConverter';
+import { VISUALIZATION, SPACER, TEXT } from '../itemTypes';
+
+const visualizationItem = {
+    id: 'visualization item',
+    type: VISUALIZATION,
+    visualization: {},
+};
+
+describe('convertUiItemsToBackend', () => {
+    it('sets content for SPACER type', () => {
+        const uiItems = [
+            {
+                id: 'spacer item',
+                type: SPACER,
+            },
+        ];
+        expect(convertUiItemsToBackend(uiItems)).toMatchObject([
+            {
+                id: 'spacer item',
+                type: SPACER,
+                text: spacerContent,
+            },
+        ]);
+    });
+
+    it('sets empty content for empty TEXT type', () => {
+        const uiItems = [
+            {
+                id: 'empty text item',
+                type: TEXT,
+                text: '',
+            },
+        ];
+        expect(convertUiItemsToBackend(uiItems)).toMatchObject([
+            {
+                id: 'empty text item',
+                type: TEXT,
+                text: emptyTextItemContent,
+            },
+        ]);
+    });
+
+    it('does not add text property to VISUALIZATION type', () => {
+        const uiItems = [visualizationItem];
+
+        expect(convertUiItemsToBackend(uiItems)).toMatchObject([
+            visualizationItem,
+        ]);
+    });
+});
+
+describe('convertBackendItemsToUi', () => {
+    it('converts backend spacer item to SPACER type', () => {
+        const backendItems = [
+            {
+                id: 'spacer item',
+                type: TEXT,
+                text: spacerContent,
+            },
+        ];
+
+        expect(convertBackendItemsToUi(backendItems)).toMatchObject([
+            {
+                id: 'spacer item',
+                type: SPACER,
+                text: spacerContent,
+            },
+        ]);
+    });
+
+    it('converts content of empty TEXT type to empty string', () => {
+        const backendItems = [
+            {
+                id: 'empty text item',
+                type: TEXT,
+                text: emptyTextItemContent,
+            },
+        ];
+
+        expect(convertBackendItemsToUi(backendItems)).toMatchObject([
+            {
+                id: 'empty text item',
+                type: TEXT,
+                text: '',
+            },
+        ]);
+    });
+
+    it('does not change VISUALIZATION type', () => {
+        const backendItems = [visualizationItem];
+
+        expect(convertBackendItemsToUi(backendItems)).toMatchObject([
+            visualizationItem,
+        ]);
+    });
+});

--- a/src/modules/itemTypes.js
+++ b/src/modules/itemTypes.js
@@ -31,7 +31,6 @@ const DOMAIN_TYPE_AGGREGATE = 'AGGREGATE';
 const DOMAIN_TYPE_TRACKER = 'TRACKER';
 
 // Dashboard helpers
-export const spacerContent = 'SPACER_ITEM_FOR_DASHBOARD_LAYOUT_CONVENIENCE';
 export const isVisualizationType = item =>
     !!itemTypeMap[item.type].isVisualizationType;
 export const hasMapView = itemType =>

--- a/src/modules/itemTypes.js
+++ b/src/modules/itemTypes.js
@@ -32,11 +32,6 @@ const DOMAIN_TYPE_TRACKER = 'TRACKER';
 
 // Dashboard helpers
 export const spacerContent = 'SPACER_ITEM_FOR_DASHBOARD_LAYOUT_CONVENIENCE';
-export const emptyTextItemContent = 'TEXT_ITEM_WITH_NO_CONTENT';
-export const isSpacerType = item =>
-    item.type === TEXT && item.text === spacerContent;
-export const isTextType = item =>
-    item.type === TEXT && item.text !== spacerContent;
 export const isVisualizationType = item =>
     !!itemTypeMap[item.type].isVisualizationType;
 export const hasMapView = itemType =>

--- a/src/modules/uiBackendItemConverter.js
+++ b/src/modules/uiBackendItemConverter.js
@@ -1,0 +1,38 @@
+import { spacerContent, TEXT, SPACER } from './itemTypes';
+
+const emptyTextItemContent = 'TEXT_ITEM_WITH_NO_CONTENT';
+const isSpacerType = item => item.type === TEXT && item.text === spacerContent;
+
+export const isTextType = item =>
+    item.type === TEXT && item.text !== spacerContent;
+
+export const convertUiItemsToBackend = items => {
+    return items.map(item => {
+        const text = isTextType(item)
+            ? item.text || emptyTextItemContent
+            : null;
+
+        return {
+            ...item,
+            ...(text ? { text } : {}),
+        };
+    });
+};
+
+export const convertBackendItemsToUi = items => {
+    return items.map(item => {
+        const type = isSpacerType(item) ? SPACER : item.type;
+
+        const text = isTextType(item)
+            ? item.text === emptyTextItemContent
+                ? ''
+                : item.text
+            : null;
+
+        return {
+            ...item,
+            ...(text !== null ? { text } : {}),
+            type,
+        };
+    });
+};

--- a/src/modules/uiBackendItemConverter.js
+++ b/src/modules/uiBackendItemConverter.js
@@ -1,16 +1,21 @@
-import { spacerContent, TEXT, SPACER } from './itemTypes';
+import { TEXT, SPACER } from './itemTypes';
 
-const emptyTextItemContent = 'TEXT_ITEM_WITH_NO_CONTENT';
-const isSpacerType = item => item.type === TEXT && item.text === spacerContent;
+export const spacerContent = 'SPACER_ITEM_FOR_DASHBOARD_LAYOUT_CONVENIENCE';
+export const emptyTextItemContent = 'TEXT_ITEM_WITH_NO_CONTENT';
 
-export const isTextType = item =>
-    item.type === TEXT && item.text !== spacerContent;
+const isBackendSpacerType = item =>
+    item.type === TEXT && item.text === spacerContent;
+const isUiSpacerType = item => item.type === SPACER;
+const isTextType = item => item.type === TEXT && item.text !== spacerContent;
 
 export const convertUiItemsToBackend = items => {
     return items.map(item => {
-        const text = isTextType(item)
-            ? item.text || emptyTextItemContent
-            : null;
+        let text = null;
+        if (isUiSpacerType(item)) {
+            text = spacerContent;
+        } else if (isTextType(item)) {
+            text = item.text || emptyTextItemContent;
+        }
 
         return {
             ...item,
@@ -21,7 +26,7 @@ export const convertUiItemsToBackend = items => {
 
 export const convertBackendItemsToUi = items => {
     return items.map(item => {
-        const type = isSpacerType(item) ? SPACER : item.type;
+        const type = isBackendSpacerType(item) ? SPACER : item.type;
 
         const text = isTextType(item)
             ? item.text === emptyTextItemContent

--- a/src/modules/uiBackendItemConverter.js
+++ b/src/modules/uiBackendItemConverter.js
@@ -8,8 +8,8 @@ const isBackendSpacerType = item =>
 const isUiSpacerType = item => item.type === SPACER;
 const isTextType = item => item.type === TEXT && item.text !== spacerContent;
 
-export const convertUiItemsToBackend = items => {
-    return items.map(item => {
+export const convertUiItemsToBackend = items =>
+    items.map(item => {
         let text = null;
         if (isUiSpacerType(item)) {
             text = spacerContent;
@@ -22,10 +22,9 @@ export const convertUiItemsToBackend = items => {
             ...(text ? { text } : {}),
         };
     });
-};
 
-export const convertBackendItemsToUi = items => {
-    return items.map(item => {
+export const convertBackendItemsToUi = items =>
+    items.map(item => {
         const type = isBackendSpacerType(item) ? SPACER : item.type;
 
         const text = isTextType(item)
@@ -40,4 +39,3 @@ export const convertBackendItemsToUi = items => {
             type,
         };
     });
-};

--- a/src/reducers/dashboards.js
+++ b/src/reducers/dashboards.js
@@ -4,15 +4,7 @@ import arrayFrom from 'd2-utilizr/lib/arrayFrom';
 import arraySort from 'd2-utilizr/lib/arraySort';
 
 import { orArray, orObject } from '../modules/util';
-import {
-    SPACER,
-    isSpacerType,
-    isTextType,
-    emptyTextItemContent,
-    REPORT_TABLE,
-    CHART,
-    VISUALIZATION,
-} from '../modules/itemTypes';
+import { convertBackendItemsToUi } from '../modules/uiBackendItemConverter';
 
 export const SET_DASHBOARDS = 'SET_DASHBOARDS';
 export const ADD_DASHBOARDS = 'ADD_DASHBOARDS';
@@ -168,35 +160,8 @@ export const sGetDashboardsSortedByStarred = state => [
  * @param {Array} data The original dashboard list
  * @returns {Array}
  */
-export const getCustomDashboards = data => {
-    const uiItems = items =>
-        items.map(item => {
-            let type = isSpacerType(item) ? SPACER : item.type;
-
-            // TODO: temporary fix before 2.34 epic branch is merged
-            // if "VISUALIZATION", reset to "REPORT_TABLE" or "CHART"
-            if (type === VISUALIZATION) {
-                type = item.reportTable
-                    ? REPORT_TABLE
-                    : item.chart
-                    ? CHART
-                    : type;
-            }
-
-            const text = isTextType(item)
-                ? item.text === emptyTextItemContent
-                    ? ''
-                    : item.text
-                : null;
-
-            return {
-                ...item,
-                ...(text !== null ? { text } : {}),
-                type,
-            };
-        });
-
-    return arrayFrom(data).map(d => ({
+export const getCustomDashboards = data =>
+    arrayFrom(data).map(d => ({
         id: d.id,
         name: d.name,
         displayName: d.displayName,
@@ -214,6 +179,5 @@ export const getCustomDashboards = data => {
             .substr(0, 16),
         access: d.access,
         numberOfItems: orArray(d.dashboardItems).length,
-        dashboardItems: uiItems(d.dashboardItems),
+        dashboardItems: convertBackendItemsToUi(d.dashboardItems),
     }));
-};


### PR DESCRIPTION
Functional changes:
* SPACER type is no longer converted to TEXT type when saving, because `type` is never used on the backend and never has been. So there is no point in doing the conversion on the frontend. Backend looks only at the `text` property. (see this backend code: https://github.com/dhis2/dhis2-core/blob/master/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dashboard/DashboardItem.java#L160)also here shows what is actually stored in the db: https://github.com/dhis2/dhis2-core/blob/master/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dashboard/hibernate/DashboardItem.hbm.xml

* When loading dashboard items, no longer convert VISUALIZATION to CHART/REPORT_TABLE, since the ui supports VISUALIZATION. (there was a comment in the old code pointing this out)

Refactor changes:
* conversion code has been moved and consolidated in a new module. Any constants that were only in use in the conversion code are co-located with the conversion code.


https://jira.dhis2.org/browse/TECH-335