### PR TITLE
fix: add some more space above description

### DIFF
--- a/src/components/TitleBar/ViewTitleBar.js
+++ b/src/components/TitleBar/ViewTitleBar.js
@@ -99,7 +99,7 @@ class ViewTitleBar extends Component {
                     <div
                         className="dashboard-description"
                         style={Object.assign(
-                            { paddingTop: '5px', paddingBottom: '5px' },
+                            { paddingTop: '10px', paddingBottom: '5px' },
                             style.description,
                             !description ? { color: '#888' } : {}
                         )}


### PR DESCRIPTION
Description rendered too close to the title bar.

![Screenshot from 2020-08-20 14-20-19](https://user-images.githubusercontent.com/1010094/90769355-630c4b80-e2f0-11ea-9e09-5bfed75edd42.png)