### PR TITLE
fix: fullscreen param to map plugin resize

### DIFF
--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -121,7 +121,7 @@ export class Item extends Component {
                 )
             }
             // call resize on Map item
-            pluginResize(this.props.item)
+            pluginResize(this.props.item, this.state.isFullscreen)
         }
     }
 
@@ -131,11 +131,14 @@ export class Item extends Component {
     }
 
     handleFullscreenChange = () => {
-        this.setState({
-            isFullscreen:
-                !!document.fullscreenElement ||
-                !!document.webkitFullscreenElement,
-        })
+        this.setState(
+            {
+                isFullscreen:
+                    !!document.fullscreenElement ||
+                    !!document.webkitFullscreenElement,
+            },
+            () => pluginResize(this.props.item, this.state.isFullscreen)
+        )
     }
 
     onToggleFullscreen = () => {

--- a/src/components/Item/VisualizationItem/Visualization/plugin.js
+++ b/src/components/Item/VisualizationItem/Visualization/plugin.js
@@ -65,11 +65,11 @@ export const load = async (
     loadPlugin(plugin, config, credentials)
 }
 
-export const resize = item => {
+export const resize = (item, isFullscreen) => {
     const plugin = getPlugin(item.type)
 
     if (plugin && plugin.resize) {
-        plugin.resize(getGridItemDomId(item.id))
+        plugin.resize(getGridItemDomId(item.id), isFullscreen)
     }
 }
 


### PR DESCRIPTION
map plugin resize function now accepts an `isFullscreen` param