### PR TITLE
feat: Restricting view options of dashboard items (DHIS2-7630)

### DIFF
--- a/src/api/settings.js
+++ b/src/api/settings.js
@@ -15,6 +15,21 @@ const SYSTEM_SETTINGS = [
     'keyGatherAnalyticalObjectStatisticsInDashboardViews',
 ]
 
+const SYSTEM_SETTINGS_REMAPPINGS = {
+    keyDashboardContextMenuItemOpenInRelevantApp: 'openInRelevantApp',
+    keyDashboardContextMenuItemShowInterpretationsAndDetails:
+        'showInterpretationsAndDetails',
+    keyDashboardContextMenuItemSwitchViewType: 'switchViewType',
+    keyDashboardContextMenuItemViewFullscreen: 'fullscreenAllowedInSettings',
+}
+
+export const renameSystemSettings = settings => {
+    return Object.keys(settings).reduce((mapped, key) => {
+        mapped[SYSTEM_SETTINGS_REMAPPINGS[key] || key] = settings[key]
+        return mapped
+    }, {})
+}
+
 const query = {
     resource: 'systemSettings',
     params: { key: SYSTEM_SETTINGS },

--- a/src/api/settings.js
+++ b/src/api/settings.js
@@ -1,9 +1,19 @@
 export const DEFAULT_SETTINGS = {
     displayNameProperty: 'displayName',
+    keyDashboardContextMenuItemOpenInRelevantApp: true,
+    keyDashboardContextMenuItemShowInterpretationsAndDetails: true,
+    keyDashboardContextMenuItemSwitchViewType: true,
+    keyDashboardContextMenuItemViewFullscreen: true,
     keyGatherAnalyticalObjectStatisticsInDashboardViews: false,
 }
 
-const SYSTEM_SETTINGS = ['keyGatherAnalyticalObjectStatisticsInDashboardViews']
+const SYSTEM_SETTINGS = [
+    'keyDashboardContextMenuItemOpenInRelevantApp',
+    'keyDashboardContextMenuItemShowInterpretationsAndDetails',
+    'keyDashboardContextMenuItemSwitchViewType',
+    'keyDashboardContextMenuItemViewFullscreen',
+    'keyGatherAnalyticalObjectStatisticsInDashboardViews',
+]
 
 const query = {
     resource: 'systemSettings',

--- a/src/components/Item/VisualizationItem/ItemHeaderButtons.js
+++ b/src/components/Item/VisualizationItem/ItemHeaderButtons.js
@@ -43,6 +43,12 @@ const ItemHeaderButtons = props => {
     const { item, visualization, onSelectActiveType, activeType } = props
 
     const { settings } = useSystemSettings()
+    const {
+        keyDashboardContextMenuItemOpenInRelevantApp: openInRelevantApp,
+        keyDashboardContextMenuItemShowInterpretationsAndDetails: showInterpretationsAndDetails,
+        keyDashboardContextMenuItemSwitchViewType: switchViewType,
+        keyDashboardContextMenuItemViewFullscreen: fullscreenAllowedInSettings,
+    } = settings
 
     const isTrackerType = isTrackerDomainType(item.type)
 
@@ -80,6 +86,7 @@ const ItemHeaderButtons = props => {
 
     const type = visualization.type || item.type
     const canViewAs =
+        switchViewType &&
         !isSingleValue(type) &&
         !isYearOverYear(type) &&
         type !== VIS_TYPE_GAUGE &&
@@ -121,13 +128,12 @@ const ItemHeaderButtons = props => {
     const buttonRef = createRef()
 
     const fullscreenAllowed =
-        props.fullscreenSupported &&
-        settings.keyDashboardContextMenuItemViewFullscreen
+        props.fullscreenSupported && fullscreenAllowedInSettings
 
     if (
-        !settings.keyDashboardContextMenuItemOpenInRelevantApp &&
-        !settings.keyDashboardContextMenuItemShowInterpretationsAndDetails &&
-        !settings.keyDashboardContextMenuItemSwitchViewType &&
+        !openInRelevantApp &&
+        !showInterpretationsAndDetails &&
+        !switchViewType &&
         !fullscreenAllowed
     ) {
         return null
@@ -156,16 +162,15 @@ const ItemHeaderButtons = props => {
                     onClickOutside={closeMenu}
                 >
                     <Menu>
-                        {canViewAs &&
-                            settings.keyDashboardContextMenuItemSwitchViewType && (
-                                <>
-                                    <ViewAsMenuItems />
-                                    {(settings.keyDashboardContextMenuItemShowInterpretationsAndDetails ||
-                                        settings.keyDashboardContextMenuItemOpenInRelevantApp ||
-                                        fullscreenAllowed) && <Divider />}
-                                </>
-                            )}
-                        {settings.keyDashboardContextMenuItemOpenInRelevantApp && (
+                        {canViewAs && (
+                            <>
+                                <ViewAsMenuItems />
+                                {(showInterpretationsAndDetails ||
+                                    openInRelevantApp ||
+                                    fullscreenAllowed) && <Divider />}
+                            </>
+                        )}
+                        {openInRelevantApp && (
                             <MenuItem
                                 dense
                                 icon={
@@ -178,7 +183,7 @@ const ItemHeaderButtons = props => {
                                 target="_blank"
                             />
                         )}
-                        {settings.keyDashboardContextMenuItemShowInterpretationsAndDetails && (
+                        {showInterpretationsAndDetails && (
                             <MenuItem
                                 dense
                                 icon={<SpeechBubble />}

--- a/src/components/Item/VisualizationItem/ItemHeaderButtons.js
+++ b/src/components/Item/VisualizationItem/ItemHeaderButtons.js
@@ -31,6 +31,7 @@ import {
     hasMapView,
     getAppName,
 } from '../../../modules/itemTypes'
+import { useSystemSettings } from '../../SystemSettingsProvider'
 
 const iconFill = { fill: colors.grey600 }
 
@@ -40,6 +41,8 @@ const ItemHeaderButtons = props => {
     const { baseUrl } = useConfig()
 
     const { item, visualization, onSelectActiveType, activeType } = props
+
+    const { settings } = useSystemSettings()
 
     const isTrackerType = isTrackerDomainType(item.type)
 
@@ -117,6 +120,18 @@ const ItemHeaderButtons = props => {
 
     const buttonRef = createRef()
 
+    const fullscreenAllowed =
+        props.fullscreenSupported &&
+        settings.keyDashboardContextMenuItemViewFullscreen
+
+    if (
+        !settings.keyDashboardContextMenuItemOpenInRelevantApp &&
+        !settings.keyDashboardContextMenuItemShowInterpretationsAndDetails &&
+        !settings.keyDashboardContextMenuItemSwitchViewType &&
+        !fullscreenAllowed
+    ) {
+        return null
+    }
     return props.isFullscreen ? (
         <Button small secondary onClick={props.onToggleFullscreen}>
             <ExitFullscreen />
@@ -141,28 +156,37 @@ const ItemHeaderButtons = props => {
                     onClickOutside={closeMenu}
                 >
                     <Menu>
-                        {canViewAs && (
-                            <>
-                                <ViewAsMenuItems />
-                                <Divider />
-                            </>
+                        {canViewAs &&
+                            settings.keyDashboardContextMenuItemSwitchViewType && (
+                                <>
+                                    <ViewAsMenuItems />
+                                    {(settings.keyDashboardContextMenuItemShowInterpretationsAndDetails ||
+                                        settings.keyDashboardContextMenuItemOpenInRelevantApp ||
+                                        fullscreenAllowed) && <Divider />}
+                                </>
+                            )}
+                        {settings.keyDashboardContextMenuItemOpenInRelevantApp && (
+                            <MenuItem
+                                dense
+                                icon={
+                                    <LaunchIcon style={{ fill: '#6e7a8a' }} />
+                                }
+                                label={i18n.t('Open in {{appName}} app', {
+                                    appName: getAppName(item.type),
+                                })}
+                                href={getLink(item, baseUrl)}
+                                target="_blank"
+                            />
                         )}
-                        <MenuItem
-                            dense
-                            icon={<LaunchIcon style={{ fill: '#6e7a8a' }} />}
-                            label={i18n.t('Open in {{appName}} app', {
-                                appName: getAppName(item.type),
-                            })}
-                            href={getLink(item, baseUrl)}
-                            target="_blank"
-                        />
-                        <MenuItem
-                            dense
-                            icon={<SpeechBubble />}
-                            label={interpretationMenuLabel}
-                            onClick={handleInterpretationClick}
-                        />
-                        {props.fullscreenSupported && (
+                        {settings.keyDashboardContextMenuItemShowInterpretationsAndDetails && (
+                            <MenuItem
+                                dense
+                                icon={<SpeechBubble />}
+                                label={interpretationMenuLabel}
+                                onClick={handleInterpretationClick}
+                            />
+                        )}
+                        {fullscreenAllowed && (
                             <MenuItem
                                 dense
                                 icon={<Fullscreen />}

--- a/src/components/Item/VisualizationItem/ItemHeaderButtons.js
+++ b/src/components/Item/VisualizationItem/ItemHeaderButtons.js
@@ -36,7 +36,7 @@ import { useSystemSettings } from '../../SystemSettingsProvider'
 const iconFill = { fill: colors.grey600 }
 
 const ItemHeaderButtons = props => {
-    const [menuIsOpen, setMenuIsOpen] = useState(null)
+    const [menuIsOpen, setMenuIsOpen] = useState(props.isOpen)
 
     const { baseUrl } = useConfig()
 
@@ -211,6 +211,7 @@ ItemHeaderButtons.propTypes = {
     activeType: PropTypes.string,
     fullscreenSupported: PropTypes.bool,
     isFullscreen: PropTypes.bool,
+    isOpen: PropTypes.bool,
     item: PropTypes.object,
     visualization: PropTypes.object,
     onSelectActiveType: PropTypes.func,

--- a/src/components/Item/VisualizationItem/ItemHeaderButtons.js
+++ b/src/components/Item/VisualizationItem/ItemHeaderButtons.js
@@ -42,13 +42,12 @@ const ItemHeaderButtons = props => {
 
     const { item, visualization, onSelectActiveType, activeType } = props
 
-    const { settings } = useSystemSettings()
     const {
-        keyDashboardContextMenuItemOpenInRelevantApp: openInRelevantApp,
-        keyDashboardContextMenuItemShowInterpretationsAndDetails: showInterpretationsAndDetails,
-        keyDashboardContextMenuItemSwitchViewType: switchViewType,
-        keyDashboardContextMenuItemViewFullscreen: fullscreenAllowedInSettings,
-    } = settings
+        openInRelevantApp,
+        showInterpretationsAndDetails,
+        switchViewType,
+        fullscreenAllowedInSettings,
+    } = useSystemSettings().settings
 
     const isTrackerType = isTrackerDomainType(item.type)
 

--- a/src/components/Item/VisualizationItem/__tests__/ItemHeaderButtons.spec.js
+++ b/src/components/Item/VisualizationItem/__tests__/ItemHeaderButtons.spec.js
@@ -250,3 +250,36 @@ it('does not let you open interpretations and details if settings do not allow',
             .exists()
     ).toBeFalsy()
 })
+
+it('does not render buttons if all relevant settings are false', () => {
+    const mockSystemSettings = {
+        settings: {
+            openInRelevantApp: false,
+            showInterpretationsAndDetails: false,
+            switchViewType: false,
+            fullscreenAllowedInSettings: false,
+        },
+    }
+
+    useSystemSettings.mockImplementationOnce(() => mockSystemSettings)
+    const buttons = shallow(
+        <ItemHeaderButtons
+            item={{
+                type: 'CHART',
+                chart: { type: 'NOT_YOY', domainType: 'AGGREGATE' },
+            }}
+            visualization={{
+                type: 'SINGLE_VALUE',
+            }}
+            onSelectActiveType={Function.prototype}
+            activeFooter={false}
+            activeType={'CHART'}
+            d2={{}}
+            onToggleFooter={Function.prototype}
+            isFullscreen={false}
+            fullscreenSupported={true}
+            isOpen={true}
+        />
+    )
+    expect(toJson(buttons)).toBeFalsy()
+})

--- a/src/components/Item/VisualizationItem/__tests__/ItemHeaderButtons.spec.js
+++ b/src/components/Item/VisualizationItem/__tests__/ItemHeaderButtons.spec.js
@@ -2,26 +2,37 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import toJson from 'enzyme-to-json'
 import ItemHeaderButtons from '../ItemHeaderButtons'
+import { useSystemSettings } from '../../../SystemSettingsProvider'
 
 jest.mock('../Visualization/plugin', () => ({
     getLink: () => 'http://rainbowdash',
     pluginIsAvailable: () => true,
 }))
 
-jest.mock('../../../SystemSettingsProvider', () => ({
-    useSystemSettings: () => {
-        return {
-            settings: {
-                keyDashboardContextMenuItemOpenInRelevantApp: true,
-                keyDashboardContextMenuItemShowInterpretationsAndDetails: true,
-                keyDashboardContextMenuItemSwitchViewType: true,
-                keyDashboardContextMenuItemViewFullscreen: true,
-            },
-        }
+jest.mock('@dhis2/analytics', () => ({
+    isSingleValue: () => {
+        return false
+    },
+    isYearOverYear: () => {
+        return false
     },
 }))
 
+jest.mock('../../../SystemSettingsProvider', () => ({
+    useSystemSettings: jest.fn(),
+}))
+
+const mockSystemSettingsDefault = {
+    settings: {
+        keyDashboardContextMenuItemOpenInRelevantApp: true,
+        keyDashboardContextMenuItemShowInterpretationsAndDetails: true,
+        keyDashboardContextMenuItemSwitchViewType: true,
+        keyDashboardContextMenuItemViewFullscreen: true,
+    },
+}
+
 it('renders correctly when not fullscreen', () => {
+    useSystemSettings.mockImplementationOnce(() => mockSystemSettingsDefault)
     const buttons = shallow(
         <ItemHeaderButtons
             item={{
@@ -42,6 +53,7 @@ it('renders correctly when not fullscreen', () => {
 })
 
 it('renders correctly when fullscreen', () => {
+    useSystemSettings.mockImplementationOnce(() => mockSystemSettingsDefault)
     const buttons = shallow(
         <ItemHeaderButtons
             item={{
@@ -60,4 +72,181 @@ it('renders correctly when fullscreen', () => {
         />
     )
     expect(toJson(buttons)).toMatchSnapshot()
+})
+
+it('renders Menu Items when open', () => {
+    useSystemSettings.mockImplementationOnce(() => mockSystemSettingsDefault)
+    const container = shallow(
+        <ItemHeaderButtons
+            item={{
+                type: 'CHART',
+                chart: { type: 'NOT_YOY', domainType: 'AGGREGATE' },
+            }}
+            visualization={{
+                type: 'SINGLE_VALUE',
+            }}
+            onSelectActiveType={Function.prototype}
+            activeFooter={false}
+            activeType={'CHART'}
+            d2={{}}
+            onToggleFooter={Function.prototype}
+            isFullscreen={false}
+            fullscreenSupported={true}
+            isOpen={true}
+        />
+    )
+
+    expect(toJson(container)).toMatchSnapshot()
+})
+
+it('does not render ViewAsMenuItems Items if settings do not allow', () => {
+    const mockSystemSettings = { settings: {} }
+    mockSystemSettings.settings = Object.assign(
+        {},
+        mockSystemSettingsDefault.settings,
+        {
+            keyDashboardContextMenuItemSwitchViewType: false,
+        }
+    )
+    useSystemSettings.mockImplementationOnce(() => mockSystemSettings)
+    const container = shallow(
+        <ItemHeaderButtons
+            item={{
+                type: 'CHART',
+                chart: { type: 'NOT_YOY', domainType: 'AGGREGATE' },
+            }}
+            visualization={{
+                type: 'SINGLE_VALUE',
+            }}
+            onSelectActiveType={Function.prototype}
+            activeFooter={false}
+            activeType={'CHART'}
+            d2={{}}
+            onToggleFooter={Function.prototype}
+            isFullscreen={false}
+            fullscreenSupported={true}
+            isOpen={true}
+        />
+    )
+    expect(container.find('ViewAsMenuItems').exists()).toBeFalsy()
+})
+
+it('does not let you open in relevant app if settings do not allow', () => {
+    const mockSystemSettings = { settings: {} }
+    mockSystemSettings.settings = Object.assign(
+        {},
+        mockSystemSettingsDefault.settings,
+        {
+            keyDashboardContextMenuItemOpenInRelevantApp: false,
+        }
+    )
+    useSystemSettings.mockImplementationOnce(() => mockSystemSettings)
+    const container = shallow(
+        <ItemHeaderButtons
+            item={{
+                type: 'CHART',
+                chart: { type: 'NOT_YOY', domainType: 'AGGREGATE' },
+            }}
+            visualization={{
+                type: 'SINGLE_VALUE',
+            }}
+            onSelectActiveType={Function.prototype}
+            activeFooter={false}
+            activeType={'CHART'}
+            d2={{}}
+            onToggleFooter={Function.prototype}
+            isFullscreen={false}
+            fullscreenSupported={true}
+            isOpen={true}
+        />
+    )
+    expect(
+        container
+            .findWhere(
+                n =>
+                    n.name() === 'MenuItem' &&
+                    n.prop('label') === 'Open in Data Visualizer app'
+            )
+            .exists()
+    ).toBeFalsy()
+})
+
+it('does not let you open in fullscreen if settings do not allow', () => {
+    const mockSystemSettings = { settings: {} }
+    mockSystemSettings.settings = Object.assign(
+        {},
+        mockSystemSettingsDefault.settings,
+        {
+            keyDashboardContextMenuItemViewFullscreen: false,
+        }
+    )
+    useSystemSettings.mockImplementationOnce(() => mockSystemSettings)
+    const container = shallow(
+        <ItemHeaderButtons
+            item={{
+                type: 'CHART',
+                chart: { type: 'NOT_YOY', domainType: 'AGGREGATE' },
+            }}
+            visualization={{
+                type: 'SINGLE_VALUE',
+            }}
+            onSelectActiveType={Function.prototype}
+            activeFooter={false}
+            activeType={'CHART'}
+            d2={{}}
+            onToggleFooter={Function.prototype}
+            isFullscreen={false}
+            fullscreenSupported={true}
+            isOpen={true}
+        />
+    )
+    expect(
+        container
+            .findWhere(
+                n =>
+                    n.name() === 'MenuItem' &&
+                    n.prop('label') === 'View fullscreen'
+            )
+            .exists()
+    ).toBeFalsy()
+})
+
+it('does not let you open interpretations and details if settings do not allow', () => {
+    const mockSystemSettings = { settings: {} }
+    mockSystemSettings.settings = Object.assign(
+        {},
+        mockSystemSettingsDefault.settings,
+        {
+            keyDashboardContextMenuItemShowInterpretationsAndDetails: false,
+        }
+    )
+    useSystemSettings.mockImplementationOnce(() => mockSystemSettings)
+    const container = shallow(
+        <ItemHeaderButtons
+            item={{
+                type: 'CHART',
+                chart: { type: 'NOT_YOY', domainType: 'AGGREGATE' },
+            }}
+            visualization={{
+                type: 'SINGLE_VALUE',
+            }}
+            onSelectActiveType={Function.prototype}
+            activeFooter={false}
+            activeType={'CHART'}
+            d2={{}}
+            onToggleFooter={Function.prototype}
+            isFullscreen={false}
+            fullscreenSupported={true}
+            isOpen={true}
+        />
+    )
+    expect(
+        container
+            .findWhere(
+                n =>
+                    n.name() === 'MenuItem' &&
+                    n.prop('label') === 'Show interpretations and details'
+            )
+            .exists()
+    ).toBeFalsy()
 })

--- a/src/components/Item/VisualizationItem/__tests__/ItemHeaderButtons.spec.js
+++ b/src/components/Item/VisualizationItem/__tests__/ItemHeaderButtons.spec.js
@@ -24,10 +24,10 @@ jest.mock('../../../SystemSettingsProvider', () => ({
 
 const mockSystemSettingsDefault = {
     settings: {
-        keyDashboardContextMenuItemOpenInRelevantApp: true,
-        keyDashboardContextMenuItemShowInterpretationsAndDetails: true,
-        keyDashboardContextMenuItemSwitchViewType: true,
-        keyDashboardContextMenuItemViewFullscreen: true,
+        openInRelevantApp: true,
+        showInterpretationsAndDetails: true,
+        switchViewType: true,
+        fullscreenAllowedInSettings: true,
     },
 }
 
@@ -105,7 +105,7 @@ it('does not render ViewAsMenuItems Items if settings do not allow', () => {
         {},
         mockSystemSettingsDefault.settings,
         {
-            keyDashboardContextMenuItemSwitchViewType: false,
+            switchViewType: false,
         }
     )
     useSystemSettings.mockImplementationOnce(() => mockSystemSettings)
@@ -137,7 +137,7 @@ it('does not let you open in relevant app if settings do not allow', () => {
         {},
         mockSystemSettingsDefault.settings,
         {
-            keyDashboardContextMenuItemOpenInRelevantApp: false,
+            openInRelevantApp: false,
         }
     )
     useSystemSettings.mockImplementationOnce(() => mockSystemSettings)
@@ -177,7 +177,7 @@ it('does not let you open in fullscreen if settings do not allow', () => {
         {},
         mockSystemSettingsDefault.settings,
         {
-            keyDashboardContextMenuItemViewFullscreen: false,
+            fullscreenAllowedInSettings: false,
         }
     )
     useSystemSettings.mockImplementationOnce(() => mockSystemSettings)
@@ -217,7 +217,7 @@ it('does not let you open interpretations and details if settings do not allow',
         {},
         mockSystemSettingsDefault.settings,
         {
-            keyDashboardContextMenuItemShowInterpretationsAndDetails: false,
+            showInterpretationsAndDetails: false,
         }
     )
     useSystemSettings.mockImplementationOnce(() => mockSystemSettings)

--- a/src/components/Item/VisualizationItem/__tests__/ItemHeaderButtons.spec.js
+++ b/src/components/Item/VisualizationItem/__tests__/ItemHeaderButtons.spec.js
@@ -8,6 +8,19 @@ jest.mock('../Visualization/plugin', () => ({
     pluginIsAvailable: () => true,
 }))
 
+jest.mock('../../../SystemSettingsProvider', () => ({
+    useSystemSettings: () => {
+        return {
+            settings: {
+                keyDashboardContextMenuItemOpenInRelevantApp: true,
+                keyDashboardContextMenuItemShowInterpretationsAndDetails: true,
+                keyDashboardContextMenuItemSwitchViewType: true,
+                keyDashboardContextMenuItemViewFullscreen: true,
+            },
+        }
+    },
+}))
+
 it('renders correctly when not fullscreen', () => {
     const buttons = shallow(
         <ItemHeaderButtons

--- a/src/components/Item/VisualizationItem/__tests__/__snapshots__/ItemHeaderButtons.spec.js.snap
+++ b/src/components/Item/VisualizationItem/__tests__/__snapshots__/ItemHeaderButtons.spec.js.snap
@@ -1,5 +1,74 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders Menu Items when open 1`] = `
+<Fragment>
+  <div>
+    <Button
+      dataTest="dashboarditem-menu-button"
+      onClick={[Function]}
+      secondary={true}
+      small={true}
+      type="button"
+    >
+      <ThreeDots />
+    </Button>
+  </div>
+  <Popover
+    arrow={false}
+    dataTest="dhis2-uicore-popover"
+    elevation="0 0 1px 0 rgba(64,75,90,0.29), 0 3px 8px -2px rgba(64,75,90,0.30)"
+    maxWidth={360}
+    onClickOutside={[Function]}
+    placement="auto-start"
+    reference={
+      Object {
+        "current": null,
+      }
+    }
+  >
+    <Menu
+      dataTest="dhis2-uicore-menulist"
+    >
+      <ViewAsMenuItems />
+      <Divider
+        dataTest="dhis2-uicore-divider"
+        margin="8px 0"
+      />
+      <MenuItem
+        dataTest="dhis2-uicore-menuitem"
+        dense={true}
+        href="http://rainbowdash"
+        icon={
+          <UNDEFINED
+            style={
+              Object {
+                "fill": "#6e7a8a",
+              }
+            }
+          />
+        }
+        label="Open in Data Visualizer app"
+        target="_blank"
+      />
+      <MenuItem
+        dataTest="dhis2-uicore-menuitem"
+        dense={true}
+        icon={<SpeechBubble />}
+        label="Show interpretations and details"
+        onClick={[Function]}
+      />
+      <MenuItem
+        dataTest="dhis2-uicore-menuitem"
+        dense={true}
+        icon={<Fullscreen />}
+        label="View fullscreen"
+        onClick={[Function]}
+      />
+    </Menu>
+  </Popover>
+</Fragment>
+`;
+
 exports[`renders correctly when fullscreen 1`] = `
 <Button
   dataTest="dhis2-uicore-button"

--- a/src/components/SystemSettingsProvider.js
+++ b/src/components/SystemSettingsProvider.js
@@ -1,7 +1,10 @@
 import React, { useContext, useState, useEffect, createContext } from 'react'
 import PropTypes from 'prop-types'
 import { useDataEngine } from '@dhis2/app-runtime'
-import settingsQuery, { DEFAULT_SETTINGS } from '../api/settings'
+import settingsQuery, {
+    renameSystemSettings,
+    DEFAULT_SETTINGS,
+} from '../api/settings'
 
 export const SystemSettingsCtx = createContext({})
 
@@ -15,7 +18,13 @@ const SystemSettingsProvider = ({ children }) => {
                 systemSettings: settingsQuery,
             })
 
-            setSettings(Object.assign({}, DEFAULT_SETTINGS, systemSettings))
+            setSettings(
+                Object.assign(
+                    {},
+                    renameSystemSettings(DEFAULT_SETTINGS),
+                    renameSystemSettings(systemSettings)
+                )
+            )
         }
         fetchData()
     }, [])


### PR DESCRIPTION
This pull request implements PEFPAR's suggestion for restricting view options from within dashboard items (https://jira.dhis2.org/browse/DHIS2-7630) using newly added system settings.

![visualTypeConstraintsDemo](https://user-images.githubusercontent.com/18490902/105974891-a41e3e00-608e-11eb-91dc-9f561a7eae9a.gif)
