### PR TITLE
feat: print layout padding

### DIFF
--- a/cypress/integration/ui/view_dashboard/index.js
+++ b/cypress/integration/ui/view_dashboard/index.js
@@ -36,7 +36,7 @@ Then('the print layout displays for {string} dashboard', title => {
 })
 
 When('I click to exit print preview', () => {
-    cy.get('[data-test="exit-print-preview"]').click()
+    cy.contains('Exit print preview').click()
 })
 
 When('I click to preview the print one-item-per-page', () => {

--- a/src/components/Dashboard/PrintActionsBar.js
+++ b/src/components/Dashboard/PrintActionsBar.js
@@ -4,27 +4,32 @@ import i18n from '@dhis2/d2-i18n'
 import { Button } from '@dhis2/ui'
 import { Link } from 'react-router-dom'
 import LessHorizontalIcon from '../../icons/LessHorizontal'
-import { a4LandscapeWidthPx } from '../ItemGrid/gridUtil'
+import { useWindowDimensions } from '../WindowDimensionsProvider'
+import isSmallScreen from '../../modules/isSmallScreen'
 
 import classes from './styles/PrintActionsBar.module.css'
 
-// 42px set in the module css file
-export const PRINT_ACTIONS_BAR_HEIGHT = 42
+// set in PrintActionsBar.module.css
+export const PRINT_ACTIONS_BAR_HEIGHT = 44
+export const PRINT_ACTIONS_BAR_HEIGHT_SM = 36
 
 const PrintActionsBar = ({ id }) => {
-    const width = a4LandscapeWidthPx
+    const { width } = useWindowDimensions()
+    const isSmall = isSmallScreen(width)
 
     return (
         <>
             <div className={classes.container}>
-                <div className={classes.inner} style={{ width }}>
+                <div className={classes.inner}>
                     <Link className={classes.link} to={`/${id}`}>
-                        <Button dataTest="exit-print-preview">
+                        <Button small={isSmall}>
                             <LessHorizontalIcon />
                             {i18n.t('Exit print preview')}
                         </Button>
                     </Link>
-                    <Button onClick={window.print}>{i18n.t('Print')}</Button>
+                    <Button small={isSmall} onClick={window.print}>
+                        {i18n.t('Print')}
+                    </Button>
                 </div>
             </div>
             <div className={classes.topMargin} />

--- a/src/components/Dashboard/PrintActionsBar.js
+++ b/src/components/Dashboard/PrintActionsBar.js
@@ -12,10 +12,7 @@ import classes from './styles/PrintActionsBar.module.css'
 export const PRINT_ACTIONS_BAR_HEIGHT = 42
 
 const PrintActionsBar = ({ id }) => {
-    const width =
-        a4LandscapeWidthPx < window.innerWidth
-            ? a4LandscapeWidthPx
-            : window.innerWidth
+    const width = a4LandscapeWidthPx
 
     return (
         <>

--- a/src/components/Dashboard/PrintDashboard.js
+++ b/src/components/Dashboard/PrintDashboard.js
@@ -22,7 +22,6 @@ import {
 } from '../../reducers/dashboards'
 import { PAGEBREAK, PRINT_TITLE_PAGE, SPACER } from '../../modules/itemTypes'
 import {
-    a4LandscapeWidthPx,
     MAX_ITEM_GRID_HEIGHT_OIPP,
     MAX_ITEM_GRID_WIDTH_OIPP,
 } from '../ItemGrid/gridUtil'
@@ -100,11 +99,7 @@ const PrintDashboard = ({
                 style={{ height: availableHeight }}
             >
                 <PrintInfo isLayout={false} />
-                <div
-                    className={classes.pageOuter}
-                    style={{ width: a4LandscapeWidthPx }}
-                    data-test="print-oipp-page"
-                >
+                <div className={classes.pageOuter} data-test="print-oipp-page">
                     <PrintItemGrid />
                 </div>
             </div>

--- a/src/components/Dashboard/PrintInfo.js
+++ b/src/components/Dashboard/PrintInfo.js
@@ -11,21 +11,21 @@ const PrintInfo = ({ isLayout }) => {
             ? a4LandscapeWidthPx
             : window.innerWidth
 
-    const infoHeader = isLayout
+    const layoutStyle = isLayout
         ? i18n.t('dashboard layout')
         : i18n.t('one item per page')
 
     return (
-        <div className={classes.infoWrapper}>
-            <p className={classes.infoHeader}>
-                {`${i18n.t('Print Preview')}: ${infoHeader}`}
+        <div className={classes.container}>
+            <p className={classes.title}>
+                {`${i18n.t('Print Preview')}: ${layoutStyle}`}
             </p>
             <div style={{ maxWidth }}>
                 <p className={classes.info}>
                     {`${i18n.t('For best print results')}:`}
                 </p>
                 <div className={classes.info}>
-                    <ul className={classes.infoList}>
+                    <ul className={classes.printSuggestions}>
                         <li>{i18n.t('Use Chrome or Edge web browser')}</li>
                         <li>
                             {i18n.t(

--- a/src/components/Dashboard/PrintInfo.js
+++ b/src/components/Dashboard/PrintInfo.js
@@ -1,16 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import i18n from '@dhis2/d2-i18n'
-import { a4LandscapeWidthPx } from '../ItemGrid/gridUtil'
 
 import classes from './styles/PrintInfo.module.css'
 
 const PrintInfo = ({ isLayout }) => {
-    const maxWidth =
-        a4LandscapeWidthPx < window.innerWidth
-            ? a4LandscapeWidthPx
-            : window.innerWidth
-
     const layoutStyle = isLayout
         ? i18n.t('dashboard layout')
         : i18n.t('one item per page')
@@ -20,25 +14,21 @@ const PrintInfo = ({ isLayout }) => {
             <p className={classes.title}>
                 {`${i18n.t('Print Preview')}: ${layoutStyle}`}
             </p>
-            <div style={{ maxWidth }}>
-                <p className={classes.info}>
-                    {`${i18n.t('For best print results')}:`}
-                </p>
-                <div className={classes.info}>
-                    <ul className={classes.printSuggestions}>
-                        <li>{i18n.t('Use Chrome or Edge web browser')}</li>
-                        <li>
-                            {i18n.t(
-                                'Wait for all dashboard items to load before printing'
-                            )}
-                        </li>
-                        <li>
-                            {i18n.t(
-                                'Use A4 landscape paper size and default margin settings in the browser print dialog'
-                            )}
-                        </li>
-                    </ul>
-                </div>
+            <div className={classes.printSuggestions}>
+                <p>{`${i18n.t('For best print results')}:`}</p>
+                <ul>
+                    <li>{i18n.t('Use Chrome or Edge web browser')}</li>
+                    <li>
+                        {i18n.t(
+                            'Wait for all dashboard items to load before printing'
+                        )}
+                    </li>
+                    <li>
+                        {i18n.t(
+                            'Use A4 landscape paper size and default margin settings in the browser print dialog'
+                        )}
+                    </li>
+                </ul>
             </div>
             <hr className={classes.divider} />
         </div>

--- a/src/components/Dashboard/PrintLayoutDashboard.js
+++ b/src/components/Dashboard/PrintLayoutDashboard.js
@@ -25,7 +25,7 @@ import {
     sGetDashboardItems,
 } from '../../reducers/dashboards'
 import { PAGEBREAK, PRINT_TITLE_PAGE } from '../../modules/itemTypes'
-import { a4LandscapeWidthPx, MAX_ITEM_GRID_HEIGHT } from '../ItemGrid/gridUtil'
+import { MAX_ITEM_GRID_HEIGHT } from '../ItemGrid/gridUtil'
 import {
     getControlBarHeight,
     HEADERBAR_HEIGHT,
@@ -109,7 +109,6 @@ const PrintLayoutDashboard = ({
                 {!fromEdit && <PrintInfo isLayout={true} />}
                 <div
                     className={classes.pageOuter}
-                    style={{ width: a4LandscapeWidthPx }}
                     data-test="print-layout-page"
                 >
                     <PrintLayoutItemGrid />

--- a/src/components/Dashboard/PrintLayoutDashboard.js
+++ b/src/components/Dashboard/PrintLayoutDashboard.js
@@ -1,11 +1,14 @@
-import React, { Component } from 'react'
+import React, { useEffect } from 'react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import { spacers } from '@dhis2/ui'
 import cx from 'classnames'
 
 import PrintInfo from './PrintInfo'
-import PrintActionsBar from './PrintActionsBar'
+import PrintActionsBar, {
+    PRINT_ACTIONS_BAR_HEIGHT,
+    PRINT_ACTIONS_BAR_HEIGHT_SM,
+} from './PrintActionsBar'
 import PrintLayoutItemGrid from '../ItemGrid/PrintLayoutItemGrid'
 import {
     acSetPrintDashboard,
@@ -13,7 +16,6 @@ import {
     acUpdatePrintDashboardItem,
 } from '../../actions/printDashboard'
 import { sGetSelectedId } from '../../reducers/selected'
-import { sGetWindowHeight } from '../../reducers/windowHeight'
 import {
     sGetEditDashboardRoot,
     sGetEditDashboardItems,
@@ -28,8 +30,10 @@ import {
     getControlBarHeight,
     HEADERBAR_HEIGHT,
 } from '../ControlBar/controlBarDimensions'
-import { PRINT_ACTIONS_BAR_HEIGHT } from './PrintActionsBar'
 import { DRAG_HANDLE_HEIGHT } from '../ControlBar/ControlBar'
+import { useWindowDimensions } from '../WindowDimensionsProvider'
+import isSmallScreen from '../../modules/isSmallScreen'
+import { getPageBreakPositions } from '../../modules/printUtils'
 
 import classes from './styles/PrintLayoutDashboard.module.css'
 
@@ -38,124 +42,81 @@ import './styles/print-layout.css'
 
 const EDIT_BAR_HEIGHT = getControlBarHeight(1) + DRAG_HANDLE_HEIGHT
 
-const isLeapPage = n => {
-    // pages 5,9,13,17,21,25,29... are leap pages
-    let x = 0
-    const startPage = 1
-    const getMultiple = factor => startPage + 4 * factor
-    let multiple = getMultiple(0)
-    let isLeapPage = false
-    while (multiple < n) {
-        multiple = getMultiple(x)
-        ++x
-        if (multiple === n) {
-            isLeapPage = true
-            break
-        }
-    }
-    return isLeapPage
-}
-
-const addPageBreaks = ({ items, addDashboardItem }) => {
-    // add enough page breaks so that each item could
-    // be put on its own page. Due to the react-grid-layout
-    // unit system, we have to estimate roughly the size of each
-    // page. At regular intervals add a unit, like a leap year
-    let yPos = 0
-    const yPosList = []
-    for (let pageNum = 1; pageNum <= items.length; ++pageNum) {
-        if (pageNum === 1) {
-            yPos += 35
-        } else if (isLeapPage(pageNum)) {
-            yPos += 40
-        } else {
-            yPos += 39
-        }
-        yPosList.push(yPos)
-    }
+const addPageBreaks = (items, addDashboardItem) => {
+    const yPosList = getPageBreakPositions(items)
 
     for (let i = 0; i < items.length; ++i) {
         addDashboardItem({ type: PAGEBREAK, yPos: yPosList[i] })
     }
 }
 
-export class PrintLayoutDashboard extends Component {
-    state = {
-        initialized: false,
-    }
+const PrintLayoutDashboard = ({
+    dashboard,
+    items,
+    setPrintDashboard,
+    addDashboardItem,
+    updateDashboardItem,
+    fromEdit,
+}) => {
+    const { width, height } = useWindowDimensions()
 
-    initPrintLayoutDashboard = () => {
-        if (this.props.dashboard) {
-            this.setState({ initialized: true })
+    const actionBarHeight = isSmallScreen(width)
+        ? PRINT_ACTIONS_BAR_HEIGHT_SM
+        : PRINT_ACTIONS_BAR_HEIGHT
 
-            this.props.setPrintDashboard(this.props.dashboard, this.props.items)
+    useEffect(() => {
+        if (dashboard) {
+            setPrintDashboard(dashboard, items)
 
             // If any items are taller than one page, reduce it to one
             // page (react-grid-layout units)
-            this.props.items.forEach(item => {
+            items.forEach(item => {
                 if (item.h > MAX_ITEM_GRID_HEIGHT) {
                     item.shortened = true
-                    this.props.updateDashboardItem(
+                    updateDashboardItem(
                         Object.assign({}, item, { h: MAX_ITEM_GRID_HEIGHT })
                     )
                 }
             })
 
-            addPageBreaks(this.props)
+            addPageBreaks(items, addDashboardItem)
 
-            this.props.addDashboardItem({
+            addDashboardItem({
                 type: PRINT_TITLE_PAGE,
                 isOneItemPerPage: false,
             })
         }
-    }
+    }, [dashboard, items])
 
-    componentDidMount() {
-        this.initPrintLayoutDashboard()
-    }
-
-    componentDidUpdate() {
-        if (!this.state.initialized) {
-            this.initPrintLayoutDashboard()
-        }
-    }
-
-    getWrapperStyle = () => {
-        return this.props.fromEdit
+    const getWrapperStyle = () => {
+        return fromEdit
             ? {
                   paddingTop: spacers.dp24,
-                  height:
-                      this.props.windowHeight -
-                      EDIT_BAR_HEIGHT -
-                      HEADERBAR_HEIGHT,
+                  height: height - EDIT_BAR_HEIGHT - HEADERBAR_HEIGHT,
               }
             : {
-                  height: this.props.windowHeight - PRINT_ACTIONS_BAR_HEIGHT,
+                  height: height - actionBarHeight,
               }
     }
 
-    render() {
-        return (
-            <>
-                {!this.props.fromEdit && (
-                    <PrintActionsBar id={this.props.dashboard.id} />
-                )}
+    return (
+        <>
+            {!fromEdit && <PrintActionsBar id={dashboard.id} />}
+            <div
+                className={cx(classes.wrapper, 'scroll-area')}
+                style={getWrapperStyle()}
+            >
+                {!fromEdit && <PrintInfo isLayout={true} />}
                 <div
-                    className={cx(classes.wrapper, 'scroll-area')}
-                    style={this.getWrapperStyle()}
+                    className={classes.pageOuter}
+                    style={{ width: a4LandscapeWidthPx }}
+                    data-test="print-layout-page"
                 >
-                    {!this.props.fromEdit && <PrintInfo isLayout={true} />}
-                    <div
-                        className={classes.pageOuter}
-                        style={{ width: a4LandscapeWidthPx }}
-                        data-test="print-layout-page"
-                    >
-                        <PrintLayoutItemGrid />
-                    </div>
+                    <PrintLayoutItemGrid />
                 </div>
-            </>
-        )
-    }
+            </div>
+        </>
+    )
 }
 
 PrintLayoutDashboard.propTypes = {
@@ -165,7 +126,6 @@ PrintLayoutDashboard.propTypes = {
     items: PropTypes.array,
     setPrintDashboard: PropTypes.func,
     updateDashboardItem: PropTypes.func,
-    windowHeight: PropTypes.number,
 }
 
 const mapStateToProps = (state, ownProps) => {
@@ -178,7 +138,6 @@ const mapStateToProps = (state, ownProps) => {
             dashboard,
             id,
             items: sGetEditDashboardItems(state),
-            windowHeight: sGetWindowHeight(state),
         }
     }
 
@@ -188,7 +147,6 @@ const mapStateToProps = (state, ownProps) => {
         dashboard,
         id,
         items: sGetDashboardItems(state),
-        windowHeight: sGetWindowHeight(state),
     }
 }
 

--- a/src/components/Dashboard/styles/PrintActionsBar.module.css
+++ b/src/components/Dashboard/styles/PrintActionsBar.module.css
@@ -31,7 +31,7 @@
     }
 
     .inner {
-        margin: 0 var(--spacers-dp4);
+        margin: 0 var(--spacers-dp8);
     }
 
     .topMargin {

--- a/src/components/Dashboard/styles/PrintActionsBar.module.css
+++ b/src/components/Dashboard/styles/PrintActionsBar.module.css
@@ -1,26 +1,42 @@
 .container {
     background-color: var(--colors-grey600);
     width: 100%;
-    padding: 3px;
+    padding: var(--spacers-dp4) 0;
     position: fixed;
     z-index: 10;
-    height: 42px;
 }
 
 .topMargin {
-    margin-top: 42px;
+    margin-top: 44px; /* PRINT_ACTIONS_BAR_HEIGHT */
 }
 
 .inner {
-    margin-left: 30px;
+    margin-left: 44px;
+    margin-right: 30px;
     display: flex;
     justify-content: space-between;
+    width: auto;
+    max-width: 1102px;
 }
 
 .link {
     display: inline-block;
     text-decoration: none;
-    margin-right: 4px;
+    margin-right: var(--spacers-dp4);
+}
+
+@media only screen and (max-width: 480px) {
+    .container {
+        padding-bottom: 3px;
+    }
+
+    .inner {
+        margin: 0 var(--spacers-dp4);
+    }
+
+    .topMargin {
+        margin-top: 36px; /* PRINT_ACTIONS_BAR_HEIGHT_SM */
+    }
 }
 
 @media print {
@@ -30,23 +46,5 @@
 
     .topMargin {
         margin-top: 0px;
-    }
-}
-
-/**
-* using a4LandscapeWidthPx (1102 px) plus margin left (30px)
-*/
-@media only screen and (max-width: 1132px) {
-    .inner {
-        width: auto !important;
-        margin-right: 30px;
-    }
-}
-
-@media only screen and (max-width: 480px) {
-    .inner {
-        margin-left: 8px;
-        margin-right: 8px;
-        width: auto !important;
     }
 }

--- a/src/components/Dashboard/styles/PrintActionsBar.module.css
+++ b/src/components/Dashboard/styles/PrintActionsBar.module.css
@@ -32,3 +32,21 @@
         margin-top: 0px;
     }
 }
+
+/**
+* using a4LandscapeWidthPx (1102 px) plus margin left (30px)
+*/
+@media only screen and (max-width: 1132px) {
+    .inner {
+        width: auto !important;
+        margin-right: 30px;
+    }
+}
+
+@media only screen and (max-width: 480px) {
+    .inner {
+        margin-left: 8px;
+        margin-right: 8px;
+        width: auto !important;
+    }
+}

--- a/src/components/Dashboard/styles/PrintDashboard.module.css
+++ b/src/components/Dashboard/styles/PrintDashboard.module.css
@@ -11,6 +11,7 @@
     border-radius: 3px;
     box-shadow: 0px 0px 3px 0px var(--colors-grey500);
     margin-bottom: 50px;
+    width: 1102px;
 }
 
 @media print {

--- a/src/components/Dashboard/styles/PrintInfo.module.css
+++ b/src/components/Dashboard/styles/PrintInfo.module.css
@@ -30,3 +30,22 @@
         display: none;
     }
 }
+
+@media only screen and (max-width: 480px) {
+    .infoHeader {
+        margin-top: 16px;
+        margin-bottom: 16px;
+    }
+
+    .infoList > li:last-child {
+        padding: 0;
+    }
+
+    .divider {
+        margin-top: 2px;
+        margin-bottom: 16px;
+        height: 1px;
+        border: 0;
+        background-color: #d5dde5;
+    }
+}

--- a/src/components/Dashboard/styles/PrintInfo.module.css
+++ b/src/components/Dashboard/styles/PrintInfo.module.css
@@ -1,12 +1,13 @@
-.infoWrapper {
-    margin-bottom: 15px;
+.container {
+    margin-bottom: var(--spacers-dp16);
     width: 100%;
 }
 
-.infoHeader {
+.title {
     font-size: 18px;
     font-weight: 600;
     color: #3e4a59;
+    margin: var(--spacers-dp16) 0;
 }
 
 .info {
@@ -16,36 +17,20 @@
     max-width: 800px;
 }
 
-.infoList > li {
-    padding: 4px 0;
+.printSuggestions > li {
+    padding: var(--spacers-dp4) 0;
 }
 
 .divider {
     width: 1102px;
-    margin-left: 0px;
+    height: 1px;
+    margin: var(--spacers-dp16) 0;
+    border: 0;
+    background-color: var(--colors-grey400);
 }
 
 @media print {
     .infoWrapper {
         display: none;
-    }
-}
-
-@media only screen and (max-width: 480px) {
-    .infoHeader {
-        margin-top: 16px;
-        margin-bottom: 16px;
-    }
-
-    .infoList > li:last-child {
-        padding: 0;
-    }
-
-    .divider {
-        margin-top: 2px;
-        margin-bottom: 16px;
-        height: 1px;
-        border: 0;
-        background-color: #d5dde5;
     }
 }

--- a/src/components/Dashboard/styles/PrintInfo.module.css
+++ b/src/components/Dashboard/styles/PrintInfo.module.css
@@ -1,23 +1,21 @@
 .container {
     margin-bottom: var(--spacers-dp16);
     width: 100%;
+    color: #3e4a59;
 }
 
 .title {
     font-size: 18px;
     font-weight: 600;
-    color: #3e4a59;
     margin: var(--spacers-dp16) 0;
 }
 
-.info {
+.printSuggestions {
     font-size: 14px;
     line-height: 1.3;
-    color: #3e4a59;
-    max-width: 800px;
 }
 
-.printSuggestions > li {
+.printSuggestions li {
     padding: var(--spacers-dp4) 0;
 }
 
@@ -30,7 +28,7 @@
 }
 
 @media print {
-    .infoWrapper {
+    .container {
         display: none;
     }
 }

--- a/src/components/Dashboard/styles/PrintLayoutDashboard.module.css
+++ b/src/components/Dashboard/styles/PrintLayoutDashboard.module.css
@@ -11,6 +11,7 @@
     border-radius: 3px;
     box-shadow: 0px 0px 3px 0px var(--colors-grey500);
     margin-bottom: 50px;
+    width: 1102px;
 }
 
 @media print {

--- a/src/components/Dashboard/styles/PrintLayoutDashboard.module.css
+++ b/src/components/Dashboard/styles/PrintLayoutDashboard.module.css
@@ -27,3 +27,9 @@
         border-radius: 0px;
     }
 }
+
+@media only screen and (max-width: 480px) {
+    .wrapper {
+        margin-left: 0px;
+    }
+}

--- a/src/components/ItemGrid/PrintItemGrid.js
+++ b/src/components/ItemGrid/PrintItemGrid.js
@@ -22,7 +22,7 @@ import {
     MARGIN,
     getGridColumns,
     hasShape,
-    a4LandscapeWidthPx,
+    A4_LANDSCAPE_WIDTH_PX,
 } from './gridUtil'
 import { orArray } from '../../modules/util'
 
@@ -50,11 +50,6 @@ export class PrintItemGrid extends Component {
             )
         }
 
-        const width =
-            a4LandscapeWidthPx < window.innerWidth
-                ? a4LandscapeWidthPx
-                : window.innerWidth
-
         return (
             <>
                 {isLoading ? (
@@ -70,7 +65,7 @@ export class PrintItemGrid extends Component {
                     margin={MARGIN}
                     cols={getGridColumns()}
                     rowHeight={GRID_ROW_HEIGHT}
-                    width={width}
+                    width={A4_LANDSCAPE_WIDTH_PX}
                     compactType={GRID_COMPACT_TYPE}
                     isDraggable={false}
                     isResizable={false}

--- a/src/components/ItemGrid/PrintLayoutItemGrid.js
+++ b/src/components/ItemGrid/PrintLayoutItemGrid.js
@@ -24,7 +24,7 @@ import {
     MARGIN,
     getGridColumns,
     hasShape,
-    a4LandscapeWidthPx,
+    A4_LANDSCAPE_WIDTH_PX,
 } from './gridUtil'
 import {
     getDomGridItemsSortedByYPos,
@@ -147,11 +147,6 @@ export class PrintLayoutItemGrid extends Component {
             )
         }
 
-        const width =
-            a4LandscapeWidthPx < window.innerWidth
-                ? a4LandscapeWidthPx
-                : window.innerWidth
-
         return (
             <div className="grid-wrapper">
                 {isLoading ? (
@@ -168,7 +163,7 @@ export class PrintLayoutItemGrid extends Component {
                     margin={MARGIN}
                     cols={getGridColumns()}
                     rowHeight={GRID_ROW_HEIGHT}
-                    width={width}
+                    width={A4_LANDSCAPE_WIDTH_PX}
                     compactType={GRID_COMPACT_TYPE}
                     isDraggable={false}
                     isResizable={false}

--- a/src/components/ItemGrid/gridUtil.js
+++ b/src/components/ItemGrid/gridUtil.js
@@ -25,7 +25,7 @@ export const MAX_ITEM_GRID_WIDTH_OIPP = 56
 // 794 px = (21cm / 2.54) * 96 pixels/inch
 // 1122 px = 29.7 /2.54 * 96 pixels/inch
 // const a4LandscapeHeightPx = 794
-export const a4LandscapeWidthPx = 1102
+export const A4_LANDSCAPE_WIDTH_PX = 1102
 
 export const getGridColumns = () => {
     switch (GRID_LAYOUT) {

--- a/src/modules/printUtils.js
+++ b/src/modules/printUtils.js
@@ -37,3 +37,42 @@ export const getDomGridItemsSortedByYPos = elements => {
     })
     return sortBy(elementsWithBoundingRect, ['bottomY'])
 }
+
+const isLeapPage = n => {
+    // pages 5,9,13,17,21,25,29... are leap pages
+    let x = 0
+    const startPage = 1
+    const getMultiple = factor => startPage + 4 * factor
+    let multiple = getMultiple(0)
+    let isLeapPage = false
+    while (multiple < n) {
+        multiple = getMultiple(x)
+        ++x
+        if (multiple === n) {
+            isLeapPage = true
+            break
+        }
+    }
+    return isLeapPage
+}
+
+export const getPageBreakPositions = items => {
+    // add enough page breaks so that each item could
+    // be put on its own page. Due to the react-grid-layout
+    // unit system, we have to estimate roughly the size of each
+    // page. At regular intervals add a unit, like a leap year
+    const yPosList = []
+    let yPos = 0
+    for (let pageNum = 1; pageNum <= items.length; ++pageNum) {
+        if (pageNum === 1) {
+            yPos += 35
+        } else if (isLeapPage(pageNum)) {
+            yPos += 40
+        } else {
+            yPos += 39
+        }
+        yPosList.push(yPos)
+    }
+
+    return yPosList
+}


### PR DESCRIPTION
Fixes in this PR:

- The toolbar in print mode should adapt to screen width
- Fix `print` button position
- Adapt margin for print wrapper in small screens
- Change style for thinner divider
- Items should still use the full page width

Refactoring:
- PrintDashboard and PrintLayoutDashboard both switched from class to functional component and uses the WindowDimensions hook
- Functions in PrintLayoutDashboard moved to separate module


**Spec:**
![image](https://user-images.githubusercontent.com/29384664/105364069-b994f300-5bca-11eb-96eb-8d837b30ca45.png)

**Fixed: small screen**:
<img src="https://user-images.githubusercontent.com/6113918/105674520-ea856880-5ee7-11eb-867d-7318a3bf366b.png" width="350px" />



**Wide screen**
![image](https://user-images.githubusercontent.com/6113918/105674563-fbce7500-5ee7-11eb-8dc8-380b333cb01f.png)



**Small screen - items still use the A4 Landscape width**
<img src="https://user-images.githubusercontent.com/6113918/105674791-4f40c300-5ee8-11eb-9d7a-fd08fe03376a.png" width="400px" />
