### PR TITLE
fix: force type COLUMN when viewing table as chart [DHIS2-9599]

### DIFF
--- a/src/components/Item/VisualizationItem/__tests__/getVisualizationConfig.spec.js
+++ b/src/components/Item/VisualizationItem/__tests__/getVisualizationConfig.spec.js
@@ -28,6 +28,32 @@ describe('getVisualizationConfig', () => {
         expect(actualResult).toEqual(expectedResult)
     })
 
+    it('returns correct config when switching from CHART to REPORT_TABLE and one row item', () => {
+        const visConfig = {
+            id: 'vis1',
+            type: 'CHART',
+            [AXIS_ID_COLUMNS]: [{ dimension: DIMENSION_ID_DATA }],
+            [AXIS_ID_ROWS]: [{ dimension: DIMENSION_ID_PERIOD }],
+            [AXIS_ID_FILTERS]: [
+                { dimension: DIMENSION_ID_ORGUNIT },
+                { dimension: 'rainbow' },
+                { dimension: 'twilight' },
+            ],
+        }
+        const actualResult = getVisualizationConfig(
+            visConfig,
+            CHART,
+            REPORT_TABLE
+        )
+        const expectedResult = {
+            ...visConfig,
+            id: undefined,
+            type: 'PIVOT_TABLE',
+        }
+
+        expect(actualResult).toEqual(expectedResult)
+    })
+
     it('returns correct config when switching from CHART to REPORT_TABLE', () => {
         const visConfig = {
             id: 'vis1',
@@ -54,18 +80,18 @@ describe('getVisualizationConfig', () => {
         expect(actualResult).toEqual(expectedResult)
     })
 
-    it('returns correct config when switching from REPORT_TABLE to CHART', () => {
+    it('returns correct config when switching from REPORT_TABLE to CHART one row item', () => {
         const visConfig = {
             id: 'vis1',
             [AXIS_ID_COLUMNS]: [
                 { dimension: DIMENSION_ID_DATA },
                 { dimension: 'rainbow' },
             ],
-            [AXIS_ID_ROWS]: [
-                { dimension: DIMENSION_ID_PERIOD },
+            [AXIS_ID_ROWS]: [{ dimension: DIMENSION_ID_PERIOD }],
+            [AXIS_ID_FILTERS]: [
+                { dimension: DIMENSION_ID_ORGUNIT },
                 { dimension: 'twilight' },
             ],
-            [AXIS_ID_FILTERS]: [{ dimension: DIMENSION_ID_ORGUNIT }],
         }
 
         const expectedVisConfig = {
@@ -75,8 +101,47 @@ describe('getVisualizationConfig', () => {
             [AXIS_ID_ROWS]: [{ dimension: DIMENSION_ID_PERIOD }],
             [AXIS_ID_FILTERS]: [
                 { dimension: DIMENSION_ID_ORGUNIT },
-                { dimension: 'rainbow' },
                 { dimension: 'twilight' },
+                { dimension: 'rainbow' },
+            ],
+        }
+
+        const actualResult = getVisualizationConfig(
+            visConfig,
+            REPORT_TABLE,
+            CHART
+        )
+
+        expect(actualResult).toEqual(expectedVisConfig)
+    })
+
+    it('returns correct config when switching from REPORT_TABLE to CHART >2 row items', () => {
+        const visConfig = {
+            id: 'vis1',
+            [AXIS_ID_COLUMNS]: [
+                { dimension: DIMENSION_ID_DATA },
+                { dimension: 'rainbow' },
+            ],
+            [AXIS_ID_ROWS]: [
+                { dimension: DIMENSION_ID_PERIOD },
+                { dimension: 'twilight' },
+                { dimension: 'pinkiepie' },
+            ],
+            [AXIS_ID_FILTERS]: [{ dimension: DIMENSION_ID_ORGUNIT }],
+        }
+
+        const expectedVisConfig = {
+            id: undefined,
+            type: 'COLUMN',
+            [AXIS_ID_COLUMNS]: [{ dimension: DIMENSION_ID_DATA }],
+            [AXIS_ID_ROWS]: [
+                { dimension: DIMENSION_ID_PERIOD },
+                { dimension: 'twilight' },
+            ],
+            [AXIS_ID_FILTERS]: [
+                { dimension: DIMENSION_ID_ORGUNIT },
+                { dimension: 'rainbow' },
+                { dimension: 'pinkiepie' },
             ],
         }
 

--- a/src/components/Item/VisualizationItem/__tests__/getVisualizationConfig.spec.js
+++ b/src/components/Item/VisualizationItem/__tests__/getVisualizationConfig.spec.js
@@ -28,32 +28,6 @@ describe('getVisualizationConfig', () => {
         expect(actualResult).toEqual(expectedResult)
     })
 
-    it('returns correct config when switching from CHART to REPORT_TABLE and one row item', () => {
-        const visConfig = {
-            id: 'vis1',
-            type: 'CHART',
-            [AXIS_ID_COLUMNS]: [{ dimension: DIMENSION_ID_DATA }],
-            [AXIS_ID_ROWS]: [{ dimension: DIMENSION_ID_PERIOD }],
-            [AXIS_ID_FILTERS]: [
-                { dimension: DIMENSION_ID_ORGUNIT },
-                { dimension: 'rainbow' },
-                { dimension: 'twilight' },
-            ],
-        }
-        const actualResult = getVisualizationConfig(
-            visConfig,
-            CHART,
-            REPORT_TABLE
-        )
-        const expectedResult = {
-            ...visConfig,
-            id: undefined,
-            type: 'PIVOT_TABLE',
-        }
-
-        expect(actualResult).toEqual(expectedResult)
-    })
-
     it('returns correct config when switching from CHART to REPORT_TABLE', () => {
         const visConfig = {
             id: 'vis1',

--- a/src/components/Item/VisualizationItem/getVisualizationConfig.js
+++ b/src/components/Item/VisualizationItem/getVisualizationConfig.js
@@ -30,7 +30,7 @@ const getVisualizationConfig = (visualization, originalType, activeType) => {
             type: activeType === CHART ? VIS_TYPE_COLUMN : VIS_TYPE_PIVOT_TABLE,
         })
     } else if (originalType === REPORT_TABLE && activeType === CHART) {
-        const layout = getAdaptedUiLayoutByType(visualization, activeType)
+        const layout = getAdaptedUiLayoutByType(visualization, VIS_TYPE_COLUMN)
         return getWithoutId({
             ...visualization,
             ...layout,

--- a/src/components/Item/VisualizationItem/getVisualizationConfig.js
+++ b/src/components/Item/VisualizationItem/getVisualizationConfig.js
@@ -37,7 +37,10 @@ const getVisualizationConfig = (visualization, originalType, activeType) => {
             type: VIS_TYPE_COLUMN,
         })
     } else if (originalType === CHART && activeType === REPORT_TABLE) {
-        const layout = getAdaptedUiLayoutByType(visualization, activeType)
+        const layout = getAdaptedUiLayoutByType(
+            visualization,
+            VIS_TYPE_PIVOT_TABLE
+        )
         return getWithoutId({
             ...visualization,
             ...layout,


### PR DESCRIPTION
type "CHART" was being sent in as the visualization type, which doesn't match anything. The result was getting the default layout which works fine when there is only 1 row item, but not when more than 1 row item.

Also, instead of "REPORT_TABLE", we should be sending in "PIVOT_TABLE"