### PR TITLE
test: remove dhis2-dashboard- from data-test name

### DIFF
--- a/cypress/integration/ui/create_dashboard/index.js
+++ b/cypress/integration/ui/create_dashboard/index.js
@@ -29,13 +29,13 @@ const toggleShowMoreButton = () => {
 
 beforeEach(() => {
     cy.visit('/', {
-        timeout: 10000,
+        timeout: 15000,
     })
 })
 
 Given('I choose to create new dashboard', () => {
     cy.get('[data-test="link-new-dashboardd"]', {
-        timeout: 10000,
+        timeout: 15000,
     }).click()
 })
 

--- a/cypress/integration/ui/create_dashboard/index.js
+++ b/cypress/integration/ui/create_dashboard/index.js
@@ -34,7 +34,7 @@ beforeEach(() => {
 })
 
 Given('I choose to create new dashboard', () => {
-    cy.get('[data-test="link-new-dashboardd"]', {
+    cy.get('[data-test="link-new-dashboard"]', {
         timeout: 15000,
     }).click()
 })

--- a/cypress/integration/ui/create_dashboard/index.js
+++ b/cypress/integration/ui/create_dashboard/index.js
@@ -24,7 +24,7 @@ const getRouteFromHash = hash => {
 }
 
 const toggleShowMoreButton = () => {
-    cy.get('[data-test="dhis2-dashboard-showmore-button"]').click()
+    cy.get('[data-test="showmore-button"]').click()
 }
 
 beforeEach(() => {
@@ -32,35 +32,29 @@ beforeEach(() => {
 })
 
 Given('I choose to create new dashboard', () => {
-    cy.get('[data-test="dhis2-dashboard-link-new-dashboard"]').click()
+    cy.get('[data-test="link-new-dashboard"]').click()
 })
 
 When('dashboard title is added', () => {
-    cy.get('[data-test="dhis2-dashboard-dashboard-title-input"]').type(
-        TEST_DASHBOARD_TITLE
-    )
+    cy.get('[data-test="dashboard-title-input"]').type(TEST_DASHBOARD_TITLE)
 })
 
 When('dashboard items are added', () => {
-    cy.get('[data-test="dhis2-dashboard-item-search"]').click()
-    cy.get(
-        '[data-test="dhis2-dashboard-menu-item-ANC: 1 and 3 coverage Yearly"]'
-    ).click()
+    cy.get('[data-test="item-search"]').click()
+    cy.get('[data-test="menu-item-ANC: 1 and 3 coverage Yearly"]').click()
 })
 
 When('escape key is pressed', () => {
     cy.get('body').trigger('keydown', { key: 'Escape' })
-    cy.get('[data-test="dhis2-dashboard-item-menu]').should('not.be.visible')
+    cy.get('[data-test="item-menu]').should('not.be.visible')
 })
 
 When('dashboard is saved', () => {
-    cy.get('[data-test="dhis2-dashboard-save-dashboard-button"]').click()
+    cy.get('[data-test="save-dashboard-button"]').click()
 })
 
 Then('the saved dashboard should be displayed', () => {
-    cy.get('[data-test="dhis2-dashboard-view-dashboard-title"]').contains(
-        TEST_DASHBOARD_TITLE
-    )
+    cy.get('[data-test="view-dashboard-title"]').contains(TEST_DASHBOARD_TITLE)
 })
 
 Then('dashboard displays in view mode', () => {
@@ -74,31 +68,29 @@ Then('dashboard displays in view mode', () => {
 
 Given('I open existing dashboard', () => {
     toggleShowMoreButton()
-    cy.get('[data-test="dhis2-dashboard-dashboard-chip"]')
+    cy.get('[data-test="dashboard-chip"]')
         .contains(TEST_DASHBOARD_TITLE)
         .click()
 })
 
 When('I choose to edit dashboard', () => {
-    cy.get('[data-test="dhis2-dashboard-link-edit-dashboard"]').click()
+    cy.get('[data-test="link-edit-dashboard"]').click()
 })
 
 When('I choose to delete dashboard', () => {
-    cy.get('[data-test="dhis2-dashboard-delete-dashboard-button"]').click()
+    cy.get('[data-test="delete-dashboard-button"]').click()
 })
 
 When('I confirm delete', () => {
-    cy.get('[data-test="dhis2-dashboard-confirm-delete-dashboard"]').click()
+    cy.get('[data-test="confirm-delete-dashboard"]').click()
 })
 
 When('I cancel delete', () => {
-    cy.get('[data-test="dhis2-dashboard-cancel-delete-dashboard"]').click()
+    cy.get('[data-test="cancel-delete-dashboard"]').click()
 })
 
 Then('the dashboard displays in edit mode', () => {
-    cy.get('[data-test="dhis2-dashboard-dashboard-title-input"]').should(
-        'exist'
-    )
+    cy.get('[data-test="dashboard-title-input"]').should('exist')
 
     cy.location().should(loc => {
         expect(getRouteFromHash(loc.hash)).to.eq(ROUTE_EDIT)
@@ -107,11 +99,11 @@ Then('the dashboard displays in edit mode', () => {
 
 Then('the dashboard is deleted and first starred dashboard displayed', () => {
     toggleShowMoreButton()
-    cy.get('[data-test="dhis2-dashboard-dashboard-chip"]')
+    cy.get('[data-test="dashboard-chip"]')
         .contains(TEST_DASHBOARD_TITLE)
         .should('not.exist')
 
-    cy.get('[data-test="dhis2-dashboard-view-dashboard-title"]')
+    cy.get('[data-test="view-dashboard-title"]')
         .should('exist')
         .should('not.be.empty')
 })

--- a/cypress/integration/ui/view_dashboard/index.js
+++ b/cypress/integration/ui/view_dashboard/index.js
@@ -13,7 +13,7 @@ Then('the Antenatal Care dashboard displays in view mode', () => {
         expect(loc.hash).to.equal(antenatalCareDashboardRoute)
     })
 
-    cy.get('[data-test="dhis2-dashboard-view-dashboard-title"]')
+    cy.get('[data-test="view-dashboard-title"]')
         .should('be.visible')
         .and('contain', 'Antenatal Care')
     cy.get('.highcharts-background').should('exist')
@@ -28,14 +28,14 @@ Then('the Immunization dashboard displays in view mode', () => {
         expect(loc.hash).to.equal(immunizationDashboardRoute)
     })
 
-    cy.get('[data-test="dhis2-dashboard-view-dashboard-title"]')
+    cy.get('[data-test="view-dashboard-title"]')
         .should('be.visible')
         .and('contain', 'Immunization')
     cy.get('.highcharts-background').should('exist')
 })
 
 When('I search for dashboards containing Immunization', () => {
-    cy.get('[data-test="dhis2-dashboard-search-dashboard-input"]').type('Immun')
+    cy.get('[data-test="search-dashboard-input"]').type('Immun')
 })
 
 Then('Immunization and Immunization data dashboards are choices', () => {
@@ -45,15 +45,13 @@ Then('Immunization and Immunization data dashboards are choices', () => {
 })
 
 When('I press enter in the search dashboard field', () => {
-    cy.get('[data-test="dhis2-dashboard-search-dashboard-input"]').type(
-        '{enter}'
-    )
+    cy.get('[data-test="search-dashboard-input"]').type('{enter}')
 })
 
 When('I click to preview the print layout', () => {
-    cy.get('[data-test="dhis2-dashboard-more-button"]').click()
-    cy.get('[data-test="dhis2-dashboard-print-menu-item"]').click()
-    cy.get('[data-test="dhis2-dashboard-print-layout-menu-item"]').click()
+    cy.get('[data-test="more-button"]').click()
+    cy.get('[data-test="print-menu-item"]').click()
+    cy.get('[data-test="print-layout-menu-item"]').click()
 })
 
 Then('the print layout displays', () => {
@@ -63,19 +61,17 @@ Then('the print layout displays', () => {
     })
 
     //check for some elements
-    cy.get('[data-test="dhis2-dashboard-print-layout-page"]').should(
-        'be.visible'
-    )
+    cy.get('[data-test="print-layout-page"]').should('be.visible')
 })
 
 When('I click to exit print preview', () => {
-    cy.get('[data-test="dhis2-dashboard-exit-print-preview"]').click()
+    cy.get('[data-test="exit-print-preview"]').click()
 })
 
 When('I click to preview the print one-item-per-page', () => {
-    cy.get('[data-test="dhis2-dashboard-more-button"]').click()
-    cy.get('[data-test="dhis2-dashboard-print-menu-item"]').click()
-    cy.get('[data-test="dhis2-dashboard-print-oipp-menu-item"]').click()
+    cy.get('[data-test="more-button"]').click()
+    cy.get('[data-test="print-menu-item"]').click()
+    cy.get('[data-test="print-oipp-menu-item"]').click()
 })
 
 Then('the print one-item-per-page displays', () => {
@@ -85,13 +81,11 @@ Then('the print one-item-per-page displays', () => {
     })
 
     //check for some elements
-    cy.get('[data-test="dhis2-dashboard-print-oipp-page"]').should('be.visible')
+    cy.get('[data-test="print-oipp-page"]').should('be.visible')
 })
 
 When('I search for dashboards containing Noexist', () => {
-    cy.get('[data-test="dhis2-dashboard-search-dashboard-input"]').type(
-        'Noexist'
-    )
+    cy.get('[data-test="search-dashboard-input"]').type('Noexist')
 })
 Then('no dashboards are choices', () => {
     cy.get('[data-test="dhis2-uicore-chip"]').should('not.be.visible')
@@ -106,7 +100,7 @@ Then("dashboards list restored and dashboard doesn't change", () => {
         expect(loc.hash).to.equal(antenatalCareDashboardRoute)
     })
 
-    cy.get('[data-test="dhis2-dashboard-view-dashboard-title"]')
+    cy.get('[data-test="view-dashboard-title"]')
         .should('be.visible')
         .and('contain', 'Antenatal Care')
     cy.get('.highcharts-background').should('exist')

--- a/cypress/integration/ui/view_dashboard/index.js
+++ b/cypress/integration/ui/view_dashboard/index.js
@@ -5,10 +5,10 @@ const immunizationDashboardRoute = '#/TAMlzYkstb7'
 
 Given('I open the Antenatal Care dashboard', () => {
     cy.visit('/', {
-        timeout: 10000,
+        timeout: 15000,
     })
     cy.get('[data-test="dhis2-uicore-chip"]', {
-        timeout: 10000,
+        timeout: 15000,
     })
         .contains('Antenatal Care')
         .click()

--- a/src/components/ControlBar/ConfirmDeleteDialog.js
+++ b/src/components/ControlBar/ConfirmDeleteDialog.js
@@ -23,7 +23,7 @@ export const ConfirmDeleteDialog = ({
             key="cancel"
             secondary
             onClick={onContinueEditing}
-            dataTest="dhis2-dashboard-cancel-delete-dashboard"
+            dataTest="cancel-delete-dashboard"
         >
             {i18n.t('Cancel')}
         </Button>,
@@ -31,7 +31,7 @@ export const ConfirmDeleteDialog = ({
             key="delete"
             destructive
             onClick={onDeleteConfirmed}
-            dataTest="dhis2-dashboard-confirm-delete-dashboard"
+            dataTest="confirm-delete-dashboard"
         >
             {i18n.t('Delete')}
         </Button>,

--- a/src/components/ControlBar/DashboardItemChip.js
+++ b/src/components/ControlBar/DashboardItemChip.js
@@ -41,7 +41,7 @@ export const DashboardItemChip = ({
             className={classes.link}
             to={`/${dashboardId}`}
             onClick={handleClick}
-            data-test="dhis2-dashboard-dashboard-chip"
+            data-test="dashboard-chip"
         >
             <Chip {...chipProps}>{label}</Chip>
         </Link>

--- a/src/components/ControlBar/DashboardsBar.js
+++ b/src/components/ControlBar/DashboardsBar.js
@@ -110,7 +110,7 @@ export const DashboardsBar = ({
                     <Link
                         className={classes.newLink}
                         to={'/new'}
-                        data-test="dhis2-dashboard-link-new-dashboard"
+                        data-test="link-new-dashboard"
                     >
                         <AddCircleIcon />
                     </Link>

--- a/src/components/ControlBar/EditBar.js
+++ b/src/components/ControlBar/EditBar.js
@@ -166,7 +166,7 @@ export class EditBar extends Component {
                     <Button
                         primary
                         onClick={this.onSave}
-                        dataTest="dhis2-dashboard-save-dashboard-button"
+                        dataTest="save-dashboard-button"
                     >
                         {i18n.t('Save changes')}
                     </Button>
@@ -182,7 +182,7 @@ export class EditBar extends Component {
                     {this.props.dashboardId && this.props.deleteAccess ? (
                         <Button
                             onClick={this.onConfirmDelete}
-                            dataTest="dhis2-dashboard-delete-dashboard-button"
+                            dataTest="delete-dashboard-button"
                         >
                             {i18n.t('Delete')}
                         </Button>

--- a/src/components/ControlBar/Filter.js
+++ b/src/components/ControlBar/Filter.js
@@ -67,7 +67,7 @@ export const Filter = ({
                 onChange={setFilterValue}
                 onKeyUp={onKeyUp}
                 value={filterText}
-                data-test="dhis2-dashboard-search-dashboard-input"
+                data-test="search-dashboard-input"
             />
             {filterText && <ClearButton onClear={clearDashboardsFilter} />}
         </div>

--- a/src/components/ControlBar/ShowMoreButton.js
+++ b/src/components/ControlBar/ShowMoreButton.js
@@ -15,7 +15,7 @@ export const ShowMoreButton = ({ onClick, isMaxHeight, disabled }) => {
                 <div
                     className={classes.showMore}
                     onClick={onClick}
-                    data-test="dhis2-dashboard-showmore-button"
+                    data-test="showmore-button"
                 >
                     {isMaxHeight ? i18n.t('Show less') : i18n.t('Show more')}
                 </div>

--- a/src/components/ControlBar/__tests__/__snapshots__/ConfirmDeleteDialog.spec.js.snap
+++ b/src/components/ControlBar/__tests__/__snapshots__/ConfirmDeleteDialog.spec.js.snap
@@ -30,7 +30,7 @@ exports[`ConfirmDeleteDialog when open = true matches the snapshot 1`] = `
       dataTest="dhis2-uicore-buttonstrip"
     >
       <Button
-        dataTest="dhis2-dashboard-cancel-delete-dashboard"
+        dataTest="cancel-delete-dashboard"
         key="cancel"
         onClick={[MockFunction]}
         secondary={true}
@@ -39,7 +39,7 @@ exports[`ConfirmDeleteDialog when open = true matches the snapshot 1`] = `
         Cancel
       </Button>
       <Button
-        dataTest="dhis2-dashboard-confirm-delete-dashboard"
+        dataTest="confirm-delete-dashboard"
         destructive={true}
         key="delete"
         onClick={[MockFunction]}

--- a/src/components/ControlBar/__tests__/__snapshots__/DashboardsBar.spec.js.snap
+++ b/src/components/ControlBar/__tests__/__snapshots__/DashboardsBar.spec.js.snap
@@ -18,7 +18,7 @@ exports[`clicking "Show more" maximizes dashboards bar height 1`] = `
         >
           <a
             class="newLink"
-            data-test="dhis2-dashboard-link-new-dashboard"
+            data-test="link-new-dashboard"
             href="/new"
           >
             <svg
@@ -53,7 +53,7 @@ exports[`clicking "Show more" maximizes dashboards bar height 1`] = `
             </svg>
             <input
               class="input"
-              data-test="dhis2-dashboard-search-dashboard-input"
+              data-test="search-dashboard-input"
               placeholder="Search for a dashboard"
               type="text"
               value=""
@@ -62,7 +62,7 @@ exports[`clicking "Show more" maximizes dashboards bar height 1`] = `
         </div>
         <a
           class="link"
-          data-test="dhis2-dashboard-dashboard-chip"
+          data-test="dashboard-chip"
           href="/fluttershy123"
         >
           <span
@@ -100,7 +100,7 @@ exports[`clicking "Show more" maximizes dashboards bar height 1`] = `
         </a>
         <a
           class="link"
-          data-test="dhis2-dashboard-dashboard-chip"
+          data-test="dashboard-chip"
           href="/rainbow123"
         >
           <span
@@ -120,7 +120,7 @@ exports[`clicking "Show more" maximizes dashboards bar height 1`] = `
       >
         <div
           class="showMore"
-          data-test="dhis2-dashboard-showmore-button"
+          data-test="showmore-button"
         >
           Show less
         </div>
@@ -153,7 +153,7 @@ exports[`renders a DashboardsBar with maximum height 1`] = `
         >
           <a
             class="newLink"
-            data-test="dhis2-dashboard-link-new-dashboard"
+            data-test="link-new-dashboard"
             href="/new"
           >
             <svg
@@ -188,7 +188,7 @@ exports[`renders a DashboardsBar with maximum height 1`] = `
             </svg>
             <input
               class="input"
-              data-test="dhis2-dashboard-search-dashboard-input"
+              data-test="search-dashboard-input"
               placeholder="Search for a dashboard"
               type="text"
               value=""
@@ -198,7 +198,7 @@ exports[`renders a DashboardsBar with maximum height 1`] = `
         </div>
         <a
           class="link"
-          data-test="dhis2-dashboard-dashboard-chip"
+          data-test="dashboard-chip"
           href="/fluttershy123"
         >
           <span
@@ -236,7 +236,7 @@ exports[`renders a DashboardsBar with maximum height 1`] = `
         </a>
         <a
           class="link"
-          data-test="dhis2-dashboard-dashboard-chip"
+          data-test="dashboard-chip"
           href="/rainbow123"
         >
           <span
@@ -288,7 +288,7 @@ exports[`renders a DashboardsBar with minimum height 1`] = `
         >
           <a
             class="newLink"
-            data-test="dhis2-dashboard-link-new-dashboard"
+            data-test="link-new-dashboard"
             href="/new"
           >
             <svg
@@ -323,7 +323,7 @@ exports[`renders a DashboardsBar with minimum height 1`] = `
             </svg>
             <input
               class="input"
-              data-test="dhis2-dashboard-search-dashboard-input"
+              data-test="search-dashboard-input"
               placeholder="Search for a dashboard"
               type="text"
               value=""
@@ -333,7 +333,7 @@ exports[`renders a DashboardsBar with minimum height 1`] = `
         </div>
         <a
           class="link"
-          data-test="dhis2-dashboard-dashboard-chip"
+          data-test="dashboard-chip"
           href="/fluttershy123"
         >
           <span
@@ -371,7 +371,7 @@ exports[`renders a DashboardsBar with minimum height 1`] = `
         </a>
         <a
           class="link"
-          data-test="dhis2-dashboard-dashboard-chip"
+          data-test="dashboard-chip"
           href="/rainbow123"
         >
           <span
@@ -391,7 +391,7 @@ exports[`renders a DashboardsBar with minimum height 1`] = `
       >
         <div
           class="showMore"
-          data-test="dhis2-dashboard-showmore-button"
+          data-test="showmore-button"
         >
           Show more
         </div>
@@ -424,7 +424,7 @@ exports[`renders a DashboardsBar with no items 1`] = `
         >
           <a
             class="newLink"
-            data-test="dhis2-dashboard-link-new-dashboard"
+            data-test="link-new-dashboard"
             href="/new"
           >
             <svg
@@ -459,7 +459,7 @@ exports[`renders a DashboardsBar with no items 1`] = `
             </svg>
             <input
               class="input"
-              data-test="dhis2-dashboard-search-dashboard-input"
+              data-test="search-dashboard-input"
               placeholder="Search for a dashboard"
               type="text"
               value=""
@@ -473,7 +473,7 @@ exports[`renders a DashboardsBar with no items 1`] = `
       >
         <div
           class="showMore"
-          data-test="dhis2-dashboard-showmore-button"
+          data-test="showmore-button"
         >
           Show more
         </div>
@@ -506,7 +506,7 @@ exports[`renders a DashboardsBar with selected item 1`] = `
         >
           <a
             class="newLink"
-            data-test="dhis2-dashboard-link-new-dashboard"
+            data-test="link-new-dashboard"
             href="/new"
           >
             <svg
@@ -541,7 +541,7 @@ exports[`renders a DashboardsBar with selected item 1`] = `
             </svg>
             <input
               class="input"
-              data-test="dhis2-dashboard-search-dashboard-input"
+              data-test="search-dashboard-input"
               placeholder="Search for a dashboard"
               type="text"
               value=""
@@ -551,7 +551,7 @@ exports[`renders a DashboardsBar with selected item 1`] = `
         </div>
         <a
           class="link"
-          data-test="dhis2-dashboard-dashboard-chip"
+          data-test="dashboard-chip"
           href="/fluttershy123"
         >
           <span
@@ -589,7 +589,7 @@ exports[`renders a DashboardsBar with selected item 1`] = `
         </a>
         <a
           class="link"
-          data-test="dhis2-dashboard-dashboard-chip"
+          data-test="dashboard-chip"
           href="/rainbow123"
         >
           <span
@@ -609,7 +609,7 @@ exports[`renders a DashboardsBar with selected item 1`] = `
       >
         <div
           class="showMore"
-          data-test="dhis2-dashboard-showmore-button"
+          data-test="showmore-button"
         >
           Show more
         </div>

--- a/src/components/ControlBar/__tests__/__snapshots__/EditBar.spec.js.snap
+++ b/src/components/ControlBar/__tests__/__snapshots__/EditBar.spec.js.snap
@@ -101,7 +101,7 @@ exports[`EditBar when update access is true when dashboard id property provided 
           dataTest="dhis2-uicore-buttonstrip"
         >
           <Button
-            dataTest="dhis2-dashboard-save-dashboard-button"
+            dataTest="save-dashboard-button"
             onClick={[Function]}
             primary={true}
             type="button"
@@ -198,7 +198,7 @@ exports[`EditBar when update access is true when dashboard id property provided 
           dataTest="dhis2-uicore-buttonstrip"
         >
           <Button
-            dataTest="dhis2-dashboard-save-dashboard-button"
+            dataTest="save-dashboard-button"
             onClick={[Function]}
             primary={true}
             type="button"
@@ -295,7 +295,7 @@ exports[`EditBar when update access is true when dashboard id property provided 
           dataTest="dhis2-uicore-buttonstrip"
         >
           <Button
-            dataTest="dhis2-dashboard-save-dashboard-button"
+            dataTest="save-dashboard-button"
             onClick={[Function]}
             primary={true}
             type="button"
@@ -392,7 +392,7 @@ exports[`EditBar when update access is true when dashboard id property provided 
           dataTest="dhis2-uicore-buttonstrip"
         >
           <Button
-            dataTest="dhis2-dashboard-save-dashboard-button"
+            dataTest="save-dashboard-button"
             onClick={[Function]}
             primary={true}
             type="button"
@@ -414,7 +414,7 @@ exports[`EditBar when update access is true when dashboard id property provided 
             Translate
           </Button>
           <Button
-            dataTest="dhis2-dashboard-delete-dashboard-button"
+            dataTest="delete-dashboard-button"
             onClick={[Function]}
             type="button"
           >
@@ -472,7 +472,7 @@ exports[`EditBar when update access is true when no dashboard id property render
           dataTest="dhis2-uicore-buttonstrip"
         >
           <Button
-            dataTest="dhis2-dashboard-save-dashboard-button"
+            dataTest="save-dashboard-button"
             onClick={[Function]}
             primary={true}
             type="button"

--- a/src/components/ControlBar/__tests__/__snapshots__/Filter.spec.js.snap
+++ b/src/components/ControlBar/__tests__/__snapshots__/Filter.spec.js.snap
@@ -11,7 +11,7 @@ exports[`Filter matches the snapshot when filterText property is empty 1`] = `
   />
   <input
     className="input"
-    data-test="dhis2-dashboard-search-dashboard-input"
+    data-test="search-dashboard-input"
     onChange={[Function]}
     onKeyUp={[Function]}
     placeholder="Search for a dashboard"

--- a/src/components/ControlBar/__tests__/__snapshots__/ShowMoreButton.spec.js.snap
+++ b/src/components/ControlBar/__tests__/__snapshots__/ShowMoreButton.spec.js.snap
@@ -6,7 +6,7 @@ exports[`ShowMoreButton renders correctly when at maxHeight 1`] = `
 >
   <div
     className="showMore"
-    data-test="dhis2-dashboard-showmore-button"
+    data-test="showmore-button"
     onClick={[Function]}
   >
     Show less
@@ -20,7 +20,7 @@ exports[`ShowMoreButton renders correctly when not at maxHeight 1`] = `
 >
   <div
     className="showMore"
-    data-test="dhis2-dashboard-showmore-button"
+    data-test="showmore-button"
     onClick={[Function]}
   >
     Show more

--- a/src/components/Dashboard/PrintActionsBar.js
+++ b/src/components/Dashboard/PrintActionsBar.js
@@ -22,7 +22,7 @@ const PrintActionsBar = ({ id }) => {
             <div className={classes.container}>
                 <div className={classes.inner} style={{ width }}>
                     <Link className={classes.link} to={`/${id}`}>
-                        <Button dataTest="dhis2-dashboard-exit-print-preview">
+                        <Button dataTest="exit-print-preview">
                             <LessHorizontalIcon />
                             {i18n.t('Exit print preview')}
                         </Button>

--- a/src/components/Dashboard/PrintDashboard.js
+++ b/src/components/Dashboard/PrintDashboard.js
@@ -106,7 +106,7 @@ export class PrintDashboard extends Component {
                     <div
                         className={classes.pageOuter}
                         style={{ width: a4LandscapeWidthPx }}
-                        data-test="dhis2-dashboard-print-oipp-page"
+                        data-test="print-oipp-page"
                     >
                         <PrintItemGrid />
                     </div>

--- a/src/components/Dashboard/PrintLayoutDashboard.js
+++ b/src/components/Dashboard/PrintLayoutDashboard.js
@@ -148,7 +148,7 @@ export class PrintLayoutDashboard extends Component {
                     <div
                         className={classes.pageOuter}
                         style={{ width: a4LandscapeWidthPx }}
-                        data-test="dhis2-dashboard-print-layout-page"
+                        data-test="print-layout-page"
                     >
                         <PrintLayoutItemGrid />
                     </div>

--- a/src/components/ItemSelector/ContentMenuItem.js
+++ b/src/components/ItemSelector/ContentMenuItem.js
@@ -55,7 +55,7 @@ const ContentMenuItem = ({ type, name, onInsert, url, visType }) => {
                     <InsertButton />
                 </div>
             }
-            dataTest={`dhis2-dashboard-menu-item-${name}`}
+            dataTest={`menu-item-${name}`}
         />
     )
 }

--- a/src/components/ItemSelector/ItemSelector.js
+++ b/src/components/ItemSelector/ItemSelector.js
@@ -19,7 +19,7 @@ const ItemSearchField = props => (
         onChange={props.onChange}
         onFocus={props.onFocus}
         value={props.value}
-        dataTest="dhis2-dashboard-item-search"
+        dataTest="item-search"
     />
 )
 
@@ -142,10 +142,7 @@ class ItemSelector extends React.Component {
                     disableEnforceFocus={true}
                     disableRestoreFocus={true}
                 >
-                    <Menu
-                        dataTest={'dhis2-dashboard-item-menu'}
-                        maxWidth={'700px'}
-                    >
+                    <Menu dataTest={'item-menu'} maxWidth={'700px'}>
                         {this.getMenuGroups()}
                     </Menu>
                 </Popover>

--- a/src/components/ItemSelector/__tests__/__snapshots__/ContentMenuItem.spec.js.snap
+++ b/src/components/ItemSelector/__tests__/__snapshots__/ContentMenuItem.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ContentMenuItem does not have LaunchLink if no url provided 1`] = `
 <MenuItem
-  dataTest="dhis2-dashboard-menu-item-Pinkie Pie"
+  dataTest="menu-item-Pinkie Pie"
   dense={true}
   label={
     <div
@@ -39,7 +39,7 @@ exports[`ContentMenuItem does not have LaunchLink if no url provided 1`] = `
 
 exports[`ContentMenuItem has a LaunchLink when url is provided 1`] = `
 <MenuItem
-  dataTest="dhis2-dashboard-menu-item-Pinkie Pie"
+  dataTest="menu-item-Pinkie Pie"
   dense={true}
   label={
     <div

--- a/src/components/TitleBar/EditTitleBar.js
+++ b/src/components/TitleBar/EditTitleBar.js
@@ -39,7 +39,7 @@ export const EditTitleBar = ({
                     onChange={updateTitle}
                     value={name}
                     placeholder={i18n.t('Untitled dashboard')}
-                    dataTest="dhis2-dashboard-dashboard-title-input"
+                    dataTest="dashboard-title-input"
                 />
                 <TextAreaField
                     className={classes.description}
@@ -47,7 +47,7 @@ export const EditTitleBar = ({
                     label={i18n.t('Dashboard description')}
                     onChange={updateDescription}
                     value={description}
-                    dataTest="dhis2-dashboard-dashboard-description-input"
+                    dataTest="dashboard-description-input"
                 />
             </div>
             <div className={classes.itemSelector}>

--- a/src/components/TitleBar/ViewTitleBar.js
+++ b/src/components/TitleBar/ViewTitleBar.js
@@ -88,10 +88,7 @@ const ViewTitleBar = (props, context) => {
     return (
         <>
             <div className={classes.titleBar}>
-                <span
-                    style={titleStyle}
-                    data-test="dhis2-dashboard-view-dashboard-title"
-                >
+                <span style={titleStyle} data-test="view-dashboard-title">
                     {name}
                 </span>
                 <div className={classes.actions}>
@@ -106,7 +103,7 @@ const ViewTitleBar = (props, context) => {
                             <Link
                                 className={classes.editLink}
                                 to={`/${id}/edit`}
-                                data-test="dhis2-dashboard-link-edit-dashboard"
+                                data-test="link-edit-dashboard"
                             >
                                 <Button>{i18n.t('Edit')}</Button>
                             </Link>
@@ -119,7 +116,7 @@ const ViewTitleBar = (props, context) => {
                         <FilterSelector />
                         <span ref={buttonRef}>
                             <Button
-                                dataTest="dhis2-dashboard-more-button"
+                                dataTest="more-button"
                                 onClick={toggleMoreOptions}
                             >
                                 <ThreeDots />
@@ -149,19 +146,19 @@ const ViewTitleBar = (props, context) => {
                                 <MenuItem
                                     dense
                                     label={i18n.t('Print')}
-                                    dataTest="dhis2-dashboard-print-menu-item"
+                                    dataTest="print-menu-item"
                                 >
                                     <MenuItem
                                         dense
                                         label={i18n.t('Dashboard layout')}
                                         onClick={printLayout}
-                                        dataTest="dhis2-dashboard-print-layout-menu-item"
+                                        dataTest="print-layout-menu-item"
                                     />
                                     <MenuItem
                                         dense
                                         label={i18n.t('One item per page')}
                                         onClick={printOipp}
-                                        dataTest="dhis2-dashboard-print-oipp-menu-item"
+                                        dataTest="print-oipp-menu-item"
                                     />
                                 </MenuItem>
                             </FlyoutMenu>

--- a/src/components/TitleBar/__tests__/__snapshots__/EditTitleBar.spec.js.snap
+++ b/src/components/TitleBar/__tests__/__snapshots__/EditTitleBar.spec.js.snap
@@ -9,7 +9,7 @@ exports[`EditTitleBar renders correctly 1`] = `
   >
     <InputField
       className="title"
-      dataTest="dhis2-dashboard-dashboard-title-input"
+      dataTest="dashboard-title-input"
       label="Dashboard title"
       name="Dashboard title input"
       onChange={[Function]}
@@ -19,7 +19,7 @@ exports[`EditTitleBar renders correctly 1`] = `
     />
     <TextAreaField
       className="description"
-      dataTest="dhis2-dashboard-dashboard-description-input"
+      dataTest="dashboard-description-input"
       label="Dashboard description"
       name="Dashboard description input"
       onChange={[Function]}
@@ -46,7 +46,7 @@ exports[`EditTitleBar renders correctly when no name 1`] = `
   >
     <InputField
       className="title"
-      dataTest="dhis2-dashboard-dashboard-title-input"
+      dataTest="dashboard-title-input"
       label="Dashboard title"
       name="Dashboard title input"
       onChange={[Function]}
@@ -56,7 +56,7 @@ exports[`EditTitleBar renders correctly when no name 1`] = `
     />
     <TextAreaField
       className="description"
-      dataTest="dhis2-dashboard-dashboard-description-input"
+      dataTest="dashboard-description-input"
       label="Dashboard description"
       name="Dashboard description input"
       onChange={[Function]}


### PR DESCRIPTION
It was recently decided in a frontend cypress meeting that prefixing data-test ids in apps wasn't useful, in contrast to libraries. This PR removes the app prefix from all data-test ids.