### PR TITLE
fix: restore schemas list needed for org unit dialog and interpretations [DHIS2-9980] [v35]

### DIFF
--- a/src/AppWrapper.js
+++ b/src/AppWrapper.js
@@ -13,7 +13,17 @@ import './locales'
 const muiTheme = () => createMuiTheme(dhis2theme)
 
 const d2Config = {
-    schemas: ['dashboard'],
+    schemas: [
+        'chart',
+        'map',
+        'report',
+        'reportTable',
+        'eventChart',
+        'eventReport',
+        'dashboard',
+        'organisationUnit',
+        'userGroup',
+    ],
 }
 
 // TODO: ER and EV plugins require the auth header in development mode.


### PR DESCRIPTION
Org unit filter and Interpretations were crashing because of missing models.