### PR TITLE
refactor: groundwork for persisting description toggle (DHIS2-9325)

### DIFF
--- a/src/actions/selected.js
+++ b/src/actions/selected.js
@@ -19,6 +19,7 @@ import { acAddVisualization } from './visualizations'
 
 import { apiFetchDashboard } from '../api/dashboards'
 import { storePreferredDashboardId } from '../api/localStorage'
+import { apiGetShowDescription } from '../api/description'
 
 import { withShape } from '../components/ItemGrid/gridUtil'
 import { loadingDashboardMsg } from '../components/SnackbarMessage/SnackbarMessage'
@@ -51,6 +52,8 @@ export const acSetSelectedShowDescription = value => ({
     value,
 })
 
+// thunks
+
 export const tLoadDashboard = id => async dispatch => {
     try {
         const dash = await apiFetchDashboard(id)
@@ -64,7 +67,6 @@ export const tLoadDashboard = id => async dispatch => {
     }
 }
 
-// thunks
 export const tSetSelectedDashboardById = id => async (dispatch, getState) => {
     dispatch(acSetSelectedIsLoading(true))
 
@@ -143,6 +145,24 @@ export const tSetSelectedDashboardById = id => async (dispatch, getState) => {
         const selected = await dispatch(tLoadDashboard(id))
 
         return onSuccess(selected)
+    } catch (err) {
+        return onError(err)
+    }
+}
+
+export const tSetShowDescription = () => async dispatch => {
+    const onSuccess = value => {
+        dispatch(acSetSelectedShowDescription(value))
+    }
+
+    const onError = error => {
+        console.log('Error (apiGetShowDescription): ', error)
+        return error
+    }
+
+    try {
+        const showDescription = await apiGetShowDescription()
+        return onSuccess(showDescription)
     } catch (err) {
         return onError(err)
     }

--- a/src/api/controlBar.js
+++ b/src/api/controlBar.js
@@ -1,33 +1,16 @@
-import { getInstance } from 'd2'
 import { DEFAULT_STATE_CONTROLBAR_ROWS } from '../reducers/controlBar'
+import {
+    apiGetUserDataStoreValue,
+    apiPostUserDataStoreValue,
+} from './userDataStore'
 
-const NAMESPACE = 'dashboard'
-const KEY = 'controlBarRows'
+const KEY_CONTROLBAR_ROWS = 'controlBarRows'
 
-const hasNamespace = async d2 => await d2.currentUser.dataStore.has(NAMESPACE)
+export const apiGetControlBarRows = async () =>
+    await apiGetUserDataStoreValue(
+        KEY_CONTROLBAR_ROWS,
+        DEFAULT_STATE_CONTROLBAR_ROWS
+    )
 
-const getNamespace = async (d2, hasNamespace) =>
-    hasNamespace
-        ? await d2.currentUser.dataStore.get(NAMESPACE)
-        : await d2.currentUser.dataStore.create(NAMESPACE)
-
-export const apiGetControlBarRows = async () => {
-    const d2 = await getInstance()
-    const namespace = await getNamespace(d2, await hasNamespace(d2))
-    const hasKey = namespace.keys && namespace.keys.find(key => key === KEY)
-
-    if (hasKey) {
-        return await namespace.get(KEY)
-    } else {
-        await apiPostControlBarRows(DEFAULT_STATE_CONTROLBAR_ROWS, namespace)
-        console.log('(These errors to /userDataStore/dashboard can be ignored)')
-        return DEFAULT_STATE_CONTROLBAR_ROWS
-    }
-}
-
-export const apiPostControlBarRows = async (rows, namespace) => {
-    const d2 = await getInstance()
-    const ns = namespace || (await getNamespace(d2, hasNamespace))
-
-    ns.set(KEY, rows)
-}
+export const apiPostControlBarRows = async value =>
+    await apiPostUserDataStoreValue(KEY_CONTROLBAR_ROWS, value)

--- a/src/api/controlBar.js
+++ b/src/api/controlBar.js
@@ -1,8 +1,8 @@
-import { DEFAULT_STATE_CONTROLBAR_ROWS } from '../reducers/controlBar'
 import {
     apiGetUserDataStoreValue,
     apiPostUserDataStoreValue,
 } from './userDataStore'
+import { DEFAULT_STATE_CONTROLBAR_ROWS } from '../reducers/controlBar'
 
 const KEY_CONTROLBAR_ROWS = 'controlBarRows'
 

--- a/src/api/description.js
+++ b/src/api/description.js
@@ -1,0 +1,16 @@
+import {
+    apiGetUserDataStoreValue,
+    apiPostUserDataStoreValue,
+} from './userDataStore'
+import { DEFAULT_STATE_SELECTED_SHOWDESCRIPTION } from '../reducers/selected'
+
+const KEY_SHOW_DESCRIPTION = 'showDescription'
+
+export const apiGetShowDescription = async () =>
+    await apiGetUserDataStoreValue(
+        KEY_SHOW_DESCRIPTION,
+        DEFAULT_STATE_SELECTED_SHOWDESCRIPTION
+    )
+
+export const apiPostShowDescription = async value =>
+    await apiPostUserDataStoreValue(KEY_SHOW_DESCRIPTION, value)

--- a/src/api/userDataStore.js
+++ b/src/api/userDataStore.js
@@ -1,0 +1,32 @@
+import { getInstance } from 'd2'
+
+export const NAMESPACE = 'dashboard'
+
+export const hasNamespace = async d2 =>
+    await d2.currentUser.dataStore.has(NAMESPACE)
+
+export const getNamespace = async (d2, hasNamespace) =>
+    hasNamespace
+        ? await d2.currentUser.dataStore.get(NAMESPACE)
+        : await d2.currentUser.dataStore.create(NAMESPACE)
+
+export const apiPostUserDataStoreValue = async (key, value) => {
+    const d2 = await getInstance()
+    const ns = await getNamespace(d2, hasNamespace)
+
+    ns.set(key, value)
+}
+
+export const apiGetUserDataStoreValue = async (key, defaultValue) => {
+    const d2 = await getInstance()
+    const namespace = await getNamespace(d2, await hasNamespace(d2))
+    const hasKey = namespace.keys && namespace.keys.find(k => k === key)
+
+    if (hasKey) {
+        return await namespace.get(key)
+    } else {
+        await apiPostUserDataStoreValue(key, defaultValue, namespace)
+        console.log('(These errors to /userDataStore can be ignored)')
+        return defaultValue
+    }
+}

--- a/src/api/userDataStore.js
+++ b/src/api/userDataStore.js
@@ -20,7 +20,7 @@ export const apiPostUserDataStoreValue = async (key, value) => {
 export const apiGetUserDataStoreValue = async (key, defaultValue) => {
     const d2 = await getInstance()
     const namespace = await getNamespace(d2, await hasNamespace(d2))
-    const hasKey = namespace.keys && namespace.keys.find(k => k === key)
+    const hasKey = namespace?.keys?.find(k => k === key)
 
     if (hasKey) {
         return await namespace.get(key)

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -9,6 +9,7 @@ import { EDIT, VIEW, NEW } from './Dashboard/dashboardModes'
 import { acReceivedUser } from '../actions/user'
 import { tFetchDashboards } from '../actions/dashboards'
 import { tSetControlBarRows } from '../actions/controlBar'
+import { tSetShowDescription } from '../actions/selected'
 import { tSetDimensions } from '../actions/dimensions'
 import Dashboard from './Dashboard/Dashboard'
 import SnackbarMessage from './SnackbarMessage/SnackbarMessage'
@@ -20,6 +21,7 @@ export class App extends Component {
         this.props.setCurrentUser(this.props.d2.currentUser)
         this.props.fetchDashboards()
         this.props.setControlBarRows()
+        this.props.setShowDescription()
         this.props.setDimensions(this.props.d2)
     }
 
@@ -74,6 +76,7 @@ App.propTypes = {
     setControlBarRows: PropTypes.func.isRequired,
     setCurrentUser: PropTypes.func.isRequired,
     setDimensions: PropTypes.func.isRequired,
+    setShowDescription: PropTypes.func.isRequired,
     baseUrl: PropTypes.string,
     d2: PropTypes.object,
 }
@@ -86,10 +89,11 @@ App.childContextTypes = {
 
 const mapDispatchToProps = dispatch => {
     return {
-        setCurrentUser: currentUser => dispatch(acReceivedUser(currentUser)),
         fetchDashboards: () => dispatch(tFetchDashboards()),
         setControlBarRows: () => dispatch(tSetControlBarRows()),
+        setCurrentUser: currentUser => dispatch(acReceivedUser(currentUser)),
         setDimensions: d2 => dispatch(tSetDimensions(d2)),
+        setShowDescription: () => dispatch(tSetShowDescription()),
     }
 }
 

--- a/src/components/__tests__/App.spec.js
+++ b/src/components/__tests__/App.spec.js
@@ -26,11 +26,12 @@ describe('App', () => {
 
     beforeEach(() => {
         props = {
-            d2: {},
-            setCurrentUser: jest.fn(),
             fetchDashboards: jest.fn(),
+            setCurrentUser: jest.fn(),
             setControlBarRows: jest.fn(),
             setDimensions: jest.fn(),
+            setShowDescription: jest.fn(),
+            d2: {},
         }
         shallowApp = undefined
         context = {


### PR DESCRIPTION
- Refactors the get/post for user data store to be reusable, this was tightly coupled to dashboard controlbar rows.
- Loads the persisted setting on app load and sets it in the redux store
- The value is stored in `<baseUrl>/api/userDataStore/dashboard/showDescription.json`

NB! Does not post the setting on toggle yet as this is done differently in https://github.com/dhis2/dashboards-app/tree/print-oipp-rebased