### PR TITLE
fix: return the right url for reports based on type (DHIS2-8600)

### DIFF
--- a/src/api/metadata.js
+++ b/src/api/metadata.js
@@ -81,7 +81,7 @@ export const getFavoritesFields = ({ withDimensions }) => [
 
 // List item
 export const getListItemFields = () => [
-    `reports[${getIdNameFields({ rename: true }).join(',')}]`,
+    `reports[${['type', ...getIdNameFields({ rename: true })].join(',')}]`,
     `resources[${getIdNameFields({ rename: true }).join(',')}]`,
     `users[${getIdNameFields({ rename: true }).join(',')}]`,
 ];

--- a/src/modules/itemTypes.js
+++ b/src/modules/itemTypes.js
@@ -112,7 +112,17 @@ export const itemTypeMap = {
         endPointName: 'reports',
         propName: 'reports',
         pluralTitle: i18n.t('Reports'),
-        appUrl: id => `dhis-web-reports/#/standard-report/view/${id}`,
+        appUrl: (id, type) => {
+            switch(type) {
+                case 'HTML':
+                    return `dhis-web-reports/#/standard-report/view/${id}`;
+
+                case 'JASPER_REPORT_TABLE':
+                case 'JASPER_JDBC':
+                default:
+                    return `api/reports/${id}/data.pdf?t=${(new Date()).getTime()}`;
+            }
+        },
     },
     [RESOURCES]: {
         id: RESOURCES,
@@ -150,7 +160,7 @@ export const getItemUrl = (type, item, d2) => {
     }
 
     if (itemTypeMap[type] && itemTypeMap[type].appUrl) {
-        url = `${getBaseUrl(d2)}/${itemTypeMap[type].appUrl(item.id)}`;
+        url = `${getBaseUrl(d2)}/${itemTypeMap[type].appUrl(item.id, item.type)}`;
     }
 
     return url;


### PR DESCRIPTION
This fixes the problem where all report urls point to the reports app. Only reports of type "HTML" should do so. Now reports of type "JASPER_REPORT_TABLE" and "JASPER_JDBC" point to api/reports endpoint instead.