### PR TITLE
refactor: use css modules for components [TECH-337]

### DIFF
--- a/src/components/ControlBar/DashboardItemChip.js
+++ b/src/components/ControlBar/DashboardItemChip.js
@@ -1,42 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
-import { Chip, colors } from '@dhis2/ui-core';
+import { Chip } from '@dhis2/ui-core';
 import { Link } from 'react-router-dom';
 import debounce from 'lodash/debounce';
 
 import StarIcon from '../../icons/Star';
 import { apiPostDataStatistics } from '../../api/dataStatistics';
 
-const styles = {
-    chip: {
-        margin: '3px',
-    },
-    link: {
-        color: colors.grey600,
-        display: 'inline-block',
-        textDecoration: 'none',
-        verticalAlign: 'top',
-    },
-    icon: {
-        height: '20px',
-        marginTop: '2px',
-        width: '20px',
-    },
-    selected: {
-        fill: colors.white,
-    },
-    unselected: {
-        fill: colors.grey700,
-    },
-};
+import classes from './styles/DashboardItemChip.module.css';
 
 export const DashboardItemChip = ({
     starred,
     selected,
     label,
     dashboardId,
-    classes,
 }) => {
     const chipProps = {
         selected,
@@ -72,4 +49,4 @@ DashboardItemChip.propTypes = {
     classes: PropTypes.object,
 };
 
-export default withStyles(styles)(DashboardItemChip);
+export default DashboardItemChip;

--- a/src/components/ControlBar/EditBar.js
+++ b/src/components/ControlBar/EditBar.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Redirect } from 'react-router-dom';
@@ -154,7 +154,7 @@ export class EditBar extends Component {
             : i18n.t('Go to dashboards');
 
         return (
-            <Fragment>
+            <>
                 <ControlBar height={controlBarHeight} editMode={true}>
                     <div style={buttonBarStyle}>
                         {updateAccess ? (
@@ -193,7 +193,7 @@ export class EditBar extends Component {
                 </ControlBar>
                 {this.translationDialog()}
                 {this.confirmDeleteDialog()}
-            </Fragment>
+            </>
         );
     }
 }

--- a/src/components/ControlBar/Filter.js
+++ b/src/components/ControlBar/Filter.js
@@ -1,31 +1,17 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
 import i18n from '@dhis2/d2-i18n';
 import InputField from '@material-ui/core/Input';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import SearchIcon from '@material-ui/icons/Search';
-import { colors } from '@dhis2/ui-core';
 
 import ClearButton from './ClearButton';
 import { DEFAULT_STATE_DASHBOARDS_FILTER_NAME } from '../../reducers/dashboardsFilter';
 
+import classes from './styles/Filter.module.css';
+
 export const KEYCODE_ENTER = 13;
 export const KEYCODE_ESCAPE = 27;
-
-const styles = {
-    filterField: {
-        fontSize: '14px',
-        width: '200px',
-        height: '30px',
-        top: '-4px',
-    },
-    searchIcon: {
-        color: colors.grey700,
-        width: '20px',
-        height: '20px',
-    },
-};
 
 export class Filter extends Component {
     constructor(props) {
@@ -62,7 +48,7 @@ export class Filter extends Component {
     };
 
     render() {
-        const { classes, name, onChangeName } = this.props;
+        const { name, onChangeName } = this.props;
 
         const startAdornment = (
             <InputAdornment position="start">
@@ -92,7 +78,6 @@ export class Filter extends Component {
 }
 
 Filter.propTypes = {
-    classes: PropTypes.object,
     name: PropTypes.string,
     onChangeName: PropTypes.func,
     onKeypressEnter: PropTypes.func,
@@ -103,4 +88,4 @@ Filter.defaultProps = {
     onChangeName: Function.prototype,
 };
 
-export default withStyles(styles)(Filter);
+export default Filter;

--- a/src/components/ControlBar/ShowMoreButton.js
+++ b/src/components/ControlBar/ShowMoreButton.js
@@ -1,30 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import i18n from '@dhis2/d2-i18n';
-import { colors } from '@dhis2/ui-core';
-import { withStyles } from '@material-ui/core/styles';
+
+import classes from './styles/ShowMoreButton.module.css';
 
 export const SHOWMORE_BAR_HEIGHT = 16;
 
-const styles = {
-    showMore: {
-        color: colors.grey700,
-        cursor: 'pointer',
-        fontSize: 11,
-        paddingTop: 5,
-        '&:hover': {
-            textDecoration: 'underline',
-        },
-    },
-    disabled: {
-        paddingTop: 5,
-        color: colors.grey500,
-        fontSize: 11,
-        cursor: 'not-allowed',
-    },
-};
-
-export const ShowMoreButton = ({ onClick, isMaxHeight, classes, disabled }) => {
+export const ShowMoreButton = ({ onClick, isMaxHeight, disabled }) => {
     return (
         <div style={{ textAlign: 'center' }}>
             {disabled ? (
@@ -39,10 +21,9 @@ export const ShowMoreButton = ({ onClick, isMaxHeight, classes, disabled }) => {
 };
 
 ShowMoreButton.propTypes = {
-    classes: PropTypes.object,
     disabled: PropTypes.bool,
     isMaxHeight: PropTypes.bool,
     onClick: PropTypes.func,
 };
 
-export default withStyles(styles)(ShowMoreButton);
+export default ShowMoreButton;

--- a/src/components/ControlBar/__tests__/DashboardItemChip.spec.js
+++ b/src/components/ControlBar/__tests__/DashboardItemChip.spec.js
@@ -53,7 +53,7 @@ describe('DashboardItemChip', () => {
             .props.className.split(' ');
 
         expect(iconClasses.length).toEqual(2);
-        expect(iconClasses).toContain('unselectedClass');
+        expect(iconClasses).toContain('unselected');
     });
 
     it('sets the selected class on icon when chip is selected', () => {
@@ -67,7 +67,7 @@ describe('DashboardItemChip', () => {
             .props.className.split(' ');
 
         expect(iconClasses.length).toEqual(2);
-        expect(iconClasses).toContain('selectedClass');
+        expect(iconClasses).toContain('selected');
     });
 
     it('passes "label" property to Chip as children', () => {

--- a/src/components/ControlBar/__tests__/__snapshots__/DashboardsBar.spec.js.snap
+++ b/src/components/ControlBar/__tests__/__snapshots__/DashboardsBar.spec.js.snap
@@ -49,12 +49,14 @@ ShallowWrapper {
             >
               <AddCircleIcon />
             </Link>
-            <WithStyles(Filter)
+            <Filter
+              name=""
+              onChangeName={[Function]}
               onKeypressEnter={[Function]}
             />
           </div>
         </div>,
-        <WithStyles(ShowMoreButton)
+        <ShowMoreButton
           disabled={true}
           isMaxHeight={true}
           onClick={[Function]}
@@ -91,7 +93,9 @@ ShallowWrapper {
               >
                 <AddCircleIcon />
               </Link>
-              <WithStyles(Filter)
+              <Filter
+                name=""
+                onChangeName={[Function]}
                 onKeypressEnter={[Function]}
               />
             </div>,
@@ -126,7 +130,9 @@ ShallowWrapper {
                 >
                   <AddCircleIcon />
                 </Link>,
-                <WithStyles(Filter)
+                <Filter
+                  name=""
+                  onChangeName={[Function]}
                   onKeypressEnter={[Function]}
                 />,
               ],
@@ -167,8 +173,8 @@ ShallowWrapper {
                 "key": undefined,
                 "nodeType": "class",
                 "props": Object {
-                  "name": undefined,
-                  "onChangeName": undefined,
+                  "name": "",
+                  "onChangeName": [Function],
                   "onKeypressEnter": [Function],
                 },
                 "ref": null,
@@ -184,7 +190,7 @@ ShallowWrapper {
       Object {
         "instance": null,
         "key": undefined,
-        "nodeType": "class",
+        "nodeType": "function",
         "props": Object {
           "disabled": true,
           "isMaxHeight": true,
@@ -231,12 +237,14 @@ ShallowWrapper {
               >
                 <AddCircleIcon />
               </Link>
-              <WithStyles(Filter)
+              <Filter
+                name=""
+                onChangeName={[Function]}
                 onKeypressEnter={[Function]}
               />
             </div>
           </div>,
-          <WithStyles(ShowMoreButton)
+          <ShowMoreButton
             disabled={true}
             isMaxHeight={true}
             onClick={[Function]}
@@ -273,7 +281,9 @@ ShallowWrapper {
                 >
                   <AddCircleIcon />
                 </Link>
-                <WithStyles(Filter)
+                <Filter
+                  name=""
+                  onChangeName={[Function]}
                   onKeypressEnter={[Function]}
                 />
               </div>,
@@ -308,7 +318,9 @@ ShallowWrapper {
                   >
                     <AddCircleIcon />
                   </Link>,
-                  <WithStyles(Filter)
+                  <Filter
+                    name=""
+                    onChangeName={[Function]}
                     onKeypressEnter={[Function]}
                   />,
                 ],
@@ -349,8 +361,8 @@ ShallowWrapper {
                   "key": undefined,
                   "nodeType": "class",
                   "props": Object {
-                    "name": undefined,
-                    "onChangeName": undefined,
+                    "name": "",
+                    "onChangeName": [Function],
                     "onKeypressEnter": [Function],
                   },
                   "ref": null,
@@ -366,7 +378,7 @@ ShallowWrapper {
         Object {
           "instance": null,
           "key": undefined,
-          "nodeType": "class",
+          "nodeType": "function",
           "props": Object {
             "disabled": true,
             "isMaxHeight": true,
@@ -471,12 +483,14 @@ ShallowWrapper {
             >
               <AddCircleIcon />
             </Link>
-            <WithStyles(Filter)
+            <Filter
+              name=""
+              onChangeName={[Function]}
               onKeypressEnter={[Function]}
             />
           </div>
         </div>,
-        <WithStyles(ShowMoreButton)
+        <ShowMoreButton
           disabled={false}
           isMaxHeight={false}
           onClick={[Function]}
@@ -513,7 +527,9 @@ ShallowWrapper {
               >
                 <AddCircleIcon />
               </Link>
-              <WithStyles(Filter)
+              <Filter
+                name=""
+                onChangeName={[Function]}
                 onKeypressEnter={[Function]}
               />
             </div>,
@@ -548,7 +564,9 @@ ShallowWrapper {
                 >
                   <AddCircleIcon />
                 </Link>,
-                <WithStyles(Filter)
+                <Filter
+                  name=""
+                  onChangeName={[Function]}
                   onKeypressEnter={[Function]}
                 />,
               ],
@@ -589,8 +607,8 @@ ShallowWrapper {
                 "key": undefined,
                 "nodeType": "class",
                 "props": Object {
-                  "name": undefined,
-                  "onChangeName": undefined,
+                  "name": "",
+                  "onChangeName": [Function],
                   "onKeypressEnter": [Function],
                 },
                 "ref": null,
@@ -606,7 +624,7 @@ ShallowWrapper {
       Object {
         "instance": null,
         "key": undefined,
-        "nodeType": "class",
+        "nodeType": "function",
         "props": Object {
           "disabled": false,
           "isMaxHeight": false,
@@ -653,12 +671,14 @@ ShallowWrapper {
               >
                 <AddCircleIcon />
               </Link>
-              <WithStyles(Filter)
+              <Filter
+                name=""
+                onChangeName={[Function]}
                 onKeypressEnter={[Function]}
               />
             </div>
           </div>,
-          <WithStyles(ShowMoreButton)
+          <ShowMoreButton
             disabled={false}
             isMaxHeight={false}
             onClick={[Function]}
@@ -695,7 +715,9 @@ ShallowWrapper {
                 >
                   <AddCircleIcon />
                 </Link>
-                <WithStyles(Filter)
+                <Filter
+                  name=""
+                  onChangeName={[Function]}
                   onKeypressEnter={[Function]}
                 />
               </div>,
@@ -730,7 +752,9 @@ ShallowWrapper {
                   >
                     <AddCircleIcon />
                   </Link>,
-                  <WithStyles(Filter)
+                  <Filter
+                    name=""
+                    onChangeName={[Function]}
                     onKeypressEnter={[Function]}
                   />,
                 ],
@@ -771,8 +795,8 @@ ShallowWrapper {
                   "key": undefined,
                   "nodeType": "class",
                   "props": Object {
-                    "name": undefined,
-                    "onChangeName": undefined,
+                    "name": "",
+                    "onChangeName": [Function],
                     "onKeypressEnter": [Function],
                   },
                   "ref": null,
@@ -788,7 +812,7 @@ ShallowWrapper {
         Object {
           "instance": null,
           "key": undefined,
-          "nodeType": "class",
+          "nodeType": "function",
           "props": Object {
             "disabled": false,
             "isMaxHeight": false,
@@ -893,12 +917,14 @@ ShallowWrapper {
             >
               <AddCircleIcon />
             </Link>
-            <WithStyles(Filter)
+            <Filter
+              name=""
+              onChangeName={[Function]}
               onKeypressEnter={[Function]}
             />
           </div>
         </div>,
-        <WithStyles(ShowMoreButton)
+        <ShowMoreButton
           disabled={false}
           isMaxHeight={false}
           onClick={[Function]}
@@ -935,7 +961,9 @@ ShallowWrapper {
               >
                 <AddCircleIcon />
               </Link>
-              <WithStyles(Filter)
+              <Filter
+                name=""
+                onChangeName={[Function]}
                 onKeypressEnter={[Function]}
               />
             </div>,
@@ -970,7 +998,9 @@ ShallowWrapper {
                 >
                   <AddCircleIcon />
                 </Link>,
-                <WithStyles(Filter)
+                <Filter
+                  name=""
+                  onChangeName={[Function]}
                   onKeypressEnter={[Function]}
                 />,
               ],
@@ -1011,8 +1041,8 @@ ShallowWrapper {
                 "key": undefined,
                 "nodeType": "class",
                 "props": Object {
-                  "name": undefined,
-                  "onChangeName": undefined,
+                  "name": "",
+                  "onChangeName": [Function],
                   "onKeypressEnter": [Function],
                 },
                 "ref": null,
@@ -1028,7 +1058,7 @@ ShallowWrapper {
       Object {
         "instance": null,
         "key": undefined,
-        "nodeType": "class",
+        "nodeType": "function",
         "props": Object {
           "disabled": false,
           "isMaxHeight": false,
@@ -1075,12 +1105,14 @@ ShallowWrapper {
               >
                 <AddCircleIcon />
               </Link>
-              <WithStyles(Filter)
+              <Filter
+                name=""
+                onChangeName={[Function]}
                 onKeypressEnter={[Function]}
               />
             </div>
           </div>,
-          <WithStyles(ShowMoreButton)
+          <ShowMoreButton
             disabled={false}
             isMaxHeight={false}
             onClick={[Function]}
@@ -1117,7 +1149,9 @@ ShallowWrapper {
                 >
                   <AddCircleIcon />
                 </Link>
-                <WithStyles(Filter)
+                <Filter
+                  name=""
+                  onChangeName={[Function]}
                   onKeypressEnter={[Function]}
                 />
               </div>,
@@ -1152,7 +1186,9 @@ ShallowWrapper {
                   >
                     <AddCircleIcon />
                   </Link>,
-                  <WithStyles(Filter)
+                  <Filter
+                    name=""
+                    onChangeName={[Function]}
                     onKeypressEnter={[Function]}
                   />,
                 ],
@@ -1193,8 +1229,8 @@ ShallowWrapper {
                   "key": undefined,
                   "nodeType": "class",
                   "props": Object {
-                    "name": undefined,
-                    "onChangeName": undefined,
+                    "name": "",
+                    "onChangeName": [Function],
                     "onKeypressEnter": [Function],
                   },
                   "ref": null,
@@ -1210,7 +1246,7 @@ ShallowWrapper {
         Object {
           "instance": null,
           "key": undefined,
-          "nodeType": "class",
+          "nodeType": "function",
           "props": Object {
             "disabled": false,
             "isMaxHeight": false,
@@ -1329,24 +1365,26 @@ ShallowWrapper {
             >
               <AddCircleIcon />
             </Link>
-            <WithStyles(Filter)
+            <Filter
+              name=""
+              onChangeName={[Function]}
               onKeypressEnter={[Function]}
             />
           </div>
-          <WithStyles(DashboardItemChip)
+          <DashboardItemChip
             dashboardId="rainbow123"
             label="Rainbow Dash"
             selected={false}
             starred={false}
           />
-          <WithStyles(DashboardItemChip)
+          <DashboardItemChip
             dashboardId="fluttershy123"
             label="Fluttershy"
             selected={false}
             starred={true}
           />
         </div>,
-        <WithStyles(ShowMoreButton)
+        <ShowMoreButton
           disabled={false}
           isMaxHeight={false}
           onClick={[Function]}
@@ -1383,18 +1421,20 @@ ShallowWrapper {
               >
                 <AddCircleIcon />
               </Link>
-              <WithStyles(Filter)
+              <Filter
+                name=""
+                onChangeName={[Function]}
                 onKeypressEnter={[Function]}
               />
             </div>,
             Array [
-              <WithStyles(DashboardItemChip)
+              <DashboardItemChip
                 dashboardId="rainbow123"
                 label="Rainbow Dash"
                 selected={false}
                 starred={false}
               />,
-              <WithStyles(DashboardItemChip)
+              <DashboardItemChip
                 dashboardId="fluttershy123"
                 label="Fluttershy"
                 selected={false}
@@ -1431,7 +1471,9 @@ ShallowWrapper {
                 >
                   <AddCircleIcon />
                 </Link>,
-                <WithStyles(Filter)
+                <Filter
+                  name=""
+                  onChangeName={[Function]}
                   onKeypressEnter={[Function]}
                 />,
               ],
@@ -1472,8 +1514,8 @@ ShallowWrapper {
                 "key": undefined,
                 "nodeType": "class",
                 "props": Object {
-                  "name": undefined,
-                  "onChangeName": undefined,
+                  "name": "",
+                  "onChangeName": [Function],
                   "onKeypressEnter": [Function],
                 },
                 "ref": null,
@@ -1486,7 +1528,7 @@ ShallowWrapper {
           Object {
             "instance": null,
             "key": "rainbow123",
-            "nodeType": "class",
+            "nodeType": "function",
             "props": Object {
               "dashboardId": "rainbow123",
               "label": "Rainbow Dash",
@@ -1500,7 +1542,7 @@ ShallowWrapper {
           Object {
             "instance": null,
             "key": "fluttershy123",
-            "nodeType": "class",
+            "nodeType": "function",
             "props": Object {
               "dashboardId": "fluttershy123",
               "label": "Fluttershy",
@@ -1517,7 +1559,7 @@ ShallowWrapper {
       Object {
         "instance": null,
         "key": undefined,
-        "nodeType": "class",
+        "nodeType": "function",
         "props": Object {
           "disabled": false,
           "isMaxHeight": false,
@@ -1564,24 +1606,26 @@ ShallowWrapper {
               >
                 <AddCircleIcon />
               </Link>
-              <WithStyles(Filter)
+              <Filter
+                name=""
+                onChangeName={[Function]}
                 onKeypressEnter={[Function]}
               />
             </div>
-            <WithStyles(DashboardItemChip)
+            <DashboardItemChip
               dashboardId="rainbow123"
               label="Rainbow Dash"
               selected={false}
               starred={false}
             />
-            <WithStyles(DashboardItemChip)
+            <DashboardItemChip
               dashboardId="fluttershy123"
               label="Fluttershy"
               selected={false}
               starred={true}
             />
           </div>,
-          <WithStyles(ShowMoreButton)
+          <ShowMoreButton
             disabled={false}
             isMaxHeight={false}
             onClick={[Function]}
@@ -1618,18 +1662,20 @@ ShallowWrapper {
                 >
                   <AddCircleIcon />
                 </Link>
-                <WithStyles(Filter)
+                <Filter
+                  name=""
+                  onChangeName={[Function]}
                   onKeypressEnter={[Function]}
                 />
               </div>,
               Array [
-                <WithStyles(DashboardItemChip)
+                <DashboardItemChip
                   dashboardId="rainbow123"
                   label="Rainbow Dash"
                   selected={false}
                   starred={false}
                 />,
-                <WithStyles(DashboardItemChip)
+                <DashboardItemChip
                   dashboardId="fluttershy123"
                   label="Fluttershy"
                   selected={false}
@@ -1666,7 +1712,9 @@ ShallowWrapper {
                   >
                     <AddCircleIcon />
                   </Link>,
-                  <WithStyles(Filter)
+                  <Filter
+                    name=""
+                    onChangeName={[Function]}
                     onKeypressEnter={[Function]}
                   />,
                 ],
@@ -1707,8 +1755,8 @@ ShallowWrapper {
                   "key": undefined,
                   "nodeType": "class",
                   "props": Object {
-                    "name": undefined,
-                    "onChangeName": undefined,
+                    "name": "",
+                    "onChangeName": [Function],
                     "onKeypressEnter": [Function],
                   },
                   "ref": null,
@@ -1721,7 +1769,7 @@ ShallowWrapper {
             Object {
               "instance": null,
               "key": "rainbow123",
-              "nodeType": "class",
+              "nodeType": "function",
               "props": Object {
                 "dashboardId": "rainbow123",
                 "label": "Rainbow Dash",
@@ -1735,7 +1783,7 @@ ShallowWrapper {
             Object {
               "instance": null,
               "key": "fluttershy123",
-              "nodeType": "class",
+              "nodeType": "function",
               "props": Object {
                 "dashboardId": "fluttershy123",
                 "label": "Fluttershy",
@@ -1752,7 +1800,7 @@ ShallowWrapper {
         Object {
           "instance": null,
           "key": undefined,
-          "nodeType": "class",
+          "nodeType": "function",
           "props": Object {
             "disabled": false,
             "isMaxHeight": false,

--- a/src/components/ControlBar/__tests__/__snapshots__/Filter.spec.js.snap
+++ b/src/components/ControlBar/__tests__/__snapshots__/Filter.spec.js.snap
@@ -22,7 +22,7 @@ ShallowWrapper {
     "key": undefined,
     "nodeType": "class",
     "props": Object {
-      "className": undefined,
+      "className": "filterField",
       "endAdornment": <WithStyles(WithFormControlContext(InputAdornment))
         position="end"
       >
@@ -36,7 +36,9 @@ ShallowWrapper {
       "startAdornment": <WithStyles(WithFormControlContext(InputAdornment))
         position="start"
       >
-        <pure(SearchIcon) />
+        <pure(SearchIcon)
+          className="searchIcon"
+        />
       </WithStyles(WithFormControlContext(InputAdornment))>,
       "value": "",
     },
@@ -50,7 +52,7 @@ ShallowWrapper {
       "key": undefined,
       "nodeType": "class",
       "props": Object {
-        "className": undefined,
+        "className": "filterField",
         "endAdornment": <WithStyles(WithFormControlContext(InputAdornment))
           position="end"
         >
@@ -64,7 +66,9 @@ ShallowWrapper {
         "startAdornment": <WithStyles(WithFormControlContext(InputAdornment))
           position="start"
         >
-          <pure(SearchIcon) />
+          <pure(SearchIcon)
+            className="searchIcon"
+          />
         </WithStyles(WithFormControlContext(InputAdornment))>,
         "value": "",
       },

--- a/src/components/ControlBar/__tests__/__snapshots__/ShowMoreButton.spec.js.snap
+++ b/src/components/ControlBar/__tests__/__snapshots__/ShowMoreButton.spec.js.snap
@@ -27,7 +27,7 @@ ShallowWrapper {
     "nodeType": "host",
     "props": Object {
       "children": <div
-        className={Object {}}
+        className="showMore"
         onClick={[Function]}
       >
         Show less
@@ -43,7 +43,7 @@ ShallowWrapper {
       "nodeType": "host",
       "props": Object {
         "children": "Show less",
-        "className": Object {},
+        "className": "showMore",
         "onClick": [Function],
       },
       "ref": null,
@@ -59,7 +59,7 @@ ShallowWrapper {
       "nodeType": "host",
       "props": Object {
         "children": <div
-          className={Object {}}
+          className="showMore"
           onClick={[Function]}
         >
           Show less
@@ -75,7 +75,7 @@ ShallowWrapper {
         "nodeType": "host",
         "props": Object {
           "children": "Show less",
-          "className": Object {},
+          "className": "showMore",
           "onClick": [Function],
         },
         "ref": null,
@@ -139,7 +139,7 @@ ShallowWrapper {
     "nodeType": "host",
     "props": Object {
       "children": <div
-        className={Object {}}
+        className="showMore"
         onClick={[Function]}
       >
         Show more
@@ -155,7 +155,7 @@ ShallowWrapper {
       "nodeType": "host",
       "props": Object {
         "children": "Show more",
-        "className": Object {},
+        "className": "showMore",
         "onClick": [Function],
       },
       "ref": null,
@@ -171,7 +171,7 @@ ShallowWrapper {
       "nodeType": "host",
       "props": Object {
         "children": <div
-          className={Object {}}
+          className="showMore"
           onClick={[Function]}
         >
           Show more
@@ -187,7 +187,7 @@ ShallowWrapper {
         "nodeType": "host",
         "props": Object {
           "children": "Show more",
-          "className": Object {},
+          "className": "showMore",
           "onClick": [Function],
         },
         "ref": null,

--- a/src/components/ControlBar/styles/DashboardItemChip.module.css
+++ b/src/components/ControlBar/styles/DashboardItemChip.module.css
@@ -1,0 +1,20 @@
+.chip {
+    margin: 3px;
+}
+.link {
+    color: var(--colors-grey600);
+    display: inline-block;
+    text-decoration: none;
+    vertical-align: top;
+}
+.icon {
+    height: 20px;
+    margin-top: 2px;
+    width: 20px;
+}
+.selected {
+    fill: var(--colors-white);
+}
+.unselected {
+    fill: var(--colors-grey700);
+}

--- a/src/components/ControlBar/styles/Filter.module.css
+++ b/src/components/ControlBar/styles/Filter.module.css
@@ -1,0 +1,11 @@
+.filterField {
+    font-size: 14px;
+    width: 200px;
+    height: 30px;
+    top: -4px;
+}
+.searchIcon {
+    color: var(--colors-grey700);
+    width: 20px;
+    height: 20px;
+}

--- a/src/components/ControlBar/styles/ShowMoreButton.module.css
+++ b/src/components/ControlBar/styles/ShowMoreButton.module.css
@@ -1,0 +1,17 @@
+.showMore {
+    color: var(--colors-grey700);
+    cursor: pointer;
+    font-size: 11;
+    padding-top: 5;
+}
+
+.showMore:hover {
+    text-decoration: underline;
+}
+
+.disabled {
+    padding-top: 5;
+    color: var(--colors-grey500);
+    font-size: 11;
+    cursor: not-allowed;
+}

--- a/src/components/Dashboard/DashboardContent.js
+++ b/src/components/Dashboard/DashboardContent.js
@@ -1,15 +1,15 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import TitleBar from '../TitleBar/TitleBar';
 import ItemGrid from '../ItemGrid/ItemGrid';
 import FilterBar from '../FilterBar/FilterBar';
 
 export const DashboardContent = props => (
-    <Fragment>
+    <>
         <TitleBar edit={props.editMode} />
         <FilterBar />
         <ItemGrid edit={props.editMode} />
-    </Fragment>
+    </>
 );
 
 DashboardContent.propTypes = {

--- a/src/components/Dashboard/EditDashboard.js
+++ b/src/components/Dashboard/EditDashboard.js
@@ -1,4 +1,4 @@
-import React, { Fragment, Component } from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import i18n from '@dhis2/d2-i18n';
 import PropTypes from 'prop-types';
@@ -63,11 +63,11 @@ export class EditDashboard extends Component {
 
     render() {
         return (
-            <Fragment>
+            <>
                 <EditBar />
                 <DashboardVerticalOffset editMode={true} />
                 {this.getDashboardContent()}
-            </Fragment>
+            </>
         );
     }
 }

--- a/src/components/Dashboard/NewDashboard.js
+++ b/src/components/Dashboard/NewDashboard.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
@@ -14,13 +14,13 @@ class NewDashboard extends Component {
 
     render() {
         return (
-            <Fragment>
+            <>
                 <EditBar />
                 <DashboardVerticalOffset editMode={true} />
                 <div className="dashboard-wrapper">
                     <DashboardContent editMode={true} />
                 </div>
-            </Fragment>
+            </>
         );
     }
 }

--- a/src/components/Dashboard/ViewDashboard.js
+++ b/src/components/Dashboard/ViewDashboard.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import isEmpty from 'lodash/isEmpty';
 import i18n from '@dhis2/d2-i18n';
@@ -38,7 +38,7 @@ export const ViewDashboard = ({ id, dashboardsIsEmpty, dashboardsLoaded }) => {
     const contentNotReady = !dashboardsLoaded || id === null;
 
     return (
-        <Fragment>
+        <>
             <DashboardsBar />
             <DashboardVerticalOffset />
             <div className="dashboard-wrapper">
@@ -49,7 +49,7 @@ export const ViewDashboard = ({ id, dashboardsIsEmpty, dashboardsLoaded }) => {
                     />
                 )}
             </div>
-        </Fragment>
+        </>
     );
 };
 

--- a/src/components/FilterBar/FilterBar.js
+++ b/src/components/FilterBar/FilterBar.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { createSelector } from 'reselect';
-import { withStyles } from '@material-ui/core/styles';
 
 import { sGetDimensions } from '../../reducers/dimensions';
 import { sGetItemFiltersRoot } from '../../reducers/itemFilters';
@@ -14,16 +13,7 @@ import { acSetActiveModalDimension } from '../../actions/activeModalDimension';
 
 import FilterBadge from './FilterBadge';
 
-const styles = {
-    bar: {
-        position: 'sticky',
-        zIndex: 7,
-        padding: '8px 0',
-        display: 'flex',
-        justifyContent: 'center',
-        flexWrap: 'wrap',
-    },
-};
+import classes from './styles/FilterBar.module.css';
 
 export class FilterBar extends Component {
     onBadgeRemove = id => {
@@ -39,7 +29,7 @@ export class FilterBar extends Component {
     };
 
     render() {
-        const { filters, userRows, classes } = this.props;
+        const { filters, userRows } = this.props;
         const top = getTopOffset(userRows) + 10;
 
         return filters.length ? (
@@ -61,7 +51,6 @@ FilterBar.propTypes = {
     filters: PropTypes.array.isRequired,
     removeEditItemFilter: PropTypes.func.isRequired,
     removeItemFilter: PropTypes.func.isRequired,
-    classes: PropTypes.object,
     setActiveModalDimension: PropTypes.func,
     userRows: PropTypes.number,
 };
@@ -103,4 +92,4 @@ export default connect(
         removeItemFilter: acRemoveItemFilter,
         removeEditItemFilter: acRemoveEditItemFilter,
     }
-)(withStyles(styles)(FilterBar));
+)(FilterBar);

--- a/src/components/FilterBar/styles/FilterBar.module.css
+++ b/src/components/FilterBar/styles/FilterBar.module.css
@@ -1,0 +1,8 @@
+.bar {
+    position: sticky;
+    z-index: 7;
+    padding: 8px 0;
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+}

--- a/src/components/Item/AppItem/Item.js
+++ b/src/components/Item/AppItem/Item.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import NotInterestedIcon from '@material-ui/icons/NotInterested';
@@ -38,7 +38,7 @@ const AppItem = ({ item, itemFilters }, context) => {
     }
 
     return appDetails && appDetails.name && appDetails.launchUrl ? (
-        <Fragment>
+        <>
             <ItemHeader title={appDetails.name} itemId={item.id} />
             <Line />
             <iframe
@@ -47,9 +47,9 @@ const AppItem = ({ item, itemFilters }, context) => {
                 className="dashboard-item-content"
                 style={{ border: 'none' }}
             />
-        </Fragment>
+        </>
     ) : (
-        <Fragment>
+        <>
             <ItemHeader title={`${appKey} app not found`} />
             <Line />
             <div
@@ -67,7 +67,7 @@ const AppItem = ({ item, itemFilters }, context) => {
                     style={{ width: 100, height: 100, align: 'center' }}
                 />
             </div>
-        </Fragment>
+        </>
     );
 };
 

--- a/src/components/Item/ListItem/Item.js
+++ b/src/components/Item/ListItem/Item.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { colors } from '@dhis2/ui-core';
@@ -35,7 +35,7 @@ const ListItem = (props, context) => {
         );
 
         return (
-            <Fragment>
+            <>
                 <a
                     className={classes.link}
                     style={{ color: colors.grey900 }}
@@ -44,12 +44,12 @@ const ListItem = (props, context) => {
                     {contentItem.name}
                 </a>
                 {editMode ? deleteButton : null}
-            </Fragment>
+            </>
         );
     };
 
     return (
-        <Fragment>
+        <>
             <ItemHeader title={getItemTitle(item)} itemId={item.id} />
             <Line />
             <div className="dashboard-item-content">
@@ -62,7 +62,7 @@ const ListItem = (props, context) => {
                     ))}
                 </ul>
             </div>
-        </Fragment>
+        </>
     );
 };
 

--- a/src/components/Item/MessagesItem/Item.js
+++ b/src/components/Item/MessagesItem/Item.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import i18n from '@dhis2/d2-i18n';
@@ -107,7 +107,7 @@ class MessagesItem extends Component {
 
     render() {
         return (
-            <Fragment>
+            <>
                 <ItemHeader
                     title={i18n.t('Messages')}
                     itemId={this.props.item.id}
@@ -123,7 +123,7 @@ class MessagesItem extends Component {
                         </div>
                     </div>
                 )}
-            </Fragment>
+            </>
         );
     }
 }

--- a/src/components/Item/NotSupportedItem/Item.js
+++ b/src/components/Item/NotSupportedItem/Item.js
@@ -1,11 +1,11 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import i18n from '@dhis2/d2-i18n';
 import ItemHeader from '../ItemHeader';
 import NotInterestedIcon from '@material-ui/icons/NotInterested';
 
 const NotSupportedItem = props => (
-    <Fragment>
+    <>
         <ItemHeader
             title={i18n.t('Item type "{{type}}" not supported', {
                 type: props.item.type,
@@ -25,7 +25,7 @@ const NotSupportedItem = props => (
                 color="disabled"
             />
         </div>
-    </Fragment>
+    </>
 );
 
 NotSupportedItem.propTypes = {

--- a/src/components/Item/SpacerItem/Item.js
+++ b/src/components/Item/SpacerItem/Item.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import i18n from '@dhis2/d2-i18n';
 
@@ -14,14 +14,14 @@ const style = {
 
 const SpacerItem = props => {
     return (
-        <Fragment>
+        <>
             <ItemHeader title={i18n.t('Spacer')} itemId={props.item.id} />
             <p style={style}>
                 {i18n.t(
                     'Use a spacer to create empty vertical space between other dashboard items.'
                 )}
             </p>
-        </Fragment>
+        </>
     );
 };
 

--- a/src/components/Item/TextItem/Item.js
+++ b/src/components/Item/TextItem/Item.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import i18n from '@dhis2/d2-i18n';
 import PropTypes from 'prop-types';
@@ -58,7 +58,7 @@ const TextItem = props => {
 
     const editItem = () => {
         return (
-            <Fragment>
+            <>
                 <ItemHeader title={i18n.t('Text item')} itemId={item.id} />
                 <Line />
                 <div className="dashboard-item-content">
@@ -73,11 +73,11 @@ const TextItem = props => {
                         />
                     </RichTextEditor>
                 </div>
-            </Fragment>
+            </>
         );
     };
 
-    return <Fragment>{editMode ? editItem() : viewItem()}</Fragment>;
+    return <>{editMode ? editItem() : viewItem()}</>;
 };
 
 const mapStateToProps = (state, ownProps) => {

--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -1,7 +1,6 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { withStyles } from '@material-ui/core/styles';
 import uniqueId from 'lodash/uniqueId';
 import VisualizationPlugin from '@dhis2/data-visualizer-plugin';
 import i18n from '@dhis2/d2-i18n';
@@ -26,41 +25,11 @@ import {
 } from '../../../modules/itemTypes';
 import memoizeOne from '../../../modules/memoizeOne';
 
-import { colors } from '@dhis2/ui-core';
 import { getVisualizationConfig } from './plugin';
 import LoadingMask from './LoadingMask';
 import { ITEM_CONTENT_PADDING_BOTTOM } from '../../ItemGrid/ItemGrid';
 
-const styles = {
-    icon: {
-        width: 16,
-        height: 16,
-        marginLeft: 3,
-        cursor: 'pointer',
-        fill: colors.grey600,
-    },
-    title: {
-        overflow: 'hidden',
-        maxWidth: '85%',
-        textOverflow: 'ellipsis',
-        whiteSpace: 'nowrap',
-    },
-    textDiv: {
-        fontSize: '14px',
-        fontStretch: 'normal',
-        padding: '10px',
-        lineHeight: '20px',
-    },
-    loadingCover: {
-        position: 'absolute',
-        height: '100%',
-        width: '100%',
-        left: 0,
-        top: 0,
-        zIndex: 100,
-        background: '#ffffffab',
-    },
-};
+import classes from './styles/Item.module.css';
 
 export class Item extends Component {
     state = {
@@ -164,7 +133,7 @@ export class Item extends Component {
 
         if (!visualization) {
             return (
-                <div className={this.props.classes.textDiv}>
+                <div className={classes.textDiv}>
                     {i18n.t('No data to display')}
                 </div>
             );
@@ -191,9 +160,9 @@ export class Item extends Component {
             case CHART:
             case REPORT_TABLE: {
                 return (
-                    <Fragment>
+                    <>
                         {!this.state.pluginIsLoaded ? (
-                            <div style={styles.loadingCover}>
+                            <div className={classes.loadingCover}>
                                 <LoadingMask />
                             </div>
                         ) : null}
@@ -207,7 +176,7 @@ export class Item extends Component {
                             forDashboard={true}
                             style={props.style}
                         />
-                    </Fragment>
+                    </>
                 );
             }
             case MAP: {
@@ -339,7 +308,6 @@ Item.contextTypes = {
 };
 
 Item.propTypes = {
-    classes: PropTypes.object,
     editMode: PropTypes.bool,
     item: PropTypes.object,
     itemFilters: PropTypes.object,
@@ -375,4 +343,4 @@ const mapDispatchToProps = dispatch => ({
 export default connect(
     mapStateToProps,
     mapDispatchToProps
-)(withStyles(styles)(Item));
+)(Item);

--- a/src/components/Item/VisualizationItem/LoadingMask.js
+++ b/src/components/Item/VisualizationItem/LoadingMask.js
@@ -1,24 +1,9 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
 import CircularProgress from '@material-ui/core/CircularProgress';
 
-const styles = theme => ({
-    progress: {
-        margin: theme.spacing.unit * 2,
-        maxWidth: 200,
-        textAlign: 'center',
-        alignSelf: 'center',
-    },
-    outer: {
-        display: 'flex',
-        justifyContent: 'center',
-        height: '100%',
-    },
-});
+import classes from './styles/LoadingMask.module.css';
 
-function CircularIndeterminate(props) {
-    const { classes } = props;
+function CircularIndeterminate() {
     return (
         <div className={classes.outer}>
             <CircularProgress className={classes.progress} />
@@ -26,8 +11,4 @@ function CircularIndeterminate(props) {
     );
 }
 
-CircularIndeterminate.propTypes = {
-    classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(CircularIndeterminate);
+export default CircularIndeterminate;

--- a/src/components/Item/VisualizationItem/styles/Item.module.css
+++ b/src/components/Item/VisualizationItem/styles/Item.module.css
@@ -1,0 +1,15 @@
+.textDiv {
+    font-size: 14px;
+    font-stretch: normal;
+    padding: 10px;
+    line-height: 20px;
+}
+.loadingCover {
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    left: 0;
+    top: 0;
+    z-index: 100;
+    background: #ffffff;
+}

--- a/src/components/Item/VisualizationItem/styles/LoadingMask.module.css
+++ b/src/components/Item/VisualizationItem/styles/LoadingMask.module.css
@@ -1,0 +1,11 @@
+.progress {
+    margin: 16;
+    max-width: 200;
+    text-align: center;
+    align-self: center;
+}
+.outer {
+    display: flex;
+    justify-content: center;
+    height: 100%;
+}

--- a/src/components/ItemFilter/FilterSelector.js
+++ b/src/components/ItemFilter/FilterSelector.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Popover from '@material-ui/core/Popover';
@@ -116,7 +116,7 @@ class FilterSelector extends Component {
         } = this.props;
 
         return (
-            <Fragment>
+            <>
                 <Button onClick={this.openPanel}>
                     {i18n.t('Add filter')}
                     <ArrowDropDownIcon />
@@ -150,7 +150,7 @@ class FilterSelector extends Component {
                         onConfirm={this.saveFilter}
                     />
                 ) : null}
-            </Fragment>
+            </>
         );
     }
 }

--- a/src/components/ItemSelector/CategorizedMenuGroup.js
+++ b/src/components/ItemSelector/CategorizedMenuGroup.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import i18n from '@dhis2/d2-i18n';
@@ -51,7 +51,7 @@ class CategorizedMenuGroup extends Component {
     render() {
         const { title, type, items, hasMore } = this.props;
         return (
-            <Fragment>
+            <>
                 <HeaderMenuItem title={title} />
                 {items.map(item => {
                     const itemUrl = getItemUrl(type, item, this.context.d2);
@@ -81,7 +81,7 @@ class CategorizedMenuGroup extends Component {
                     />
                 ) : null}
                 <Divider margin="8px 0px" />
-            </Fragment>
+            </>
         );
     }
 }

--- a/src/components/ItemSelector/ItemSelector.js
+++ b/src/components/ItemSelector/ItemSelector.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import i18n from '@dhis2/d2-i18n';
 import Popover from '@material-ui/core/Popover';
@@ -122,7 +122,7 @@ class ItemSelector extends React.Component {
 
     render() {
         return (
-            <Fragment>
+            <>
                 <ItemSearchField
                     value={this.state.filter}
                     onChange={this.setFilter}
@@ -142,7 +142,7 @@ class ItemSelector extends React.Component {
                 >
                     <Menu>{this.getMenuGroups()}</Menu>
                 </Popover>
-            </Fragment>
+            </>
         );
     }
 }

--- a/src/components/ItemSelector/SinglesMenuGroup.js
+++ b/src/components/ItemSelector/SinglesMenuGroup.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
@@ -12,7 +12,7 @@ export const SinglesMenuGroup = ({ acAddDashboardItem, category }) => {
     };
 
     return (
-        <Fragment>
+        <>
             <HeaderMenuItem title={category.header} />
             {category.items.map(item => (
                 <ContentMenuItem
@@ -22,7 +22,7 @@ export const SinglesMenuGroup = ({ acAddDashboardItem, category }) => {
                     onInsert={addToDashboard(item)}
                 />
             ))}
-        </Fragment>
+        </>
     );
 };
 

--- a/src/components/TitleBar/EditTitleBar.js
+++ b/src/components/TitleBar/EditTitleBar.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
 import i18n from '@dhis2/d2-i18n';
 import { InputField, TextAreaField } from '@dhis2/ui-core';
 
@@ -13,49 +12,13 @@ import {
 import { orObject } from '../../modules/util';
 import { sGetEditDashboardRoot } from '../../reducers/editDashboard';
 
-const styles = {
-    section: { display: 'flex', justifyContent: 'space-between' },
-    titleDescription: {
-        flex: '3',
-        marginRight: '50px',
-    },
-    title: {
-        display: 'block',
-        clear: 'both',
-    },
-    description: {
-        display: 'block',
-        clear: 'both',
-        marginTop: '15px',
-    },
-    underline: {
-        '&::before': {
-            borderBottom: `none`,
-        },
-        '&:hover::before': {
-            borderBottom: `none!important`,
-        },
-    },
-    input: {
-        backgroundColor: 'rgba(0, 0, 10, 0.05)',
-        borderRadius: '4px',
-        width: '100%',
-        '&:hover': {
-            backgroundColor: 'rgba(0, 0, 10, 0.08)',
-        },
-    },
-    itemSelector: {
-        flex: '2',
-        position: 'relative',
-    },
-};
+import classes from './styles/EditTitleBar.module.css';
 
 export const EditTitleBar = ({
     name,
     description,
     onChangeTitle,
     onChangeDescription,
-    classes,
 }) => {
     const updateTitle = (_, e) => {
         onChangeTitle(e.target.value);
@@ -91,6 +54,18 @@ export const EditTitleBar = ({
     );
 };
 
+EditTitleBar.propTypes = {
+    onChangeDescription: PropTypes.func.isRequired,
+    onChangeTitle: PropTypes.func.isRequired,
+    description: PropTypes.string,
+    name: PropTypes.string,
+};
+
+EditTitleBar.defaultProps = {
+    name: '',
+    description: '',
+};
+
 const mapStateToProps = state => {
     const selectedDashboard = orObject(sGetEditDashboardRoot(state));
 
@@ -108,17 +83,4 @@ const mapDispatchToProps = {
 export default connect(
     mapStateToProps,
     mapDispatchToProps
-)(withStyles(styles)(EditTitleBar));
-
-EditTitleBar.propTypes = {
-    onChangeDescription: PropTypes.func.isRequired,
-    onChangeTitle: PropTypes.func.isRequired,
-    classes: PropTypes.object,
-    description: PropTypes.string,
-    name: PropTypes.string,
-};
-
-EditTitleBar.defaultProps = {
-    name: '',
-    description: '',
-};
+)(EditTitleBar);

--- a/src/components/TitleBar/ViewTitleBar.js
+++ b/src/components/TitleBar/ViewTitleBar.js
@@ -1,7 +1,6 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
 import { Link } from 'react-router-dom';
 import i18n from '@dhis2/d2-i18n';
 import SharingDialog from '@dhis2/d2-ui-sharing-dialog';
@@ -22,40 +21,10 @@ import {
     sGetDashboardById,
     sGetDashboardItems,
 } from '../../reducers/dashboards';
-import { colors } from '@dhis2/ui-core';
+
+import classes from './styles/ViewTitleBar.module.css';
 
 const NO_DESCRIPTION = i18n.t('No description');
-
-const styles = {
-    actions: {
-        display: 'flex',
-        alignItems: 'center',
-        marginLeft: '20px',
-    },
-    starIcon: {
-        fill: colors.grey600,
-    },
-    textButton: {
-        minWidth: '30px',
-        top: '1px',
-    },
-    editLink: {
-        display: 'inline-block',
-        verticalAlign: 'top',
-        textDecoration: 'none',
-        marginRight: '4px',
-    },
-    titleBar: {
-        display: 'flex',
-        alignItems: 'flex-start',
-    },
-    titleBarIcon: {
-        marginLeft: 5,
-        position: 'relative',
-        top: 1,
-        cursor: 'pointer',
-    },
-};
 
 class ViewTitleBar extends Component {
     constructor(props) {
@@ -80,7 +49,6 @@ class ViewTitleBar extends Component {
             starred,
             onStarClick,
             onInfoClick,
-            classes,
         } = this.props;
 
         const titleStyle = Object.assign({}, style.title, {
@@ -92,7 +60,7 @@ class ViewTitleBar extends Component {
         const StarIcon = starred ? Star : StarBorder;
 
         return (
-            <Fragment>
+            <>
                 <div className={classes.titleBar}>
                     <span style={titleStyle}>{name}</span>
                     <div className={classes.actions}>
@@ -148,10 +116,34 @@ class ViewTitleBar extends Component {
                         onRequestClose={this.toggleSharingDialog}
                     />
                 ) : null}
-            </Fragment>
+            </>
         );
     }
 }
+
+ViewTitleBar.propTypes = {
+    access: PropTypes.object,
+    description: PropTypes.string,
+    id: PropTypes.string,
+    name: PropTypes.string,
+    showDescription: PropTypes.bool,
+    starred: PropTypes.bool,
+    style: PropTypes.object,
+    onInfoClick: PropTypes.func,
+    onStarClick: PropTypes.func,
+};
+
+ViewTitleBar.defaultProps = {
+    name: '',
+    description: '',
+    starred: false,
+    showDescription: false,
+    onInfoClick: null,
+};
+
+ViewTitleBar.contextTypes = {
+    d2: PropTypes.object,
+};
 
 const mapStateToProps = state => {
     const id = sGetSelectedId(state);
@@ -185,29 +177,4 @@ export default connect(
     mapStateToProps,
     null,
     mergeProps
-)(withStyles(styles)(ViewTitleBar));
-
-ViewTitleBar.propTypes = {
-    access: PropTypes.object,
-    classes: PropTypes.object,
-    description: PropTypes.string,
-    id: PropTypes.string,
-    name: PropTypes.string,
-    showDescription: PropTypes.bool,
-    starred: PropTypes.bool,
-    style: PropTypes.object,
-    onInfoClick: PropTypes.func,
-    onStarClick: PropTypes.func,
-};
-
-ViewTitleBar.defaultProps = {
-    name: '',
-    description: '',
-    starred: false,
-    showDescription: false,
-    onInfoClick: null,
-};
-
-ViewTitleBar.contextTypes = {
-    d2: PropTypes.object,
-};
+)(ViewTitleBar);

--- a/src/components/TitleBar/ViewTitleBar.js
+++ b/src/components/TitleBar/ViewTitleBar.js
@@ -11,7 +11,7 @@ import { orObject } from '../../modules/util';
 import { tStarDashboard } from '../../actions/dashboards';
 import { acSetSelectedShowDescription } from '../../actions/selected';
 import FilterSelector from '../ItemFilter/FilterSelector';
-import { Button } from '@dhis2/ui-core';
+import { Button, colors } from '@dhis2/ui-core';
 import Info from './Info';
 import {
     sGetSelectedId,
@@ -68,7 +68,7 @@ class ViewTitleBar extends Component {
                             className={classes.titleBarIcon}
                             onClick={onStarClick}
                         >
-                            <StarIcon className={classes.starIcon} />
+                            <StarIcon style={{ fill: colors.grey600 }} />
                         </div>
                         <div className={classes.titleBarIcon}>
                             <Info onClick={onInfoClick} />

--- a/src/components/TitleBar/__tests__/__snapshots__/EditTitleBar.spec.js.snap
+++ b/src/components/TitleBar/__tests__/__snapshots__/EditTitleBar.spec.js.snap
@@ -37,7 +37,7 @@ ShallowWrapper {
     "props": Object {
       "children": Array [
         <div
-          className="titledesc"
+          className="titleDescription"
         >
           <InputField
             className="title"
@@ -97,7 +97,7 @@ ShallowWrapper {
               width="100%"
             />,
           ],
-          "className": "titledesc",
+          "className": "titleDescription",
         },
         "ref": null,
         "rendered": Array [
@@ -171,7 +171,7 @@ ShallowWrapper {
       "props": Object {
         "children": Array [
           <div
-            className="titledesc"
+            className="titleDescription"
           >
             <InputField
               className="title"
@@ -231,7 +231,7 @@ ShallowWrapper {
                 width="100%"
               />,
             ],
-            "className": "titledesc",
+            "className": "titleDescription",
           },
           "ref": null,
           "rendered": Array [
@@ -361,7 +361,7 @@ ShallowWrapper {
     "props": Object {
       "children": Array [
         <div
-          className="titledesc"
+          className="titleDescription"
         >
           <InputField
             className="title"
@@ -421,7 +421,7 @@ ShallowWrapper {
               width="100%"
             />,
           ],
-          "className": "titledesc",
+          "className": "titleDescription",
         },
         "ref": null,
         "rendered": Array [
@@ -495,7 +495,7 @@ ShallowWrapper {
       "props": Object {
         "children": Array [
           <div
-            className="titledesc"
+            className="titleDescription"
           >
             <InputField
               className="title"
@@ -555,7 +555,7 @@ ShallowWrapper {
                 width="100%"
               />,
             ],
-            "className": "titledesc",
+            "className": "titleDescription",
           },
           "ref": null,
           "rendered": Array [

--- a/src/components/TitleBar/styles/EditTitleBar.module.css
+++ b/src/components/TitleBar/styles/EditTitleBar.module.css
@@ -2,7 +2,7 @@
     display: flex;
     justify-content: space-between;
 }
-.title-description {
+.titleDescription {
     flex: 3;
     margin-right: 50px;
 }
@@ -15,21 +15,7 @@
     clear: both;
     margin-top: 15px;
 }
-.underline:before {
-    border-bottom: none;
-}
-.underline:hover::before {
-    border-bottom: none !important;
-}
-.input {
-    background-color: rgba(0 0 10 0.05);
-    border-radius: 4px;
-    width: 100%;
-    &:hover {
-        background-color: rgba(0 0 10 0.08);
-    }
-}
-.item-selector {
+.itemSelector {
     flex: 2;
     position: relative;
 }

--- a/src/components/TitleBar/styles/EditTitleBar.module.css
+++ b/src/components/TitleBar/styles/EditTitleBar.module.css
@@ -1,0 +1,35 @@
+.section {
+    display: flex;
+    justify-content: space-between;
+}
+.title-description {
+    flex: 3;
+    margin-right: 50px;
+}
+.title {
+    display: block;
+    clear: both;
+}
+.description {
+    display: block;
+    clear: both;
+    margin-top: 15px;
+}
+.underline:before {
+    border-bottom: none;
+}
+.underline:hover::before {
+    border-bottom: none !important;
+}
+.input {
+    background-color: rgba(0 0 10 0.05);
+    border-radius: 4px;
+    width: 100%;
+    &:hover {
+        background-color: rgba(0 0 10 0.08);
+    }
+}
+.item-selector {
+    flex: 2;
+    position: relative;
+}

--- a/src/components/TitleBar/styles/ViewTitleBar.module.css
+++ b/src/components/TitleBar/styles/ViewTitleBar.module.css
@@ -3,10 +3,6 @@
     align-items: center;
     margin-left: 20px;
 }
-.textButton {
-    min-width: 30px;
-    top: 1px;
-}
 .editLink {
     display: inline-block;
     vertical-align: top;

--- a/src/components/TitleBar/styles/ViewTitleBar.module.css
+++ b/src/components/TitleBar/styles/ViewTitleBar.module.css
@@ -3,9 +3,6 @@
     align-items: center;
     margin-left: 20px;
 }
-.starIcon {
-    fill: var(--colors-grey600);
-}
 .textButton {
     min-width: 30px;
     top: 1px;

--- a/src/components/TitleBar/styles/ViewTitleBar.module.css
+++ b/src/components/TitleBar/styles/ViewTitleBar.module.css
@@ -1,0 +1,28 @@
+.actions {
+    display: flex;
+    align-items: center;
+    margin-left: 20px;
+}
+.starIcon {
+    fill: var(--colors-grey600);
+}
+.textButton {
+    min-width: 30px;
+    top: 1px;
+}
+.editLink {
+    display: inline-block;
+    vertical-align: top;
+    text-decoration: none;
+    margin-right: 4px;
+}
+.titleBar {
+    display: flex;
+    align-items: flex-start;
+}
+.titleBarIcon {
+    margin-left: 5;
+    position: relative;
+    top: 1;
+    cursor: pointer;
+}


### PR DESCRIPTION
No functional changes

Changes include:
* replace `<Fragment>` with `<>`
* port css to css modules

Updating the app to follow the css standard determined here: https://github.com/dhis2/notes/issues/79#issuecomment-563933328


Fixes: https://jira.dhis2.org/browse/TECH-337