### PR TITLE
fix: correctly calculate bottom of the printable area [DHIS2-9366]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,11 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-08-26T05:58:25.332Z\n"
-"PO-Revision-Date: 2020-08-26T05:58:25.332Z\n"
+"POT-Creation-Date: 2020-08-31T08:37:42.542Z\n"
+"PO-Revision-Date: 2020-08-31T08:37:42.542Z\n"
+
+msgid "Untitled dashboard"
+msgstr ""
 
 msgid "Cancel"
 msgstr ""
@@ -175,9 +178,6 @@ msgid "Text box"
 msgstr ""
 
 msgid "Dashboard title"
-msgstr ""
-
-msgid "Untitled dashboard"
 msgstr ""
 
 msgid "Dashboard description"

--- a/src/components/ItemGrid/PrintLayoutItemGrid.js
+++ b/src/components/ItemGrid/PrintLayoutItemGrid.js
@@ -4,11 +4,17 @@ import PropTypes from 'prop-types'
 import i18n from '@dhis2/d2-i18n'
 import ReactGridLayout from 'react-grid-layout'
 import { Layer, CenteredContent, CircularLoader } from '@dhis2/ui'
-import sortBy from 'lodash/sortBy'
 
 import { Item } from '../Item/Item'
+import NoContentMessage from '../../widgets/NoContentMessage'
 
 import { acUpdatePrintDashboardLayout } from '../../actions/printDashboard'
+import { sGetSelectedIsLoading } from '../../reducers/selected'
+import {
+    sGetPrintDashboardRoot,
+    sGetPrintDashboardItems,
+} from '../../reducers/printDashboard'
+
 import {
     GRID_ROW_HEIGHT,
     GRID_COMPACT_TYPE,
@@ -16,22 +22,18 @@ import {
     getGridColumns,
     hasShape,
 } from './gridUtil'
-import { orArray } from '../../modules/util'
-import { a4LandscapeWidthPx } from '../../modules/printUtils'
-import { PRINT_LAYOUT } from '../Dashboard/dashboardModes'
-import { itemTypeMap, PAGEBREAK } from '../../modules/itemTypes'
+import {
+    a4LandscapeWidthPx,
+    getDomGridItemsSortedByYPos,
+} from '../../modules/printUtils'
 
-import NoContentMessage from '../../widgets/NoContentMessage'
+import { PRINT_LAYOUT } from '../Dashboard/dashboardModes'
+import { PAGEBREAK } from '../../modules/itemTypes'
 
 import 'react-grid-layout/css/styles.css'
 import 'react-resizable/css/styles.css'
 
 import './ItemGrid.css'
-import { sGetSelectedIsLoading } from '../../reducers/selected'
-import {
-    sGetPrintDashboardRoot,
-    sGetPrintDashboardItems,
-} from '../../reducers/printDashboard'
 
 // this is set in the .dashboard-item-content css
 export const ITEM_CONTENT_PADDING_BOTTOM = 4
@@ -53,53 +55,27 @@ export class PrintLayoutItemGrid extends Component {
     getItemComponents = items => items.map(item => this.getItemComponent(item))
 
     hideExtraPageBreaks() {
-        const elements = Array.from(
-            document.querySelectorAll('.react-grid-item')
+        const sortedElements = getDomGridItemsSortedByYPos(
+            Array.from(document.querySelectorAll('.react-grid-item'))
         )
-
-        const types = Object.keys(itemTypeMap)
-        const items = elements.map(el => {
-            const classNames = el.className.split(' ')
-
-            const type = classNames.find(
-                className => types.indexOf(className) > -1
-            )
-
-            const rect = el.getBoundingClientRect()
-
-            return {
-                type,
-                el,
-                y: rect.y,
-                h: rect.height,
-            }
-        })
-        const sortedItems = sortBy(items, ['y'])
 
         let pageBreakBottom = 0
         let lastItemBottom = 0
         let foundNonPageBreak = false
 
-        for (let i = sortedItems.length - 1; i >= 0; --i) {
-            const item = sortedItems[i]
+        for (let i = sortedElements.length - 1; i >= 0; --i) {
+            const item = sortedElements[i]
             if (item.type === PAGEBREAK) {
                 if (!foundNonPageBreak) {
                     item.el.classList.add('removed')
                 } else {
-                    const y = item.el.style.transform
-                        ? item.el.style.transform.split(' ')[1].slice(0, -3)
-                        : item.y
-
-                    pageBreakBottom = parseInt(y) + parseInt(item.h)
+                    pageBreakBottom = item.bottomY
                     break
                 }
             } else {
                 foundNonPageBreak = true
-                const y = item.el.style.transform
-                    ? item.el.style.transform.split(' ')[1].slice(0, -3)
-                    : item.y
 
-                const thisItemBottom = parseInt(y) + parseInt(item.h)
+                const thisItemBottom = item.bottomY
                 if (thisItemBottom > lastItemBottom) {
                     lastItemBottom = thisItemBottom
                 }
@@ -192,9 +168,7 @@ const mapStateToProps = state => {
 
     return {
         isLoading: sGetSelectedIsLoading(state) || !selectedDashboard,
-        dashboardItems: orArray(sGetPrintDashboardItems(state)).filter(
-            hasShape
-        ),
+        dashboardItems: sGetPrintDashboardItems(state).filter(hasShape),
     }
 }
 

--- a/src/modules/__tests__/printUtils.spec.js
+++ b/src/modules/__tests__/printUtils.spec.js
@@ -1,0 +1,306 @@
+import { getDomGridItemsSortedByYPos } from '../printUtils'
+
+describe('printUtils', () => {
+    describe('getDomGridItemsSortedByYPos', () => {
+        it('handles empty array', () => {
+            expect(getDomGridItemsSortedByYPos([])).toEqual([])
+        })
+
+        it('handles grid items with page breaks - transform', () => {
+            const bottomItemH = 370
+            const bottomItemTy = '2390'
+            const elements = [
+                {
+                    classList: ['react-grid-item', 'PAGEBREAK'],
+                    getBoundingClientRect: () => ({
+                        y: 158,
+                        height: 50,
+                    }),
+                    style: {
+                        transform: 'translate(10px, 4690px)',
+                    },
+                },
+                {
+                    classList: ['react-grid-item', 'PAGEBREAK'],
+                    getBoundingClientRect: () => ({
+                        y: 158,
+                        height: 50,
+                    }),
+                    style: {
+                        transform: 'translate(10px, 3890px)',
+                    },
+                },
+                {
+                    classList: ['react-grid-item', 'PAGEBREAK'],
+                    getBoundingClientRect: () => ({
+                        y: 158,
+                        height: 50,
+                    }),
+                    style: {
+                        transform: 'translate(10px, 3090px)',
+                    },
+                },
+                {
+                    classList: ['react-grid-item', 'PAGEBREAK'],
+                    getBoundingClientRect: () => ({
+                        y: 158,
+                        height: 50,
+                    }),
+                    style: {
+                        transform: 'translate(10px, 2290px)',
+                    },
+                },
+                {
+                    classList: ['react-grid-item', 'PAGEBREAK'],
+                    getBoundingClientRect: () => ({
+                        y: 158,
+                        height: 50,
+                    }),
+                    style: {
+                        transform: 'translate(10px, 1510px)',
+                    },
+                },
+                {
+                    classList: ['react-grid-item', 'PAGEBREAK'],
+                    getBoundingClientRect: () => ({
+                        y: 158,
+                        height: 50,
+                    }),
+                    style: {
+                        transform: 'translate(10px, 710px)',
+                    },
+                },
+                {
+                    classList: ['react-grid-item', 'EVENT_CHART'],
+                    getBoundingClientRect: () => ({
+                        y: 158,
+                        height: 530,
+                    }),
+                    style: {
+                        transform: 'translate(738px, 10px)',
+                    },
+                },
+                {
+                    classList: ['react-grid-item', 'MESSAGES'],
+                    getBoundingClientRect: () => ({
+                        y: 158,
+                        height: 330,
+                    }),
+                    style: {
+                        transform: 'translate(738px, 2390px)',
+                    },
+                },
+                {
+                    classList: ['react-grid-item', 'REPORT_TABLE'],
+                    getBoundingClientRect: () => ({
+                        y: 158,
+                        height: bottomItemH,
+                    }),
+                    style: {
+                        transform: 'translate(738px, 2390px)',
+                    },
+                },
+                {
+                    classList: ['react-grid-item', 'EVENT_REPORT'],
+                    getBoundingClientRect: () => ({
+                        y: 158,
+                        height: 530,
+                    }),
+                    style: {
+                        transform: 'translate(10px, 10px)',
+                    },
+                },
+                {
+                    classList: ['react-grid-item', 'SPACER'],
+                    getBoundingClientRect: () => ({
+                        y: 158,
+                        height: 430,
+                    }),
+                    style: {
+                        transform: 'translate(720px, 810px)',
+                    },
+                },
+                {
+                    classList: ['react-grid-item', 'TEXT'],
+                    getBoundingClientRect: () => ({
+                        y: 158,
+                        height: 430,
+                    }),
+                    style: {
+                        transform: 'translate(10px, 810px)',
+                    },
+                },
+                {
+                    classList: ['react-grid-item', 'MAP'],
+                    getBoundingClientRect: () => ({
+                        y: 158,
+                        height: 430,
+                    }),
+                    style: {
+                        transform: 'translate(738px, 1610px)',
+                    },
+                },
+                {
+                    classList: ['react-grid-item', 'CHART'],
+                    getBoundingClientRect: () => ({
+                        y: 158,
+                        height: 430,
+                    }),
+                    style: {
+                        transform: 'translate(10px, 1610px)',
+                    },
+                },
+            ]
+
+            const result = getDomGridItemsSortedByYPos(elements)
+
+            expect(result.length).toEqual(elements.length)
+            const expectedPageBreakIndexes = [2, 5, 8, 11, 12, 13]
+
+            expectedPageBreakIndexes.forEach(i => {
+                expect(result[i].type).toEqual('PAGEBREAK')
+            })
+
+            const expectedBottomItem = result[10]
+            expect(expectedBottomItem.type).toEqual('REPORT_TABLE')
+            expect(expectedBottomItem.bottomY).toEqual(
+                bottomItemH + parseInt(bottomItemTy)
+            )
+        })
+
+        it('handles grid items with page breaks - no transform', () => {
+            const bottomItemH = 370
+            const bottomItemY = 2548
+            const elements = [
+                {
+                    classList: ['react-grid-item', 'PAGEBREAK'],
+                    getBoundingClientRect: () => ({
+                        y: 4848,
+                        height: 50,
+                    }),
+                    style: {},
+                },
+                {
+                    classList: ['react-grid-item', 'PAGEBREAK'],
+                    getBoundingClientRect: () => ({
+                        y: 4048,
+                        height: 50,
+                    }),
+                    style: {},
+                },
+                {
+                    classList: ['react-grid-item', 'PAGEBREAK'],
+                    getBoundingClientRect: () => ({
+                        y: 3248,
+                        height: 50,
+                    }),
+                    style: {},
+                },
+                {
+                    classList: ['react-grid-item', 'PAGEBREAK'],
+                    getBoundingClientRect: () => ({
+                        y: 2448,
+                        height: 50,
+                    }),
+                    style: {},
+                },
+                {
+                    classList: ['react-grid-item', 'PAGEBREAK'],
+                    getBoundingClientRect: () => ({
+                        y: 1668,
+                        height: 50,
+                    }),
+                    style: {},
+                },
+                {
+                    classList: ['react-grid-item', 'PAGEBREAK'],
+                    getBoundingClientRect: () => ({
+                        y: 868,
+                        height: 50,
+                    }),
+                    style: {},
+                },
+                {
+                    classList: ['react-grid-item', 'EVENT_CHART'],
+                    getBoundingClientRect: () => ({
+                        y: 168,
+                        height: 530,
+                    }),
+                    style: {},
+                },
+
+                {
+                    classList: ['react-grid-item', 'REPORT_TABLE'],
+                    getBoundingClientRect: () => ({
+                        y: bottomItemY,
+                        height: bottomItemH,
+                    }),
+                    style: {},
+                },
+                {
+                    classList: ['react-grid-item', 'EVENT_REPORT'],
+                    getBoundingClientRect: () => ({
+                        y: 168,
+                        height: 530,
+                    }),
+                    style: {},
+                },
+                {
+                    classList: ['react-grid-item', 'SPACER'],
+                    getBoundingClientRect: () => ({
+                        y: 968,
+                        height: 430,
+                    }),
+                    style: {},
+                },
+                {
+                    classList: ['react-grid-item', 'TEXT'],
+                    getBoundingClientRect: () => ({
+                        y: 968,
+                        height: 430,
+                    }),
+                    style: {},
+                },
+                {
+                    classList: ['react-grid-item', 'MAP'],
+                    getBoundingClientRect: () => ({
+                        y: 1768,
+                        height: 430,
+                    }),
+                    style: {},
+                },
+                {
+                    classList: ['react-grid-item', 'CHART'],
+                    getBoundingClientRect: () => ({
+                        y: 1768,
+                        height: 430,
+                    }),
+                    style: {},
+                },
+                {
+                    classList: ['react-grid-item', 'MESSAGES'],
+                    getBoundingClientRect: () => ({
+                        y: 2548,
+                        height: 330,
+                    }),
+                    style: {},
+                },
+            ]
+
+            const result = getDomGridItemsSortedByYPos(elements)
+
+            expect(result.length).toEqual(elements.length)
+            const expectedPageBreakIndexes = [2, 5, 8, 11, 12, 13]
+
+            expectedPageBreakIndexes.forEach(i => {
+                expect(result[i].type).toEqual('PAGEBREAK')
+            })
+
+            const expectedBottomItem = result[10]
+            expect(expectedBottomItem.type).toEqual('REPORT_TABLE')
+            expect(expectedBottomItem.bottomY).toEqual(
+                bottomItemH + parseInt(bottomItemY)
+            )
+        })
+    })
+})

--- a/src/modules/printUtils.js
+++ b/src/modules/printUtils.js
@@ -1,5 +1,31 @@
+import sortBy from 'lodash/sortBy'
+import { orArray } from './util'
+import { itemTypeMap } from './itemTypes'
 // for A4 landscape (297x210mm)
 // 794 px = (21cm / 2.54) * 96 pixels/inch
 // 1122 px = 29.7 /2.54 * 96 pixels/inch
 // const a4LandscapeHeightPx = 794
 export const a4LandscapeWidthPx = 1102
+
+export const getDomGridItemsSortedByYPos = elements => {
+    const types = Object.keys(itemTypeMap)
+    const elementsWithBoundingRect = orArray(elements).map(el => {
+        const type = Array.from(el.classList).find(
+            className => types.indexOf(className) > -1
+        )
+
+        const rect = el.getBoundingClientRect()
+
+        const y = el.style.transform
+            ? parseInt(el.style.transform?.split(' ')[1]?.slice(0, -3))
+            : parseInt(rect.y)
+
+        return {
+            type,
+            classList: el.classList,
+            bottomY: y + parseInt(rect.height),
+            el,
+        }
+    })
+    return sortBy(elementsWithBoundingRect, ['bottomY'])
+}

--- a/src/reducers/printDashboard.js
+++ b/src/reducers/printDashboard.js
@@ -1,7 +1,7 @@
 /** @module reducers/editDashboard */
 import update from 'immutability-helper'
 import isEmpty from 'lodash/isEmpty'
-import { orArray, orObject } from '../modules/util'
+import { orArray } from '../modules/util'
 
 export const SET_PRINT_DASHBOARD = 'SET_PRINT_DASHBOARD'
 export const CLEAR_PRINT_DASHBOARD = 'CLEAR_PRINT_DASHBOARD'
@@ -11,12 +11,13 @@ export const REMOVE_PRINT_DASHBOARD_ITEM = 'REMOVE_PRINT_DASHBOARD_ITEM'
 export const UPDATE_PRINT_DASHBOARD_ITEM = 'UPDATE_PRINT_DASHBOARD_ITEM'
 
 export const DEFAULT_STATE_PRINT_DASHBOARD = {}
+const DEFAULT_DASHBOARD_ITEMS = []
 export const NEW_PRINT_DASHBOARD_STATE = {
     id: '',
     name: '',
     access: {},
     description: '',
-    dashboardItems: [],
+    dashboardItems: DEFAULT_DASHBOARD_ITEMS,
 }
 
 export default (state = DEFAULT_STATE_PRINT_DASHBOARD, action) => {
@@ -129,5 +130,8 @@ export const sGetPrintDashboardRoot = state => state.printDashboard
 
 export const sGetIsPrinting = state => !isEmpty(state.printDashboard)
 
-export const sGetPrintDashboardItems = state =>
-    orObject(sGetPrintDashboardRoot(state)).dashboardItems
+export const sGetPrintDashboardItems = state => {
+    return (
+        sGetPrintDashboardRoot(state)?.dashboardItems || DEFAULT_DASHBOARD_ITEMS
+    )
+}


### PR DESCRIPTION
Calculation of the "page" bottom was incorrect.  Correct calculation code pulled into a separate function and tests added.  Make sure to check for the error from Print preview via Edit mode.

Bottom of the print preview was looking like this:

![image](https://user-images.githubusercontent.com/6113918/91701678-ef7fff00-eb77-11ea-9131-c3fbd07fb696.png)


Fixed:  
![image](https://user-images.githubusercontent.com/6113918/91701738-0161a200-eb78-11ea-85fe-162ec548ee59.png)
