### PR TITLE
fix: base url in production

### DIFF
--- a/d2.config.js
+++ b/d2.config.js
@@ -1,6 +1,6 @@
 const config = {
     type: 'app',
-
+    coreApp: true,
     title: 'Dashboard',
 
     entryPoints: {


### PR DESCRIPTION
Hey @jenniferarnesen 

I'm opening this PR to fix the base url path in production. Currently the base url path resolves to `'../../..'` but we need it to resolve to `'..'`for core apps. Adding `coreApp` to the d2.config fixes this.