### PR TITLE
feat: responsive - redirect to view when url of /edit or /new manually entered [DHIS2-10138]

### DIFF
--- a/cypress/integration/ui/responsive_dashboard.feature
+++ b/cypress/integration/ui/responsive_dashboard.feature
@@ -30,3 +30,18 @@ Feature: Small screen dashboard
         When I restore the wide screen
         Then the wide screen edit view is shown
         And my changes are still there
+
+    @nonutating
+    Scenario: I change the url to new while in small screen
+        Given I open the "Delivery" dashboard
+        When I go to small screen
+        And I change url to new
+        Then the "Delivery" dashboard displays in default view mode
+
+
+    @nonutating
+    Scenario: I change the url to edit while in small screen
+        Given I open the "Delivery" dashboard
+        When I go to small screen
+        And I change url to edit
+        Then the "Delivery" dashboard displays in view mode

--- a/cypress/integration/ui/responsive_dashboard/responsive_dashboard.js
+++ b/cypress/integration/ui/responsive_dashboard/responsive_dashboard.js
@@ -1,4 +1,7 @@
 import { When, Then } from 'cypress-cucumber-preprocessor/steps'
+import { EXTENDED_TIMEOUT } from '../../../support/utils'
+import { chartSel } from '../../../selectors/dashboardItem'
+import { dashboardTitleSel } from '../../../selectors/titleBar'
 
 const TEST_DASHBOARD_TITLE = 'TEST_DASHBOARD_TITLE'
 
@@ -68,5 +71,34 @@ Then('my changes are still there', () => {
         const val = $input.val()
 
         expect(val).to.match(re)
+    })
+})
+
+// Scenario: I change the url to new while in small screen
+When('I change url to new', () => {
+    const url = `${Cypress.config().baseUrl}/#/new`
+    cy.window().then(win => {
+        win.location.assign(url)
+        cy.wait(2000) // eslint-disable-line cypress/no-unnecessary-waiting
+    })
+})
+
+Then('the {string} dashboard displays in default view mode', title => {
+    cy.location().should(loc => {
+        expect(loc.hash).to.equal('#/')
+    })
+
+    cy.get(dashboardTitleSel).should('be.visible').and('contain', title)
+    cy.get(chartSel, EXTENDED_TIMEOUT).should('exist')
+})
+
+// Scenario: I change the url to 'edit' while in small screen
+When('I change url to edit', () => {
+    cy.location().then(loc => {
+        const url = `${loc.href}/edit`
+        cy.window().then(win => {
+            win.location.assign(url)
+            cy.wait(2000) // eslint-disable-line cypress/no-unnecessary-waiting
+        })
     })
 })

--- a/src/components/Dashboard/Dashboard.js
+++ b/src/components/Dashboard/Dashboard.js
@@ -75,6 +75,8 @@ export const Dashboard = ({
         if (isSmallScreen(width) && isEditMode(mode)) {
             const redirectUrl = routeId ? `/${routeId}` : '/'
             setRedirectUrl(redirectUrl)
+        } else {
+            setRedirectUrl(null)
         }
     }, [mode])
 
@@ -95,10 +97,6 @@ export const Dashboard = ({
         }
     }, [])
 
-    if (redirectUrl) {
-        return <Redirect to={redirectUrl} />
-    }
-
     if (!dashboardsLoaded) {
         return (
             <Layer translucent>
@@ -107,6 +105,10 @@ export const Dashboard = ({
                 </CenteredContent>
             </Layer>
         )
+    }
+
+    if (redirectUrl) {
+        return <Redirect to={redirectUrl} />
     }
 
     if (mode === NEW) {

--- a/src/components/Dashboard/Dashboard.js
+++ b/src/components/Dashboard/Dashboard.js
@@ -1,10 +1,11 @@
-import React, { useEffect } from 'react'
+import React, { useState, useEffect } from 'react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import isEmpty from 'lodash/isEmpty'
 import i18n from '@dhis2/d2-i18n'
 import { Layer, CenteredContent, CircularLoader } from '@dhis2/ui'
 import debounce from 'lodash/debounce'
+import { Redirect } from 'react-router-dom'
 
 import DashboardsBar from '../ControlBar/DashboardsBar'
 import NoContentMessage from '../../widgets/NoContentMessage'
@@ -31,7 +32,11 @@ import {
     PRINT,
     PRINT_LAYOUT,
     isPrintMode,
+    isEditMode,
 } from './dashboardModes'
+
+import { useWindowDimensions } from '../WindowDimensionsProvider'
+import isSmallScreen from '../../modules/isSmallScreen'
 
 const setHeaderbarVisibility = mode => {
     const header = document.getElementsByTagName('header')[0]
@@ -59,8 +64,18 @@ export const Dashboard = ({
     selectDashboard,
     setWindowHeight,
 }) => {
+    const { width } = useWindowDimensions()
+    const [redirectUrl, setRedirectUrl] = useState(null)
+
     useEffect(() => {
         setHeaderbarVisibility(mode)
+    }, [mode])
+
+    useEffect(() => {
+        if (isSmallScreen(width) && isEditMode(mode)) {
+            const redirectUrl = routeId ? `/${routeId}` : '/'
+            setRedirectUrl(redirectUrl)
+        }
     }, [mode])
 
     useEffect(() => {
@@ -79,6 +94,10 @@ export const Dashboard = ({
             window.removeEventListener('resize', onResize)
         }
     }, [])
+
+    if (redirectUrl) {
+        return <Redirect to={redirectUrl} />
+    }
 
     if (!dashboardsLoaded) {
         return (

--- a/src/components/Dashboard/__tests__/Dashboard.spec.js
+++ b/src/components/Dashboard/__tests__/Dashboard.spec.js
@@ -1,8 +1,9 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { mount } from 'enzyme'
 import toJson from 'enzyme-to-json'
 
 import { Dashboard } from '../Dashboard'
+import WindowDimensionsProvider from '../../WindowDimensionsProvider'
 import { NEW, VIEW, EDIT, PRINT, PRINT_LAYOUT } from '../dashboardModes'
 import { NON_EXISTING_DASHBOARD_ID } from '../../../reducers/selected'
 
@@ -14,12 +15,33 @@ jest.mock('../NewDashboard', () => 'NewDashboard')
 jest.mock('../PrintDashboard', () => 'PrintDashboard')
 jest.mock('../PrintLayoutDashboard', () => 'PrintLayoutDashboard')
 
+jest.mock('@dhis2/ui', () => {
+    return {
+        Layer: () =>
+            function MockLayer() {
+                return <div className="mock-layer" />
+            },
+        CenteredContent: () =>
+            function MockCenteredContent() {
+                return <div className="mock-centered-content" />
+            },
+        CircularLoader: () =>
+            function CircularLoader() {
+                return <div className="mock-circular-loader" />
+            },
+    }
+})
+
 describe('Dashboard', () => {
     let props
     let shallowDashboard
     const dashboard = () => {
         if (!shallowDashboard) {
-            shallowDashboard = shallow(<Dashboard {...props} />)
+            shallowDashboard = mount(
+                <WindowDimensionsProvider>
+                    <Dashboard {...props} />
+                </WindowDimensionsProvider>
+            )
         }
         return shallowDashboard
     }

--- a/src/components/Dashboard/__tests__/__snapshots__/Dashboard.spec.js.snap
+++ b/src/components/Dashboard/__tests__/__snapshots__/Dashboard.spec.js.snap
@@ -1,81 +1,286 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Dashboard renders EDIT dashboard 1`] = `<EditDashboard />`;
+exports[`Dashboard renders EDIT dashboard 1`] = `
+<WindowDimensionsProvider>
+  <Dashboard
+    dashboardsIsEmpty={false}
+    dashboardsLoaded={true}
+    id="rainbowdash"
+    match={
+      Object {
+        "params": Object {
+          "dashboardId": null,
+        },
+      }
+    }
+    mode="edit"
+    selectDashboard={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            undefined,
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      }
+    }
+  >
+    <EditDashboard />
+  </Dashboard>
+</WindowDimensionsProvider>
+`;
 
-exports[`Dashboard renders NEW dashboard 1`] = `<NewDashboard />`;
+exports[`Dashboard renders NEW dashboard 1`] = `
+<WindowDimensionsProvider>
+  <Dashboard
+    dashboardsIsEmpty={false}
+    dashboardsLoaded={true}
+    id="rainbowdash"
+    match={
+      Object {
+        "params": Object {
+          "dashboardId": null,
+        },
+      }
+    }
+    mode="new"
+    selectDashboard={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            undefined,
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      }
+    }
+  >
+    <NewDashboard />
+  </Dashboard>
+</WindowDimensionsProvider>
+`;
 
-exports[`Dashboard renders PRINT dashboard 1`] = `<PrintDashboard />`;
+exports[`Dashboard renders PRINT dashboard 1`] = `
+<WindowDimensionsProvider>
+  <Dashboard
+    dashboardsIsEmpty={false}
+    dashboardsLoaded={true}
+    id="rainbowdash"
+    match={
+      Object {
+        "params": Object {
+          "dashboardId": null,
+        },
+      }
+    }
+    mode="print"
+    selectDashboard={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            undefined,
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      }
+    }
+  >
+    <PrintDashboard />
+  </Dashboard>
+</WindowDimensionsProvider>
+`;
 
-exports[`Dashboard renders PRINT_LAYOUT dashboard 1`] = `<PrintLayoutDashboard />`;
+exports[`Dashboard renders PRINT_LAYOUT dashboard 1`] = `
+<WindowDimensionsProvider>
+  <Dashboard
+    dashboardsIsEmpty={false}
+    dashboardsLoaded={true}
+    id="rainbowdash"
+    match={
+      Object {
+        "params": Object {
+          "dashboardId": null,
+        },
+      }
+    }
+    mode="print-layout"
+    selectDashboard={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            undefined,
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      }
+    }
+  >
+    <PrintLayoutDashboard />
+  </Dashboard>
+</WindowDimensionsProvider>
+`;
 
 exports[`Dashboard renders correctly when dashboard id is not valid 1`] = `
-<Fragment>
-  <DashboardsBar />
-  <NoContentMessage
-    text="Requested dashboard not found"
-  />
-</Fragment>
+<WindowDimensionsProvider>
+  <Dashboard
+    dashboardsIsEmpty={false}
+    dashboardsLoaded={true}
+    id="0"
+    match={
+      Object {
+        "params": Object {
+          "dashboardId": null,
+        },
+      }
+    }
+    mode="view"
+    selectDashboard={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            undefined,
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      }
+    }
+  >
+    <DashboardsBar />
+    <NoContentMessage
+      text="Requested dashboard not found"
+    />
+  </Dashboard>
+</WindowDimensionsProvider>
 `;
 
 exports[`Dashboard renders correctly when dashboards loaded and id is null 1`] = `
-<Layer
-  dataTest="dhis2-uicore-layer"
-  level={2000}
-  position="fixed"
-  translucent={true}
->
-  <CenteredContent
-    dataTest="dhis2-uicore-centeredcontent"
-    position="middle"
+<WindowDimensionsProvider>
+  <Dashboard
+    dashboardsIsEmpty={false}
+    dashboardsLoaded={true}
+    id={null}
+    match={
+      Object {
+        "params": Object {
+          "dashboardId": null,
+        },
+      }
+    }
+    mode="view"
+    selectDashboard={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            undefined,
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      }
+    }
   >
-    <CircularLoader
-      dataTest="dhis2-uicore-circularloader"
+    <Layer
+      translucent={true}
     />
-  </CenteredContent>
-</Layer>
+  </Dashboard>
+</WindowDimensionsProvider>
 `;
 
 exports[`Dashboard renders correctly when dashboards not loaded and id is not null 1`] = `
-<Layer
-  dataTest="dhis2-uicore-layer"
-  level={2000}
-  position="fixed"
-  translucent={true}
->
-  <CenteredContent
-    dataTest="dhis2-uicore-centeredcontent"
-    position="middle"
+<WindowDimensionsProvider>
+  <Dashboard
+    dashboardsIsEmpty={false}
+    dashboardsLoaded={false}
+    id="rainbowdash"
+    match={
+      Object {
+        "params": Object {
+          "dashboardId": null,
+        },
+      }
+    }
+    mode="view"
+    selectDashboard={[MockFunction]}
   >
-    <CircularLoader
-      dataTest="dhis2-uicore-circularloader"
+    <Layer
+      translucent={true}
     />
-  </CenteredContent>
-</Layer>
+  </Dashboard>
+</WindowDimensionsProvider>
 `;
 
 exports[`Dashboard renders correctly when dashboards not loaded and id is null 1`] = `
-<Layer
-  dataTest="dhis2-uicore-layer"
-  level={2000}
-  position="fixed"
-  translucent={true}
->
-  <CenteredContent
-    dataTest="dhis2-uicore-centeredcontent"
-    position="middle"
+<WindowDimensionsProvider>
+  <Dashboard
+    dashboardsIsEmpty={false}
+    dashboardsLoaded={false}
+    id={null}
+    match={
+      Object {
+        "params": Object {
+          "dashboardId": null,
+        },
+      }
+    }
+    mode="view"
+    selectDashboard={[MockFunction]}
   >
-    <CircularLoader
-      dataTest="dhis2-uicore-circularloader"
+    <Layer
+      translucent={true}
     />
-  </CenteredContent>
-</Layer>
+  </Dashboard>
+</WindowDimensionsProvider>
 `;
 
 exports[`Dashboard renders correctly when no dashboards found 1`] = `
-<Fragment>
-  <DashboardsBar />
-  <NoContentMessage
-    text="No dashboards found. Use the + button to create a new dashboard."
-  />
-</Fragment>
+<WindowDimensionsProvider>
+  <Dashboard
+    dashboardsIsEmpty={true}
+    dashboardsLoaded={true}
+    id="rainbowdash"
+    match={
+      Object {
+        "params": Object {
+          "dashboardId": null,
+        },
+      }
+    }
+    mode="view"
+    selectDashboard={[MockFunction]}
+  >
+    <DashboardsBar />
+    <NoContentMessage
+      text="No dashboards found. Use the + button to create a new dashboard."
+    />
+  </Dashboard>
+</WindowDimensionsProvider>
 `;


### PR DESCRIPTION
If the app is displayed in small screen, then edit and new are not supported. If the user manually enters the /edit or /new route, then the app will redirect back to the view mode of the same dashboard that was being viewed.

Note that if the user was already in /edit or /new, and then changed the screen to <=480px, then they won't get redirected, but a message will be displayed about not being able to edit in small screen.