### PR TITLE
fix: install the Cypress binary for the e2e tests

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -125,6 +125,9 @@ jobs:
                   path: '**/node_modules'
                   key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
 
+            - name: Install Cypress binary
+              run: yarn cypress install
+
             - name: End-to-End tests
               uses: cypress-io/github-action@v2
               with:


### PR DESCRIPTION
e2e tests were passing just fine. Then they started failing because apparently the Cypress binary was not in the cache on CI. This explicitly installs Cypress.