### PR TITLE
fix: reduce renders caused by state change

### DIFF
--- a/src/actions/selected.js
+++ b/src/actions/selected.js
@@ -1,4 +1,8 @@
-import { getCustomDashboards, sGetDashboardById } from '../reducers/dashboards'
+import {
+    getCustomDashboards,
+    sGetDashboardById,
+    EMPTY_DASHBOARD,
+} from '../reducers/dashboards'
 import {
     SET_SELECTED_ID,
     SET_SELECTED_ISLOADING,
@@ -33,7 +37,6 @@ import {
     EVENT_CHART,
     MESSAGES,
 } from '../modules/itemTypes'
-import { orObject } from '../modules/util'
 
 // actions
 
@@ -57,8 +60,9 @@ export const tSetSelectedDashboardById = id => async (dispatch, getState) => {
     dispatch(acSetSelectedIsLoading(true))
 
     const snackbarTimeout = setTimeout(() => {
-        const dashboardName = orObject(sGetDashboardById(getState(), id))
-            .displayName
+        const dashboardName = (
+            sGetDashboardById(getState(), id) || EMPTY_DASHBOARD
+        ).displayName
         if (sGetSelectedIsLoading(getState()) && dashboardName) {
             loadingDashboardMsg.name = dashboardName
 

--- a/src/components/Item/PrintTitlePageItem/Item.js
+++ b/src/components/Item/PrintTitlePageItem/Item.js
@@ -3,13 +3,14 @@ import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import i18n from '@dhis2/d2-i18n'
 
-import { orObject } from '../../../modules/util'
-
 import {
     sGetSelectedId,
     sGetSelectedShowDescription,
 } from '../../../reducers/selected'
-import { sGetDashboardById } from '../../../reducers/dashboards'
+import {
+    sGetDashboardById,
+    EMPTY_DASHBOARD,
+} from '../../../reducers/dashboards'
 import { sGetNamedItemFilters } from '../../../reducers/itemFilters'
 
 import classes from './styles/Item.module.css'
@@ -63,7 +64,7 @@ PrintTitlePageItem.defaultProps = {
 
 const mapStateToProps = state => {
     const id = sGetSelectedId(state)
-    const dashboard = orObject(sGetDashboardById(state, id))
+    const dashboard = sGetDashboardById(state, id) || EMPTY_DASHBOARD
 
     return {
         name: dashboard.displayName,

--- a/src/components/ItemFilter/FilterSelector.js
+++ b/src/components/ItemFilter/FilterSelector.js
@@ -12,10 +12,7 @@ import FilterDialog from './FilterDialog'
 import { sGetSettingsDisplayNameProperty } from '../../reducers/settings'
 import { sGetActiveModalDimension } from '../../reducers/activeModalDimension'
 import { sGetDimensions } from '../../reducers/dimensions'
-import {
-    sGetItemFiltersRoot,
-    sGetFiltersKeys,
-} from '../../reducers/itemFilters'
+import { sGetItemFiltersRoot } from '../../reducers/itemFilters'
 import { acAddItemFilter, acRemoveItemFilter } from '../../actions/itemFilters'
 import {
     acClearActiveModalDimension,
@@ -100,7 +97,7 @@ const FilterSelector = props => {
                         style={{ width: '320px' }}
                         dimensions={props.dimensions}
                         onDimensionClick={selectDimension}
-                        selectedIds={props.selectedDimensions}
+                        selectedIds={Object.keys(props.initiallySelectedItems)}
                     />
                 </Popover>
             )}
@@ -125,7 +122,6 @@ const mapStateToProps = state => ({
     dimension: sGetActiveModalDimension(state),
     dimensions: sGetDimensions(state),
     initiallySelectedItems: sGetItemFiltersRoot(state),
-    selectedDimensions: sGetFiltersKeys(state),
 })
 
 FilterSelector.propTypes = {
@@ -136,7 +132,6 @@ FilterSelector.propTypes = {
     displayNameProperty: PropTypes.string,
     initiallySelectedItems: PropTypes.object,
     removeItemFilter: PropTypes.func,
-    selectedDimensions: PropTypes.array,
     setActiveModalDimension: PropTypes.func,
 }
 

--- a/src/components/TitleBar/ViewTitleBar.js
+++ b/src/components/TitleBar/ViewTitleBar.js
@@ -83,6 +83,8 @@ const ViewTitleBar = (props, context) => {
 
     const buttonRef = createRef()
 
+    const userAccess = orObject(access)
+
     return (
         <>
             <div className={classes.titleBar}>
@@ -95,7 +97,7 @@ const ViewTitleBar = (props, context) => {
                         <StarIcon style={{ fill: colors.grey600 }} />
                     </div>
                     <div className={classes.strip}>
-                        {access.update ? (
+                        {userAccess.update ? (
                             <Link
                                 className={classes.editLink}
                                 to={`/${id}/edit`}
@@ -103,7 +105,7 @@ const ViewTitleBar = (props, context) => {
                                 <Button>{i18n.t('Edit')}</Button>
                             </Link>
                         ) : null}
-                        {access.manage ? (
+                        {userAccess.manage ? (
                             <Button onClick={toggleSharingDialog}>
                                 {i18n.t('Share')}
                             </Button>
@@ -211,7 +213,7 @@ const mapStateToProps = state => {
         dashboardItems: sGetDashboardItems(state),
         showDescription: sGetSelectedShowDescription(state),
         starred: dashboard.starred,
-        access: orObject(dashboard.access),
+        access: dashboard.access,
     }
 }
 

--- a/src/components/TitleBar/ViewTitleBar.js
+++ b/src/components/TitleBar/ViewTitleBar.js
@@ -21,6 +21,7 @@ import {
 import {
     sGetDashboardById,
     sGetDashboardItems,
+    EMPTY_DASHBOARD,
 } from '../../reducers/dashboards'
 
 import classes from './styles/ViewTitleBar.module.css'
@@ -201,7 +202,7 @@ ViewTitleBar.contextTypes = {
 
 const mapStateToProps = state => {
     const id = sGetSelectedId(state)
-    const dashboard = orObject(sGetDashboardById(state, id))
+    const dashboard = sGetDashboardById(state, id) || EMPTY_DASHBOARD
 
     return {
         id,

--- a/src/reducers/dashboards.js
+++ b/src/reducers/dashboards.js
@@ -17,6 +17,8 @@ export const DEFAULT_STATE_DASHBOARDS = {
     items: [],
 }
 
+export const EMPTY_DASHBOARD = {}
+
 // reducer helper functions
 
 const updateDashboardProp = ({ state, dashboardId, prop, value }) => ({

--- a/src/reducers/itemFilters.js
+++ b/src/reducers/itemFilters.js
@@ -38,8 +38,6 @@ export default (state = DEFAULT_STATE_ITEM_FILTERS, action) => {
 
 export const sGetItemFiltersRoot = state => state.itemFilters
 
-export const sGetFiltersKeys = state => Object.keys(sGetItemFiltersRoot(state))
-
 // simplify the filters structure to:
 // [{ id: 'pe', name: 'Period', values: [{ id: 2019: name: '2019' }, {id: 'LAST_MONTH', name: 'Last month' }]}, ...]
 export const sGetNamedItemFilters = createSelector(


### PR DESCRIPTION
orObject and orArray cause new objects to be created, and this could cause a component to think something has changed when it may not have.

Also, FilterDialog was rerendering several times even because of the `selectedDimensions` property. Turns out this property isn't really needed. By removing that property, the number of renders was reduced to 1.

I doubt this alone would have much if any performance effect, but all the little stuff does add up.