### PR TITLE
fix: trigger event to hide tooltip when click wasn't on button

### DIFF
--- a/src/components/ControlBar/ShowMoreButton.js
+++ b/src/components/ControlBar/ShowMoreButton.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import PropTypes from 'prop-types'
 import i18n from '@dhis2/d2-i18n'
 import { Tooltip } from '@dhis2/ui'
@@ -9,25 +9,48 @@ import classes from './styles/ShowMoreButton.module.css'
 export const SHOWMORE_BAR_HEIGHT = 16
 
 const ShowMoreButton = ({ onClick, isMaxHeight, disabled }) => {
+    const containerRef = useRef(null)
     const buttonLabel = isMaxHeight
         ? i18n.t('Show fewer dashboards')
         : i18n.t('Show more dashboards')
+
+    const onButtonClicked = () => {
+        // The click may happen on the svg or path
+        // element of the button icon.
+        // In that case it is necessary to trigger
+        // the mouseout on the button element
+        // to ensure that the tooltip is removed
+        const buttonEl = containerRef.current.children[0]
+        const event = new MouseEvent('mouseout', {
+            bubbles: true,
+            cancelable: false,
+        })
+
+        onClick()
+        buttonEl.dispatchEvent(event)
+    }
+
     return (
-        <div className={classes.container}>
+        <div className={classes.container} ref={containerRef}>
             {disabled ? (
                 <div className={classes.disabled}>
                     <ChevronDown />
                 </div>
             ) : (
                 <Tooltip content={buttonLabel} placement="bottom">
-                    <button
-                        className={classes.showMore}
-                        onClick={onClick}
-                        data-test="showmore-button"
-                        aria-label={buttonLabel}
-                    >
-                        {isMaxHeight ? <ChevronUp /> : <ChevronDown />}
-                    </button>
+                    {({ onMouseOver, onMouseOut, ref }) => (
+                        <button
+                            className={classes.showMore}
+                            onClick={onButtonClicked}
+                            data-test="showmore-button"
+                            aria-label={buttonLabel}
+                            ref={ref}
+                            onMouseOver={onMouseOver}
+                            onMouseOut={onMouseOut}
+                        >
+                            {isMaxHeight ? <ChevronUp /> : <ChevronDown />}
+                        </button>
+                    )}
                 </Tooltip>
             )}
         </div>

--- a/src/components/ControlBar/__tests__/__snapshots__/DashboardsBar.spec.js.snap
+++ b/src/components/ControlBar/__tests__/__snapshots__/DashboardsBar.spec.js.snap
@@ -118,28 +118,23 @@ exports[`clicking "Show more" maximizes dashboards bar height 1`] = `
       <div
         class="container"
       >
-        <span
-          class="jsx-611321200"
-          data-test="dhis2-uicore-tooltip-reference"
+        <button
+          aria-label="Show fewer dashboards"
+          class="showMore"
+          data-test="showmore-button"
         >
-          <button
-            aria-label="Show fewer dashboards"
-            class="showMore"
-            data-test="showmore-button"
+          <svg
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="m11.2928932 8.29289322c.360484-.36048396.927715-.3882135 1.3200062-.08318861l.0942074.08318861 5 4.99999998c.3905243.3905243.3905243 1.0236893 0 1.4142136-.360484.3604839-.927715.3882135-1.3200062.0831886l-.0942074-.0831886-4.2928932-4.2921068-4.29289322 4.2921068c-.36048396.3604839-.92771502.3882135-1.32000622.0831886l-.09420734-.0831886c-.36048396-.360484-.3882135-.927715-.08318861-1.3200062l.08318861-.0942074z"
-                fill="#a0adba"
-              />
-            </svg>
-          </button>
-        </span>
+            <path
+              d="m11.2928932 8.29289322c.360484-.36048396.927715-.3882135 1.3200062-.08318861l.0942074.08318861 5 4.99999998c.3905243.3905243.3905243 1.0236893 0 1.4142136-.360484.3604839-.927715.3882135-1.3200062.0831886l-.0942074-.0831886-4.2928932-4.2921068-4.29289322 4.2921068c-.36048396.3604839-.92771502.3882135-1.32000622.0831886l-.09420734-.0831886c-.36048396-.360484-.3882135-.927715-.08318861-1.3200062l.08318861-.0942074z"
+              fill="#a0adba"
+            />
+          </svg>
+        </button>
       </div>
     </div>
     <div
@@ -421,28 +416,23 @@ exports[`renders a DashboardsBar with minimum height 1`] = `
       <div
         class="container"
       >
-        <span
-          class="jsx-611321200"
-          data-test="dhis2-uicore-tooltip-reference"
+        <button
+          aria-label="Show more dashboards"
+          class="showMore"
+          data-test="showmore-button"
         >
-          <button
-            aria-label="Show more dashboards"
-            class="showMore"
-            data-test="showmore-button"
+          <svg
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="m11.29289 15.7071c.39053.3905 1.02369.3905 1.41422 0l4.99999-4.99999c.3905-.39053.3905-1.02369 0-1.41422-.3905-.39052-1.0237-.39052-1.4142 0l-4.2929 4.2929-4.29289-4.2929c-.39053-.39052-1.02369-.39052-1.41422 0-.39052.39053-.39052 1.02369 0 1.41422z"
-                fill="#a0adba"
-              />
-            </svg>
-          </button>
-        </span>
+            <path
+              d="m11.29289 15.7071c.39053.3905 1.02369.3905 1.41422 0l4.99999-4.99999c.3905-.39053.3905-1.02369 0-1.41422-.3905-.39052-1.0237-.39052-1.4142 0l-4.2929 4.2929-4.29289-4.2929c-.39053-.39052-1.02369-.39052-1.41422 0-.39052.39053-.39052 1.02369 0 1.41422z"
+              fill="#a0adba"
+            />
+          </svg>
+        </button>
       </div>
     </div>
     <div
@@ -522,28 +512,23 @@ exports[`renders a DashboardsBar with no items 1`] = `
       <div
         class="container"
       >
-        <span
-          class="jsx-611321200"
-          data-test="dhis2-uicore-tooltip-reference"
+        <button
+          aria-label="Show more dashboards"
+          class="showMore"
+          data-test="showmore-button"
         >
-          <button
-            aria-label="Show more dashboards"
-            class="showMore"
-            data-test="showmore-button"
+          <svg
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="m11.29289 15.7071c.39053.3905 1.02369.3905 1.41422 0l4.99999-4.99999c.3905-.39053.3905-1.02369 0-1.41422-.3905-.39052-1.0237-.39052-1.4142 0l-4.2929 4.2929-4.29289-4.2929c-.39053-.39052-1.02369-.39052-1.41422 0-.39052.39053-.39052 1.02369 0 1.41422z"
-                fill="#a0adba"
-              />
-            </svg>
-          </button>
-        </span>
+            <path
+              d="m11.29289 15.7071c.39053.3905 1.02369.3905 1.41422 0l4.99999-4.99999c.3905-.39053.3905-1.02369 0-1.41422-.3905-.39052-1.0237-.39052-1.4142 0l-4.2929 4.2929-4.29289-4.2929c-.39053-.39052-1.02369-.39052-1.41422 0-.39052.39053-.39052 1.02369 0 1.41422z"
+              fill="#a0adba"
+            />
+          </svg>
+        </button>
       </div>
     </div>
     <div
@@ -677,28 +662,23 @@ exports[`renders a DashboardsBar with selected item 1`] = `
       <div
         class="container"
       >
-        <span
-          class="jsx-611321200"
-          data-test="dhis2-uicore-tooltip-reference"
+        <button
+          aria-label="Show more dashboards"
+          class="showMore"
+          data-test="showmore-button"
         >
-          <button
-            aria-label="Show more dashboards"
-            class="showMore"
-            data-test="showmore-button"
+          <svg
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="m11.29289 15.7071c.39053.3905 1.02369.3905 1.41422 0l4.99999-4.99999c.3905-.39053.3905-1.02369 0-1.41422-.3905-.39052-1.0237-.39052-1.4142 0l-4.2929 4.2929-4.29289-4.2929c-.39053-.39052-1.02369-.39052-1.41422 0-.39052.39053-.39052 1.02369 0 1.41422z"
-                fill="#a0adba"
-              />
-            </svg>
-          </button>
-        </span>
+            <path
+              d="m11.29289 15.7071c.39053.3905 1.02369.3905 1.41422 0l4.99999-4.99999c.3905-.39053.3905-1.02369 0-1.41422-.3905-.39052-1.0237-.39052-1.4142 0l-4.2929 4.2929-4.29289-4.2929c-.39053-.39052-1.02369-.39052-1.41422 0-.39052.39053-.39052 1.02369 0 1.41422z"
+              fill="#a0adba"
+            />
+          </svg>
+        </button>
       </div>
     </div>
     <div

--- a/src/components/ControlBar/__tests__/__snapshots__/ShowMoreButton.spec.js.snap
+++ b/src/components/ControlBar/__tests__/__snapshots__/ShowMoreButton.spec.js.snap
@@ -5,28 +5,23 @@ exports[`ShowMoreButton renders correctly when at maxHeight 1`] = `
   <div
     class="container"
   >
-    <span
-      class="jsx-611321200"
-      data-test="dhis2-uicore-tooltip-reference"
+    <button
+      aria-label="Show fewer dashboards"
+      class="showMore"
+      data-test="showmore-button"
     >
-      <button
-        aria-label="Show fewer dashboards"
-        class="showMore"
-        data-test="showmore-button"
+      <svg
+        height="24"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <svg
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="m11.2928932 8.29289322c.360484-.36048396.927715-.3882135 1.3200062-.08318861l.0942074.08318861 5 4.99999998c.3905243.3905243.3905243 1.0236893 0 1.4142136-.360484.3604839-.927715.3882135-1.3200062.0831886l-.0942074-.0831886-4.2928932-4.2921068-4.29289322 4.2921068c-.36048396.3604839-.92771502.3882135-1.32000622.0831886l-.09420734-.0831886c-.36048396-.360484-.3882135-.927715-.08318861-1.3200062l.08318861-.0942074z"
-            fill="#a0adba"
-          />
-        </svg>
-      </button>
-    </span>
+        <path
+          d="m11.2928932 8.29289322c.360484-.36048396.927715-.3882135 1.3200062-.08318861l.0942074.08318861 5 4.99999998c.3905243.3905243.3905243 1.0236893 0 1.4142136-.360484.3604839-.927715.3882135-1.3200062.0831886l-.0942074-.0831886-4.2928932-4.2921068-4.29289322 4.2921068c-.36048396.3604839-.92771502.3882135-1.32000622.0831886l-.09420734-.0831886c-.36048396-.360484-.3882135-.927715-.08318861-1.3200062l.08318861-.0942074z"
+          fill="#a0adba"
+        />
+      </svg>
+    </button>
   </div>
 </div>
 `;
@@ -36,28 +31,23 @@ exports[`ShowMoreButton renders correctly when not at maxHeight 1`] = `
   <div
     class="container"
   >
-    <span
-      class="jsx-611321200"
-      data-test="dhis2-uicore-tooltip-reference"
+    <button
+      aria-label="Show more dashboards"
+      class="showMore"
+      data-test="showmore-button"
     >
-      <button
-        aria-label="Show more dashboards"
-        class="showMore"
-        data-test="showmore-button"
+      <svg
+        height="24"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <svg
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="m11.29289 15.7071c.39053.3905 1.02369.3905 1.41422 0l4.99999-4.99999c.3905-.39053.3905-1.02369 0-1.41422-.3905-.39052-1.0237-.39052-1.4142 0l-4.2929 4.2929-4.29289-4.2929c-.39053-.39052-1.02369-.39052-1.41422 0-.39052.39053-.39052 1.02369 0 1.41422z"
-            fill="#a0adba"
-          />
-        </svg>
-      </button>
-    </span>
+        <path
+          d="m11.29289 15.7071c.39053.3905 1.02369.3905 1.41422 0l4.99999-4.99999c.3905-.39053.3905-1.02369 0-1.41422-.3905-.39052-1.0237-.39052-1.4142 0l-4.2929 4.2929-4.29289-4.2929c-.39053-.39052-1.02369-.39052-1.41422 0-.39052.39053-.39052 1.02369 0 1.41422z"
+          fill="#a0adba"
+        />
+      </svg>
+    </button>
   </div>
 </div>
 `;


### PR DESCRIPTION
Problem: the tooltip for the Show more button (indicated by Chevron up/down) didn't get removed when clicking on the button. This is because when the control bar expands or collapses, the `mouseout` event didn't get triggered for the tooltip. 