### PR TITLE
fix: change the url for report links (DHIS2-8600)

### DIFF
--- a/src/modules/itemTypes.js
+++ b/src/modules/itemTypes.js
@@ -112,8 +112,7 @@ export const itemTypeMap = {
         endPointName: 'reports',
         propName: 'reports',
         pluralTitle: i18n.t('Reports'),
-        appUrl: id =>
-            `dhis-web-reporting/getReportParams.action?mode=report&uid=${id}`,
+        appUrl: id => `dhis-web-reports/#/standard-report/view/${id}`,
     },
     [RESOURCES]: {
         id: RESOURCES,


### PR DESCRIPTION
Changes the report links from
`dhis-web-reporting/getReportParams.action?mode=report&uid=<id>`
to
`dhis-web-reports/index.action#/standard-report/view/<id>`