### PR TITLE
ci: set D2_VERBOSE so all d2 cli output is visible on CI

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,8 +1,6 @@
 name: 'dhis2: verify (app)'
 
-on:
-    push:
-        branches:
+on: push
 
 env:
     GIT_AUTHOR_NAME: '@dhis2-bot'
@@ -11,6 +9,7 @@ env:
     GIT_COMMITTER_EMAIL: 'apps@dhis2.org'
     GH_TOKEN: ${{secrets.DHIS2_BOT_GITHUB_TOKEN}}
     CI: true
+    D2_VERBOSE: true
 
 jobs:
     install:


### PR DESCRIPTION
By setting the D2_VERBOSE environment variable in the Actions workflow, all d2 cli commands (notably `app-platform` builds) will show all output in CI - this should help with debugging any build failures that might otherwise be swallowed.