### PR TITLE
chore: automerge all minor dependency PRs

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -8,9 +8,5 @@ update_configs:
       target_branch: 'master'
       automerged_updates:
           - match:
-                dependency_name: '@dhis2/*'
                 dependency_type: 'all'
                 update_type: 'semver:minor'
-          - match:
-                dependency_type: 'all'
-                update_type: 'security:patch'


### PR DESCRIPTION
Would like to wait a bit longer and see how the [kodiak](https://github.com/dhis2/notes/issues/71#issuecomment-716535285) experiments are going. In the meantime I want dependabot to automerge all minor deps.