### PR TITLE
revert: fix: use better spacing in item title when the title wraps to multiple lines

### DIFF
--- a/src/components/Item/ItemHeader/styles/ItemHeader.module.css
+++ b/src/components/Item/ItemHeader/styles/ItemHeader.module.css
@@ -1,6 +1,10 @@
+.itemWrap {
+    padding: var(--spacers-dp8);
+}
+
 .itemHeaderWrap {
     display: flex;
-    margin: var(--spacers-dp8) var(--spacers-dp4) var(--spacers-dp8)
+    margin: var(--spacers-dp4) var(--spacers-dp4) var(--spacers-dp8)
         var(--spacers-dp8);
 }
 
@@ -8,6 +12,7 @@
     font-weight: 700;
     color: var(--colors-grey800);
     font-size: 14px;
+    line-height: 28px;
     padding: 0;
     margin: 0;
     align-self: center;


### PR DESCRIPTION
This reverts commit f76ed0eabfa11e5e69b93bd16d27964a2231ee05.

Will be merged at a later time.