### PR TITLE
fix: set overflow to hidden for vis and map items

### DIFF
--- a/src/components/ItemGrid/ItemGrid.css
+++ b/src/components/ItemGrid/ItemGrid.css
@@ -55,7 +55,10 @@
     overflow: auto;
 }
 
-.CHART .dashboard-item-content {
+.CHART .dashboard-item-content,
+.VISUALIZATION .dashboard-item-content,
+.MAP .dashboard-item-content,
+.EVENT_CHART .dashboard-item-content {
     overflow: hidden;
 }
 
@@ -65,9 +68,4 @@
 .react-grid-item.MESSAGES .dashboard-item-content,
 .react-grid-item.APP .dashboard-item-content {
     flex: 1;
-}
-
-.CHART.resizing .dashboard-item-content,
-.EVENT_CHART.resizing .dashboard-item-content {
-    overflow: hidden;
 }


### PR DESCRIPTION
Our css rules for item overflow were not updated after the `VISUALIZATION` type was introduced.

![Screenshot from 2020-09-08 23-27-36](https://user-images.githubusercontent.com/1010094/92530750-40a18a00-f22d-11ea-8a38-b1c4b8014df0.png)

The problem seems to be that content size doesn't always fit the container:

![Screenshot from 2020-09-08 23-10-25](https://user-images.githubusercontent.com/1010094/92530030-ddfbbe80-f22b-11ea-8419-7563f9a9876c.png)
![Screenshot from 2020-09-08 23-10-53](https://user-images.githubusercontent.com/1010094/92530040-dfc58200-f22b-11ea-8cc1-2f8cdac88923.png)

This should be fixed properly later. It doesn't seem to be off by more than a few pixels, so the visualization should always be visible for now, thus this is okay as a last minute fix for 2.35. Pivot table visualizations will still get scrollbars, as they should, as they provide their own through the pivot container further down the tree. EVENT_REPORTS was not added as they would lose the scrollbar.

Removed the `.resizing` rules as well as they were not right/superfluous.