### PR TITLE
fix: setting selectedId to null caused endless spinner [DHIS2-9337]

### DIFF
--- a/src/actions/dashboards.js
+++ b/src/actions/dashboards.js
@@ -13,7 +13,6 @@ import {
 import { NON_EXISTING_DASHBOARD_ID } from '../reducers/selected'
 import { sGetUserUsername } from '../reducers/user'
 import { tSetSelectedDashboardById, acSetSelectedId } from './selected'
-import { acClearEditDashboard } from './editDashboard'
 import {
     apiFetchDashboards,
     apiStarDashboard,
@@ -110,10 +109,6 @@ export const tStarDashboard = (id, isStarred) => async dispatch => {
 export const tDeleteDashboard = id => async dispatch => {
     try {
         await apiDeleteDashboard(id)
-        dispatch(acClearEditDashboard())
-        dispatch(acSetSelectedId())
-        dispatch(acSetDashboardItems([]))
-
         await dispatch(tFetchDashboards())
 
         return Promise.resolve()


### PR DESCRIPTION
Due to changes in state handling in the Dashboard component, setting selectedId to null caused an endless spinner. Also removed the 2 other redux actions because these things (clear edit dashboard and clear dashboard items) will be executed when the route is changed right after the thunk completes.