### PR TITLE
feat: scroll away control bar when viewing dashboard on screen with height <=480px

### DIFF
--- a/src/components/App.css
+++ b/src/components/App.css
@@ -22,14 +22,6 @@ body {
     overflow: hidden !important;
 }
 
-.dashboard-wrapper {
-    background-color: #f4f6f8;
-    padding-left: 16px;
-    padding-right: 16px;
-    overflow: auto;
-    padding-bottom: 24px;
-}
-
 /* plugin TODO */
 
 table.pivot * {

--- a/src/components/Dashboard/DashboardContainer.js
+++ b/src/components/Dashboard/DashboardContainer.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import cx from 'classnames'
+
+import classes from './styles/DashboardContainer.module.css'
+
+const DashboardContainer = ({ children, covered }) => {
+    return (
+        <div
+            className={cx(
+                classes.container,
+                'dashboard-scroll-container',
+                covered && classes.covered
+            )}
+        >
+            {children}
+        </div>
+    )
+}
+
+DashboardContainer.propTypes = {
+    children: PropTypes.node,
+    covered: PropTypes.bool,
+}
+
+export default DashboardContainer

--- a/src/components/Dashboard/EditDashboard.js
+++ b/src/components/Dashboard/EditDashboard.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux'
 import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
 
+import DashboardContainer from './DashboardContainer'
 import EditTitleBar from '../TitleBar/EditTitleBar'
 import EditItemGrid from '../ItemGrid/EditItemGrid'
 import EditBar from '../ControlBar/EditBar'
@@ -31,10 +32,10 @@ const EditDashboard = props => {
             return <LayoutPrintPreview fromEdit={true} />
         }
         return (
-            <div className="dashboard-wrapper">
+            <DashboardContainer>
                 <EditTitleBar />
                 <EditItemGrid />
-            </div>
+            </DashboardContainer>
         )
     }
 

--- a/src/components/Dashboard/NewDashboard.js
+++ b/src/components/Dashboard/NewDashboard.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import i18n from '@dhis2/d2-i18n'
 
+import DashboardContainer from './DashboardContainer'
 import EditBar from '../ControlBar/EditBar'
 import EditTitleBar from '../TitleBar/EditTitleBar'
 import EditItemGrid from '../ItemGrid/EditItemGrid'
@@ -26,10 +27,10 @@ const NewDashboard = props => {
                 {props.isPrintPreviewView ? (
                     <LayoutPrintPreview fromEdit={true} />
                 ) : (
-                    <div className="dashboard-wrapper">
+                    <DashboardContainer>
                         <EditTitleBar />
                         <EditItemGrid />
-                    </div>
+                    </DashboardContainer>
                 )}
             </div>
             <div className={classes.notice}>

--- a/src/components/Dashboard/ViewDashboard.js
+++ b/src/components/Dashboard/ViewDashboard.js
@@ -29,7 +29,7 @@ export const ViewDashboard = props => {
 
     useEffect(() => {
         Array.from(
-            document.querySelectorAll('.dashboard-scroll-container')
+            document.getElementsByClassName('dashboard-scroll-container')
         ).forEach(container => {
             container.scroll(0, 0)
         })

--- a/src/components/Dashboard/ViewDashboard.js
+++ b/src/components/Dashboard/ViewDashboard.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import { ComponentCover } from '@dhis2/ui'
 import cx from 'classnames'
+import DashboardContainer from './DashboardContainer'
 import ViewTitleBar from '../TitleBar/ViewTitleBar'
 import ViewItemGrid from '../ItemGrid/ViewItemGrid'
 import FilterBar from '../FilterBar/FilterBar'
@@ -27,24 +28,18 @@ export const ViewDashboard = props => {
     }, [props.dashboardIsEditing, props.dashboardIsPrinting])
 
     useEffect(() => {
-        document.querySelector('.dashboard-wrapper')?.scroll(0, 0)
+        document.querySelector('.dashboard-scroll-container')?.scroll(0, 0)
     }, [props.selectedId])
 
     const onExpandedChanged = expanded => setControlbarExpanded(expanded)
 
     return (
-        <div className={classes.container}>
+        <div className={cx(classes.container, 'dashboard-scroll-container')}>
             <DashboardsBar
                 expanded={controlbarExpanded}
                 onExpandedChanged={onExpandedChanged}
             />
-            <div
-                className={cx(
-                    classes.dashboardContainer,
-                    'dashboard-wrapper',
-                    controlbarExpanded && classes.covered
-                )}
-            >
+            <DashboardContainer covered={controlbarExpanded}>
                 {controlbarExpanded && (
                     <ComponentCover
                         className={classes.cover}
@@ -55,7 +50,7 @@ export const ViewDashboard = props => {
                 <ViewTitleBar />
                 <FilterBar />
                 <ViewItemGrid />
-            </div>
+            </DashboardContainer>
         </div>
     )
 }

--- a/src/components/Dashboard/ViewDashboard.js
+++ b/src/components/Dashboard/ViewDashboard.js
@@ -28,7 +28,11 @@ export const ViewDashboard = props => {
     }, [props.dashboardIsEditing, props.dashboardIsPrinting])
 
     useEffect(() => {
-        document.querySelector('.dashboard-scroll-container')?.scroll(0, 0)
+        Array.from(
+            document.querySelectorAll('.dashboard-scroll-container')
+        ).forEach(container => {
+            container.scroll(0, 0)
+        })
     }, [props.selectedId])
 
     const onExpandedChanged = expanded => setControlbarExpanded(expanded)

--- a/src/components/Dashboard/__tests__/__snapshots__/EditDashboard.spec.js.snap
+++ b/src/components/Dashboard/__tests__/__snapshots__/EditDashboard.spec.js.snap
@@ -9,7 +9,7 @@ exports[`EditDashboard renders dashboard 1`] = `
       EditBar
     </div>
     <div
-      class="dashboard-wrapper"
+      class="container dashboard-scroll-container"
     >
       <div>
         EditTitleBar

--- a/src/components/Dashboard/__tests__/__snapshots__/NewDashboard.spec.js.snap
+++ b/src/components/Dashboard/__tests__/__snapshots__/NewDashboard.spec.js.snap
@@ -10,7 +10,7 @@ exports[`NewDashboard renders dashboard 1`] = `
         EditBar
       </div>
       <div
-        class="dashboard-wrapper"
+        class="container dashboard-scroll-container"
       >
         <div>
           EditTitleBar

--- a/src/components/Dashboard/__tests__/__snapshots__/ViewDashboard.spec.js.snap
+++ b/src/components/Dashboard/__tests__/__snapshots__/ViewDashboard.spec.js.snap
@@ -8,7 +8,7 @@ exports[`ViewDashboard renders correctly default 1`] = `
   dashboardIsPrinting={false}
 >
   <div
-    className="container"
+    className="container dashboard-scroll-container"
   >
     <MockDashboardsBar
       expanded={false}
@@ -18,25 +18,29 @@ exports[`ViewDashboard renders correctly default 1`] = `
         MockDashboardsBar
       </div>
     </MockDashboardsBar>
-    <div
-      className="dashboardContainer dashboard-wrapper"
+    <DashboardContainer
+      covered={false}
     >
-      <MockViewTitleBar>
-        <div>
-          MockViewTitleBar
-        </div>
-      </MockViewTitleBar>
-      <MockFilterBar>
-        <div>
-          MockFilterBar
-        </div>
-      </MockFilterBar>
-      <MockViewItemGrid>
-        <div>
-          MockViewItemGrid
-        </div>
-      </MockViewItemGrid>
-    </div>
+      <div
+        className="container dashboard-scroll-container"
+      >
+        <MockViewTitleBar>
+          <div>
+            MockViewTitleBar
+          </div>
+        </MockViewTitleBar>
+        <MockFilterBar>
+          <div>
+            MockFilterBar
+          </div>
+        </MockFilterBar>
+        <MockViewItemGrid>
+          <div>
+            MockViewItemGrid
+          </div>
+        </MockViewItemGrid>
+      </div>
+    </DashboardContainer>
   </div>
 </ViewDashboard>
 `;

--- a/src/components/Dashboard/styles/DashboardContainer.module.css
+++ b/src/components/Dashboard/styles/DashboardContainer.module.css
@@ -1,0 +1,19 @@
+.container {
+    background-color: #f4f6f8;
+    padding-left: var(--spacers-dp16);
+    padding-right: var(--spacers-dp16);
+    padding-bottom: var(--spacers-dp24);
+    overflow: auto;
+}
+
+@media only screen and (max-height: 480px) {
+    .container {
+        overflow: visible;
+    }
+}
+
+@media only screen and (max-height: 480px), only screen and (max-width: 480px) {
+    .covered {
+        overflow: hidden;
+    }
+}

--- a/src/components/Dashboard/styles/ViewDashboard.module.css
+++ b/src/components/Dashboard/styles/ViewDashboard.module.css
@@ -21,3 +21,13 @@
         overflow: hidden;
     }
 }
+
+@media only screen and (max-height: 480px) {
+    .container {
+        overflow-y: auto;
+    }
+
+    .container .dashboardContainer {
+        overflow: visible;
+    }
+}

--- a/src/components/Dashboard/styles/ViewDashboard.module.css
+++ b/src/components/Dashboard/styles/ViewDashboard.module.css
@@ -5,10 +5,6 @@
     position: relative;
 }
 
-.dashboardContainer {
-    position: relative;
-}
-
 .cover {
     display: none;
 }
@@ -17,17 +13,10 @@
     .cover {
         display: block;
     }
-    .dashboardContainer.covered {
-        overflow: hidden;
-    }
 }
 
 @media only screen and (max-height: 480px) {
     .container {
         overflow-y: auto;
-    }
-
-    .container .dashboardContainer {
-        overflow: visible;
     }
 }

--- a/src/components/Item/ProgressiveLoadingContainer.js
+++ b/src/components/Item/ProgressiveLoadingContainer.js
@@ -51,23 +51,27 @@ class ProgressiveLoadingContainer extends Component {
             this.props.debounceMs
         )
 
-        document
-            .getElementsByClassName('dashboard-wrapper')[0]
-            ?.addEventListener(
+        Array.from(
+            document.getElementsByClassName('dashboard-scroll-container')
+        ).forEach(container => {
+            container.addEventListener(
                 'scroll',
                 this.shouldLoadHandler,
                 this.handlerOptions
             )
+        })
     }
 
     removeHandler() {
-        document
-            .getElementsByClassName('dashboard-wrapper')[0]
-            ?.removeEventListener(
+        Array.from(
+            document.getElementsByClassName('dashboard-scroll-container')
+        ).forEach(container => {
+            container.removeEventListener(
                 'scroll',
                 this.shouldLoadHandler,
                 this.handlerOptions
             )
+        })
     }
 
     componentDidMount() {


### PR DESCRIPTION
When the screen height is <=480px, then scroll all the content, including the control bar. When more than 480px, scroll only the actual dashboard. Note that progressive loading is not working consistently right now (pre-existing issue - currently being investigated)

Small refactor:
* move styling from App.css and into a css module on a new component DashboardContainer

https://user-images.githubusercontent.com/6113918/108341782-5488e900-71da-11eb-98c2-9ea04bab72d2.mov

