### PR TITLE
fix: use latest analytics version to get period selector translations (v33)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "license": "BSD-3-Clause",
     "dependencies": {
-        "@dhis2/analytics": "2.4.12",
+        "@dhis2/analytics": "~2.4.14",
         "@dhis2/d2-i18n": "^1.0.6",
         "@dhis2/d2-ui-core": "^7.0.2",
         "@dhis2/d2-ui-interpretations": "^7.0.2",
@@ -13,7 +13,7 @@
         "@dhis2/d2-ui-rich-text": "^7.0.2",
         "@dhis2/d2-ui-sharing-dialog": "^7.0.2",
         "@dhis2/d2-ui-translation-dialog": "^7.0.2",
-        "@dhis2/data-visualizer-plugin": "^33.1.11",
+        "@dhis2/data-visualizer-plugin": "^33.1.12",
         "@dhis2/ui": "1.0.0-beta.15",
         "@dhis2/ui-core": "2.5.1",
         "@material-ui/core": "^3.9.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "license": "BSD-3-Clause",
     "dependencies": {
-        "@dhis2/analytics": "~2.4.14",
+        "@dhis2/analytics": "~2.4.15",
         "@dhis2/d2-i18n": "^1.0.6",
         "@dhis2/d2-ui-core": "^7.0.2",
         "@dhis2/d2-ui-interpretations": "^7.0.2",
@@ -13,7 +13,7 @@
         "@dhis2/d2-ui-rich-text": "^7.0.2",
         "@dhis2/d2-ui-sharing-dialog": "^7.0.2",
         "@dhis2/d2-ui-translation-dialog": "^7.0.2",
-        "@dhis2/data-visualizer-plugin": "^33.1.12",
+        "@dhis2/data-visualizer-plugin": "^33.1.13",
         "@dhis2/ui": "1.0.0-beta.15",
         "@dhis2/ui-core": "2.5.1",
         "@material-ui/core": "^3.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1022,10 +1022,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
-"@dhis2/analytics@2.4.12", "@dhis2/analytics@~2.4.12":
-  version "2.4.12"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-2.4.12.tgz#2e27a8a8d63d3d2f7795d044bf69a9f96e76362c"
-  integrity sha512-YM0ckmWZAJTNFxY8RkZr3EsekGkVGFbzpWL5lB2F9iPOep8CdqKJOBcQfO5LwY57JExbAqaVh1mwJY+m2Li0oQ==
+"@dhis2/analytics@~2.4.14":
+  version "2.4.14"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-2.4.14.tgz#423ba713507e195cdaef86009917ee4869a4208c"
+  integrity sha512-MwzbB7YAbsMo5c5ORxfUAgiOWjKVfFdTYg36VJCbnR1kUpKaguBYeZpe+DZDztEAfmFMnPQLDeIMl46/HCKc/A==
   dependencies:
     "@dhis2/d2-ui-org-unit-dialog" "^7.0.2"
     "@dhis2/ui-core" "^3.4.0"
@@ -1161,12 +1161,12 @@
     react-select "^2.0.0"
     rxjs "^5.5.7"
 
-"@dhis2/data-visualizer-plugin@^33.1.11":
-  version "33.1.11"
-  resolved "https://registry.yarnpkg.com/@dhis2/data-visualizer-plugin/-/data-visualizer-plugin-33.1.11.tgz#b77ffec96612fe5f42e1f0f37541549d6c32c980"
-  integrity sha512-5STiX9/55imZvQmJ119Lxmm0kyVVLDGjfmoFaXrtsqVzfhWqpauv+EFSEgR2XU3JzcNr9Onb04MzB27P24vyRg==
+"@dhis2/data-visualizer-plugin@^33.1.12":
+  version "33.1.12"
+  resolved "https://registry.yarnpkg.com/@dhis2/data-visualizer-plugin/-/data-visualizer-plugin-33.1.12.tgz#920d2f85d947ba5a1021814b612c6e954545ab19"
+  integrity sha512-5sKK3tLSgp0L/z0c/LacDSZOPP0pOMwO9Y/QiUrCrsVAm12TzyN8IAxYF7+1WOrJuVuzzG6h7XJxZODn8Rs5uw==
   dependencies:
-    "@dhis2/analytics" "~2.4.12"
+    "@dhis2/analytics" "~2.4.14"
     "@material-ui/core" "^3.1.2"
     lodash-es "^4.17.11"
     react "^16.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1022,10 +1022,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
-"@dhis2/analytics@~2.4.14":
-  version "2.4.14"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-2.4.14.tgz#423ba713507e195cdaef86009917ee4869a4208c"
-  integrity sha512-MwzbB7YAbsMo5c5ORxfUAgiOWjKVfFdTYg36VJCbnR1kUpKaguBYeZpe+DZDztEAfmFMnPQLDeIMl46/HCKc/A==
+"@dhis2/analytics@~2.4.15":
+  version "2.4.15"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-2.4.15.tgz#98fada63b9ce450c9c5bd448939d298e0d4aa831"
+  integrity sha512-3IECcaJDkvi9emJK44QagKplD2fRLND2inhOtXG17ntVQKczor9LAM98XPIUsuJ+bf76XpQ9lN0pK9rja6gkUQ==
   dependencies:
     "@dhis2/d2-ui-org-unit-dialog" "^7.0.2"
     "@dhis2/ui-core" "^3.4.0"
@@ -1161,12 +1161,12 @@
     react-select "^2.0.0"
     rxjs "^5.5.7"
 
-"@dhis2/data-visualizer-plugin@^33.1.12":
-  version "33.1.12"
-  resolved "https://registry.yarnpkg.com/@dhis2/data-visualizer-plugin/-/data-visualizer-plugin-33.1.12.tgz#920d2f85d947ba5a1021814b612c6e954545ab19"
-  integrity sha512-5sKK3tLSgp0L/z0c/LacDSZOPP0pOMwO9Y/QiUrCrsVAm12TzyN8IAxYF7+1WOrJuVuzzG6h7XJxZODn8Rs5uw==
+"@dhis2/data-visualizer-plugin@^33.1.13":
+  version "33.1.13"
+  resolved "https://registry.yarnpkg.com/@dhis2/data-visualizer-plugin/-/data-visualizer-plugin-33.1.13.tgz#cc7d4ee07dfa9c6dda67d5f2c7171c2243c52a80"
+  integrity sha512-yLi2ZU9Lb+SVytVAmxGuZCN+Aja9LHr9wFoh3iKb574MAbYI2nztfEpajJ/XBRMDdkXxzPuR3C5LzKiBQF1b4Q==
   dependencies:
-    "@dhis2/analytics" "~2.4.14"
+    "@dhis2/analytics" "~2.4.15"
     "@material-ui/core" "^3.1.2"
     lodash-es "^4.17.11"
     react "^16.6.0"


### PR DESCRIPTION
Part of fix for https://jira.dhis2.org/browse/DHIS2-8638

![image](https://user-images.githubusercontent.com/6113918/81885892-2e9a2e00-9550-11ea-8a48-da351d4a406c.png)
