### PR TITLE
fix: check whether the dashboard id has been set after the check for existing dashboards [DHIS2-9738]

### DIFF
--- a/src/components/Dashboard/Dashboard.js
+++ b/src/components/Dashboard/Dashboard.js
@@ -81,7 +81,7 @@ export const Dashboard = ({
         }
     }, [])
 
-    if (!dashboardsLoaded || id === null) {
+    if (!dashboardsLoaded) {
         return (
             <Layer translucent>
                 <CenteredContent>
@@ -118,6 +118,16 @@ export const Dashboard = ({
                     text={i18n.t('Requested dashboard not found')}
                 />
             </>
+        )
+    }
+
+    if (id === null) {
+        return (
+            <Layer translucent>
+                <CenteredContent>
+                    <CircularLoader />
+                </CenteredContent>
+            </Layer>
         )
     }
 


### PR DESCRIPTION
The state checks need to happen in a certain order, unfortunately.  In an empty database, the `id` never gets set, resulting in an infinite circular loader. So that check needs to happen after the check for existing dashboards. In an empty database, there are no dashboards.  

It's too bad the unit tests don't catch this. Looking forward to getting the cypress tests in.