### PR TITLE
fix: hide titles for maps (DHIS2-8616)

### DIFF
--- a/src/components/Item/VisualizationItem/DefaultPlugin.js
+++ b/src/components/Item/VisualizationItem/DefaultPlugin.js
@@ -84,6 +84,7 @@ class DefaultPlugin extends Component {
             pluginManager.load(this.props.item, this.props.visualization, {
                 credentials: this.pluginCredentials,
                 activeType: !this.props.editMode ? this.getActiveType() : null,
+                options: this.props.options,
             });
         }
     }
@@ -121,6 +122,7 @@ DefaultPlugin.propTypes = {
     editMode: PropTypes.bool,
     item: PropTypes.object,
     itemFilters: PropTypes.object,
+    options: PropTypes.object,
     style: PropTypes.object,
     visualization: PropTypes.object,
 };
@@ -129,6 +131,7 @@ DefaultPlugin.defaultProps = {
     style: {},
     item: {},
     itemFilters: {},
+    options: {},
     visualization: {},
 };
 

--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -202,10 +202,6 @@ export class Item extends Component {
                         ...props.visualization,
                         mapViews,
                     };
-
-                    props.options = {
-                        hideTitle: true,
-                    };
                 } else {
                     // this is the case of a non map AO passed to the maps plugin
                     // due to a visualization type switch in dashboard item
@@ -215,6 +211,11 @@ export class Item extends Component {
                         props.itemFilters
                     );
                 }
+
+                props.options = {
+                    ...props.options,
+                    hideTitle: true,
+                };
 
                 return <DefaultPlugin {...props} />;
             }

--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -202,6 +202,10 @@ export class Item extends Component {
                         ...props.visualization,
                         mapViews,
                     };
+
+                    props.options = {
+                        hideTitle: true,
+                    };
                 } else {
                     // this is the case of a non map AO passed to the maps plugin
                     // due to a visualization type switch in dashboard item

--- a/src/components/Item/VisualizationItem/plugin.js
+++ b/src/components/Item/VisualizationItem/plugin.js
@@ -85,10 +85,11 @@ export const getLink = (item, d2) => {
 export const load = async (
     item,
     visualization,
-    { credentials, activeType }
+    { credentials, activeType, options = {} }
 ) => {
     const config = {
         ...visualization,
+        ...options,
         el: getGridItemDomId(item.id),
     };
 


### PR DESCRIPTION
Fixes https://jira.dhis2.org/browse/DHIS2-8616 which utilizes https://jira.dhis2.org/browse/DHIS2-8618

Adds support for passing options as part of the plugin call.

Passes `hideTitle: true` to the maps plugin.

Removes this title overlay:
<img width="463" alt="map-with-title" src="https://user-images.githubusercontent.com/1010094/78874674-0ac56300-7a4d-11ea-8a70-9ade21ca8a79.png">
