### PR TITLE
fix: unmount map when switching dashboard mode or changing active type [DHIS2-9558]

### DIFF
--- a/src/components/Item/VisualizationItem/DefaultPlugin.js
+++ b/src/components/Item/VisualizationItem/DefaultPlugin.js
@@ -95,6 +95,17 @@ class DefaultPlugin extends Component {
         this.reloadPlugin(prevProps)
     }
 
+    componentWillUnmount() {
+        if (
+            pluginManager.pluginIsAvailable(
+                this.props.item,
+                this.props.visualization
+            )
+        ) {
+            pluginManager.unmount(this.props.item, this.getActiveType())
+        }
+    }
+
     getActiveType = () =>
         this.props.visualization.activeType || this.props.item.type
 
@@ -121,11 +132,11 @@ DefaultPlugin.contextTypes = {
 
 DefaultPlugin.propTypes = {
     classes: PropTypes.object,
-    useActiveType: PropTypes.bool,
     item: PropTypes.object,
     itemFilters: PropTypes.object,
     options: PropTypes.object,
     style: PropTypes.object,
+    useActiveType: PropTypes.bool,
     visualization: PropTypes.object,
 }
 

--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -254,13 +254,8 @@ export class Item extends Component {
     }
 
     onSelectActiveType = type => {
-        if (type === this.getActiveType()) {
-            return
-        }
-
-        pluginManager.unmount(this.props.item, this.getActiveType())
-
-        this.props.onSelectActiveType(this.props.visualization.id, type)
+        type !== this.getActiveType() &&
+            this.props.onSelectActiveType(this.props.visualization.id, type)
     }
 
     getActiveType = () =>


### PR DESCRIPTION
When switching modes, the components are unmounted and mounted anew. But `plugin.unmount` was not being called on maps plugin, resulting in the warning about too many WebGL contexts.

Also removed the call to `plugin.unmount` in the onSelectActiveType handler since the component gets unmounted anyway (ComponentWillUnmount) which will call the `plugin.unmount`