### PR TITLE
test: run cypress ci against live dhis2 instance instead of fixtures

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -10,10 +10,11 @@ env:
     SERVER_START_CMD: 'yarn cypress:start'
     SERVER_URL: 'http://localhost:3000'
     CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-    CYPRESS_TAGS: '@nonmutating'
-    cypress_dhis2_base_url: 'http://localhost:8080'
-    cypress_dhis2_api_stub_mode: 'STUB'
-    REACT_APP_DHIS2_BASE_URL: 'http://localhost:8080'
+    cypress_dhis2_api_stub_mode: 'DISABLED'
+    REACT_APP_DHIS2_BASE_URL: ${{ secrets.CYPRESS_DHIS2_BASE_URL }}
+    cypress_dhis2_base_url: ${{ secrets.CYPRESS_DHIS2_BASE_URL }}
+    cypress_dhis2_username: ${{ secrets.CYPRESS_DHIS2_USERNAME }}
+    cypress_dhis2_password: ${{ secrets.CYPRESS_DHIS2_PASSWORD }}
 
 jobs:
     e2e:

--- a/cypress/integration/ui/create_dashboard/index.js
+++ b/cypress/integration/ui/create_dashboard/index.js
@@ -28,11 +28,15 @@ const toggleShowMoreButton = () => {
 }
 
 beforeEach(() => {
-    cy.visit('/')
+    cy.visit('/', {
+        timeout: 10000,
+    })
 })
 
 Given('I choose to create new dashboard', () => {
-    cy.get('[data-test="dhis2-dashboard-link-new-dashboard"]').click()
+    cy.get('[data-test="dhis2-dashboard-link-new-dashboard"]', {
+        timeout: 10000,
+    }).click()
 })
 
 When('dashboard title is added', () => {

--- a/cypress/integration/ui/view_dashboard/index.js
+++ b/cypress/integration/ui/view_dashboard/index.js
@@ -4,8 +4,14 @@ const antenatalCareDashboardRoute = '#/nghVC4wtyzi'
 const immunizationDashboardRoute = '#/TAMlzYkstb7'
 
 Given('I open the Antenatal Care dashboard', () => {
-    cy.visit('/')
-    cy.get('[data-test="dhis2-uicore-chip"]').contains('Antenatal Care').click()
+    cy.visit('/', {
+        timeout: 10000,
+    })
+    cy.get('[data-test="dhis2-uicore-chip"]', {
+        timeout: 10000,
+    })
+        .contains('Antenatal Care')
+        .click()
 })
 
 Then('the Antenatal Care dashboard displays in view mode', () => {


### PR DESCRIPTION
Switching from fixtures to live instance for now, for 2 reasons:
* Experiencing some issues with generating fixtures with upcoming new tests.
* With live instance, all tests can be run, including mutating tests like creating/deleting dashboards

The dhis2 instance is a dedicated instance on debug.dhis2.org, since dashboard tests are currently heavily reliant on the data, so we don't want people using and changing the instance.

Timeouts were added when initially visiting a dashboard since this seems to take more time with the debug instance than the fixtures.