### PR TITLE
Fix/new report items not showing (v34) (DHIS2-8567)

### DIFF
--- a/src/actions/editDashboard.js
+++ b/src/actions/editDashboard.js
@@ -14,7 +14,10 @@ import {
 import { sGetEditDashboardRoot } from '../reducers/editDashboard';
 import { updateDashboard, postDashboard } from '../api/editDashboard';
 import { tSetSelectedDashboardById } from '../actions/selected';
-import { NEW_ITEM_SHAPE } from '../components/ItemGrid/gridUtil';
+import {
+    NEW_ITEM_SHAPE,
+    getGridItemProperties,
+} from '../components/ItemGrid/gridUtil';
 import {
     itemTypeMap,
     isSpacerType,
@@ -70,13 +73,17 @@ export const acAddDashboardItem = item => {
     delete item.type;
     const itemPropName = itemTypeMap[type].propName;
 
+    const id = generateUid();
+    const gridItemProperties = getGridItemProperties(id);
+
     return {
         type: ADD_DASHBOARD_ITEM,
         value: {
-            id: generateUid(),
+            id,
             type,
             [itemPropName]: item.content,
             ...NEW_ITEM_SHAPE,
+            ...gridItemProperties,
         },
     };
 };

--- a/src/components/ItemGrid/ItemGrid.js
+++ b/src/components/ItemGrid/ItemGrid.js
@@ -92,13 +92,14 @@ export class ItemGrid extends Component {
 
     adjustHeightForExpanded = dashboardItem => {
         const expandedItem = this.state.expandedItems[dashboardItem.id];
-        const hProp = { h: dashboardItem.h };
 
         if (expandedItem && expandedItem === true) {
-            hProp.h = dashboardItem.h + EXPANDED_HEIGHT;
+            return Object.assign({}, dashboardItem, {
+                h: dashboardItem.h + EXPANDED_HEIGHT,
+            });
         }
 
-        return Object.assign({}, dashboardItem, hProp);
+        return dashboardItem;
     };
 
     getItemComponent = item => {

--- a/src/components/ItemGrid/ItemGrid.js
+++ b/src/components/ItemGrid/ItemGrid.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import memoize from 'lodash/memoize';
 import i18n from '@dhis2/d2-i18n';
 import ReactGridLayout from 'react-grid-layout';
 import { CircularLoader, ScreenCover } from '@dhis2/ui-core';
@@ -16,7 +15,6 @@ import { isVisualizationType } from '../../modules/itemTypes';
 import {
     GRID_ROW_HEIGHT,
     GRID_COMPACT_TYPE,
-    ITEM_MIN_HEIGHT,
     MARGIN,
     getGridColumns,
     hasShape,
@@ -49,12 +47,6 @@ export class ItemGrid extends Component {
     state = {
         expandedItems: {},
     };
-
-    constructor(props) {
-        super(props);
-
-        this.getMemoizedItem = memoize(this.getItem);
-    }
 
     onToggleItemExpanded = clickedId => {
         const isExpanded =
@@ -98,7 +90,7 @@ export class ItemGrid extends Component {
 
     onRemoveItemWrapper = id => () => this.onRemoveItem(id);
 
-    getItem = dashboardItem => {
+    adjustHeightForExpanded = dashboardItem => {
         const expandedItem = this.state.expandedItems[dashboardItem.id];
         const hProp = { h: dashboardItem.h };
 
@@ -106,15 +98,8 @@ export class ItemGrid extends Component {
             hProp.h = dashboardItem.h + EXPANDED_HEIGHT;
         }
 
-        return Object.assign({}, dashboardItem, hProp, {
-            i: dashboardItem.id,
-            minH: ITEM_MIN_HEIGHT,
-            randomNumber: Math.random(),
-        });
+        return Object.assign({}, dashboardItem, hProp);
     };
-
-    getItems = dashboardItems =>
-        dashboardItems.map(item => this.getMemoizedItem(item));
 
     getItemComponent = item => {
         const itemClassNames = [
@@ -150,8 +135,8 @@ export class ItemGrid extends Component {
         }
 
         const items = edit
-            ? this.getItems(dashboardItems)
-            : dashboardItems.map(this.getItem);
+            ? dashboardItems
+            : dashboardItems.map(this.adjustHeightForExpanded);
 
         return (
             <div className="grid-wrapper">

--- a/src/components/ItemGrid/gridUtil.js
+++ b/src/components/ItemGrid/gridUtil.js
@@ -11,7 +11,6 @@ const GRID_LAYOUT = 'FLEXIBLE'; // FIXED | FLEXIBLE
 export const MARGIN = [10, 10];
 
 export const NEW_ITEM_SHAPE = { x: 0, y: 0, w: 20, h: 29 };
-export const ITEM_MIN_HEIGHT = 4;
 
 // Dimensions for getShape
 
@@ -58,6 +57,13 @@ export const getShape = i => {
         y: row * itemHeight,
         w: itemWidth,
         h: itemHeight,
+    };
+};
+
+export const getGridItemProperties = itemId => {
+    return {
+        i: itemId,
+        minH: 4, // minimum height for item
     };
 };
 

--- a/src/reducers/dashboards.js
+++ b/src/reducers/dashboards.js
@@ -13,6 +13,7 @@ import {
     CHART,
     VISUALIZATION,
 } from '../modules/itemTypes';
+import { getGridItemProperties } from '../components/ItemGrid/gridUtil';
 
 export const SET_DASHBOARDS = 'SET_DASHBOARDS';
 export const ADD_DASHBOARDS = 'ADD_DASHBOARDS';
@@ -189,10 +190,13 @@ export const getCustomDashboards = data => {
                     : item.text
                 : null;
 
+            const gridProperties = getGridItemProperties(item.id);
+
             return {
                 ...item,
                 ...(text !== null ? { text } : {}),
                 type,
+                ...gridProperties,
             };
         });
 

--- a/src/reducers/editDashboard.js
+++ b/src/reducers/editDashboard.js
@@ -103,7 +103,13 @@ export default (state = DEFAULT_STATE_EDIT_DASHBOARD, action) => {
             if (dashboardItemIndex > -1) {
                 const newState = update(state, {
                     dashboardItems: {
-                        $splice: [[dashboardItemIndex, 1, dashboardItem]],
+                        $splice: [
+                            [
+                                dashboardItemIndex,
+                                1,
+                                Object.assign({}, dashboardItem),
+                            ],
+                        ],
                     },
                 });
 


### PR DESCRIPTION
The memoized function was not detecting that the Reports (List item) dashboard item had changed if a report was added. Therefore it appeared that the items weren't being added.

Use redux properly rather than resorting to memoize for grid item properties.

Fixes: https://jira.dhis2.org/browse/DHIS2-8567

Thorough testing needed. Memoize was part of a performance improvement (in edit mode) so that needs to be checked again. And we need to make sure all the item types are behaving properly in edit (ie., resize, move, type text, delete, add...) and view mode (i.e., view interpretations).