### PR TITLE
chore: replace mui circular loader with ui-core

### DIFF
--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -162,7 +162,7 @@ export class Item extends Component {
             case REPORT_TABLE: {
                 return (
                     <>
-                        {this.state.pluginIsLoaded && (
+                        {!this.state.pluginIsLoaded && (
                             <div style={props.style}>
                                 <LoadingMask />
                             </div>

--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -162,11 +162,11 @@ export class Item extends Component {
             case REPORT_TABLE: {
                 return (
                     <>
-                        {!this.state.pluginIsLoaded ? (
+                        {!this.state.pluginIsLoaded && (
                             <div className={classes.loadingCover}>
                                 <LoadingMask />
                             </div>
-                        ) : null}
+                        )}
                         <VisualizationPlugin
                             d2={this.d2}
                             visualization={this.memoizedApplyFilters(

--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -162,8 +162,8 @@ export class Item extends Component {
             case REPORT_TABLE: {
                 return (
                     <>
-                        {!this.state.pluginIsLoaded && (
-                            <div style={props.style} className={classes.cover}>
+                        {this.state.pluginIsLoaded && (
+                            <div style={props.style}>
                                 <LoadingMask />
                             </div>
                         )}

--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -163,7 +163,7 @@ export class Item extends Component {
                 return (
                     <>
                         {!this.state.pluginIsLoaded && (
-                            <div className={classes.loadingCover}>
+                            <div style={props.style} className={classes.cover}>
                                 <LoadingMask />
                             </div>
                         )}

--- a/src/components/Item/VisualizationItem/LoadingMask.js
+++ b/src/components/Item/VisualizationItem/LoadingMask.js
@@ -1,13 +1,11 @@
 import React from 'react';
-import { CircularLoader } from '@dhis2/ui-core';
-
-import classes from './styles/LoadingMask.module.css';
+import { ComponentCover, CircularLoader } from '@dhis2/ui-core';
 
 function LoadingMask() {
     return (
-        <div className={classes.mask}>
+        <ComponentCover>
             <CircularLoader />
-        </div>
+        </ComponentCover>
     );
 }
 

--- a/src/components/Item/VisualizationItem/LoadingMask.js
+++ b/src/components/Item/VisualizationItem/LoadingMask.js
@@ -5,10 +5,8 @@ import classes from './styles/LoadingMask.module.css';
 
 const LoadingMask = () => {
     return (
-        <div className={classes.vertical}>
-            <div className={classes.horizontal}>
-                <CircularLoader />
-            </div>
+        <div className={classes.center}>
+            <CircularLoader />
         </div>
     );
 };

--- a/src/components/Item/VisualizationItem/LoadingMask.js
+++ b/src/components/Item/VisualizationItem/LoadingMask.js
@@ -1,11 +1,13 @@
 import React from 'react';
-import { ComponentCover, CircularLoader } from '@dhis2/ui-core';
+import { CircularLoader } from '@dhis2/ui-core';
+
+import classes from './styles/LoadingMask.module.css';
 
 function LoadingMask() {
     return (
-        <ComponentCover>
+        <div className={classes.mask}>
             <CircularLoader />
-        </ComponentCover>
+        </div>
     );
 }
 

--- a/src/components/Item/VisualizationItem/LoadingMask.js
+++ b/src/components/Item/VisualizationItem/LoadingMask.js
@@ -1,14 +1,12 @@
 import React from 'react';
-import CircularProgress from '@material-ui/core/CircularProgress';
+import { ComponentCover, CircularLoader } from '@dhis2/ui-core';
 
-import classes from './styles/LoadingMask.module.css';
-
-function CircularIndeterminate() {
+function LoadingMask() {
     return (
-        <div className={classes.outer}>
-            <CircularProgress className={classes.progress} />
-        </div>
+        <ComponentCover>
+            <CircularLoader />
+        </ComponentCover>
     );
 }
 
-export default CircularIndeterminate;
+export default LoadingMask;

--- a/src/components/Item/VisualizationItem/LoadingMask.js
+++ b/src/components/Item/VisualizationItem/LoadingMask.js
@@ -1,12 +1,16 @@
 import React from 'react';
-import { ComponentCover, CircularLoader } from '@dhis2/ui-core';
+import { CircularLoader } from '@dhis2/ui-core';
 
-function LoadingMask() {
+import classes from './styles/LoadingMask.module.css';
+
+const LoadingMask = () => {
     return (
-        <ComponentCover>
-            <CircularLoader />
-        </ComponentCover>
+        <div className={classes.vertical}>
+            <div className={classes.horizontal}>
+                <CircularLoader />
+            </div>
+        </div>
     );
-}
+};
 
 export default LoadingMask;

--- a/src/components/Item/VisualizationItem/styles/Item.module.css
+++ b/src/components/Item/VisualizationItem/styles/Item.module.css
@@ -4,12 +4,3 @@
     padding: 10px;
     line-height: 20px;
 }
-
-.cover {
-    position: absolute;
-    top: auto;
-    left: 0;
-    width: 100%;
-    z-index: 100;
-    background-color: var(--colors-white);
-}

--- a/src/components/Item/VisualizationItem/styles/Item.module.css
+++ b/src/components/Item/VisualizationItem/styles/Item.module.css
@@ -4,8 +4,12 @@
     padding: 10px;
     line-height: 20px;
 }
-.loadingCover {
-    height: 100%;
+
+.cover {
+    position: absolute;
+    top: auto;
+    left: 0;
     width: 100%;
-    margin-left: -4px;
+    z-index: 100;
+    background-color: var(--colors-white);
 }

--- a/src/components/Item/VisualizationItem/styles/Item.module.css
+++ b/src/components/Item/VisualizationItem/styles/Item.module.css
@@ -5,11 +5,7 @@
     line-height: 20px;
 }
 .loadingCover {
-    position: absolute;
     height: 100%;
     width: 100%;
-    left: 0;
-    top: 0;
-    z-index: 100;
-    background: #ffffff;
+    margin-left: -4px;
 }

--- a/src/components/Item/VisualizationItem/styles/LoadingMask.module.css
+++ b/src/components/Item/VisualizationItem/styles/LoadingMask.module.css
@@ -1,0 +1,10 @@
+.vertical {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    height: 100%;
+}
+
+.horizontal {
+    margin: 0 auto;
+}

--- a/src/components/Item/VisualizationItem/styles/LoadingMask.module.css
+++ b/src/components/Item/VisualizationItem/styles/LoadingMask.module.css
@@ -1,6 +1,0 @@
-.mask {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 100%;
-}

--- a/src/components/Item/VisualizationItem/styles/LoadingMask.module.css
+++ b/src/components/Item/VisualizationItem/styles/LoadingMask.module.css
@@ -1,10 +1,6 @@
-.vertical {
+.center {
     display: flex;
-    flex-direction: column;
     justify-content: center;
     height: 100%;
-}
-
-.horizontal {
-    margin: 0 auto;
+    align-items: center;
 }

--- a/src/components/Item/VisualizationItem/styles/LoadingMask.module.css
+++ b/src/components/Item/VisualizationItem/styles/LoadingMask.module.css
@@ -1,11 +1,6 @@
-.progress {
-    margin: var(--spacers-dp16);
-    max-width: 200px;
-    text-align: center;
-    align-self: center;
-}
-.outer {
+.mask {
     display: flex;
+    align-items: center;
     justify-content: center;
     height: 100%;
 }


### PR DESCRIPTION
This version also shows the item title and actions, giving the user a little more info and options if a visualization is not loading:

![image](https://user-images.githubusercontent.com/6113918/80150222-d5e8fe00-856c-11ea-984a-1b53c7a8eebc.png)

[TECH-343]
Fixes: https://jira.dhis2.org/browse/TECH-343