### PR TITLE
test: temporarily disable create dashboard tests

### DIFF
--- a/cypress/integration/ui/create_dashboard.feature
+++ b/cypress/integration/ui/create_dashboard.feature
@@ -1,28 +1,28 @@
 Feature: Creating and deleting dashboard
 
-    @mutating
-    Scenario: I create a new dashboard
-        Given I choose to create new dashboard
-        And dashboard title is added
-        And dashboard items are added
-        And escape key is pressed
-        And dashboard is saved
-        Then dashboard displays in view mode
-        And the saved dashboard should be displayed
+# @mutating
+# Scenario: I create a new dashboard
+#     Given I choose to create new dashboard
+#     And dashboard title is added
+#     And dashboard items are added
+#     And escape key is pressed
+#     And dashboard is saved
+#     Then dashboard displays in view mode
+#     And the saved dashboard should be displayed
 
-    @mutating
-    Scenario: I cancel a delete dashboard action
-        Given I open existing dashboard
-        When I choose to edit dashboard
-        And I choose to delete dashboard
-        And I cancel delete
-        Then the dashboard displays in edit mode
+# @mutating
+# Scenario: I cancel a delete dashboard action
+#     Given I open existing dashboard
+#     When I choose to edit dashboard
+#     And I choose to delete dashboard
+#     And I cancel delete
+#     Then the dashboard displays in edit mode
 
-    @mutating
-    Scenario: I delete a dashboard
-        Given I open existing dashboard
-        When I choose to edit dashboard
-        And I choose to delete dashboard
-        And I confirm delete
-        Then dashboard displays in view mode
-        And the dashboard is deleted and first starred dashboard displayed
+# @mutating
+# Scenario: I delete a dashboard
+#     Given I open existing dashboard
+#     When I choose to edit dashboard
+#     And I choose to delete dashboard
+#     And I confirm delete
+#     Then dashboard displays in view mode
+#     And the dashboard is deleted and first starred dashboard displayed


### PR DESCRIPTION
The create dashboard tests are flaky and I need to figure out what's going on. For now, disabling them so that the failure doesn't interfere with other PRs.