### PR TITLE
fix: allow series in the request string (DHIS2-9715)

### DIFF
--- a/src/api/metadata.js
+++ b/src/api/metadata.js
@@ -61,7 +61,6 @@ export const getFavoriteFields = ({ withDimensions, withOptions }) => {
                   '!relativePeriods',
                   '!reportParams',
                   '!rowDimensions',
-                  '!series',
                   '!translations',
                   '!userOrganisationUnit',
                   '!userOrganisationUnitChildren',


### PR DESCRIPTION
Removes `!series` from the visualization request string to allow the series config of a visualization to be passed from the api.