### PR TITLE
fix: debounce the item selector query in dashboard editor [DHIS2-10530]

### DIFF
--- a/cypress/integration/ui/view_dashboard.feature
+++ b/cypress/integration/ui/view_dashboard.feature
@@ -17,11 +17,11 @@ Feature: Viewing dashboards
 
     @nonmutating
     Scenario: I search for a dashboard with nonmatching search text
-        Given I open the "Delivery" dashboard
+        Given I open the "Antenatal Care" dashboard
         When I search for dashboards containing Noexist
         Then no dashboards are choices
         When I press enter in the search dashboard field
-        Then dashboards list restored and dashboard is still "Delivery"
+        Then dashboards list restored and dashboard is still "Antenatal Care"
 
     @nonmutating
     Scenario: I view the print layout preview

--- a/src/api/dashboardsQ.js
+++ b/src/api/dashboardsQ.js
@@ -1,0 +1,6 @@
+export const getDashboardsQQuery = (query = '', maxItems = []) => {
+    return {
+        resource: `dashboards/q/${query}`,
+        params: { count: 11, max: maxItems },
+    }
+}

--- a/src/components/ItemSelector/ItemSelector.js
+++ b/src/components/ItemSelector/ItemSelector.js
@@ -17,7 +17,7 @@ const ItemSelector = () => {
     const [items, setItems] = useState(null)
     const [maxOptions, setMaxOptions] = useState(new Set())
     const dataEngine = useDataEngine()
-    const debouncedFilterText = useDebounce(filter, 200)
+    const debouncedFilterText = useDebounce(filter, 350)
 
     useEffect(() => {
         const query = getDashboardsQQuery(

--- a/src/components/ItemSelector/SinglesMenuGroup.js
+++ b/src/components/ItemSelector/SinglesMenuGroup.js
@@ -6,7 +6,7 @@ import HeaderMenuItem from './HeaderMenuItem'
 import ContentMenuItem from './ContentMenuItem'
 import { acAddDashboardItem } from '../../actions/editDashboard'
 
-export const SinglesMenuGroup = ({ acAddDashboardItem, category }) => {
+const SinglesMenuGroup = ({ acAddDashboardItem, category }) => {
     const addToDashboard = ({ type, content }) => () => {
         acAddDashboardItem({ type, content })
     }

--- a/src/components/ItemSelector/__tests__/SinglesMenuGroup.spec.js
+++ b/src/components/ItemSelector/__tests__/SinglesMenuGroup.spec.js
@@ -1,28 +1,35 @@
 import React from 'react'
-import { shallow } from 'enzyme'
-import toJson from 'enzyme-to-json'
-import { SinglesMenuGroup } from '../SinglesMenuGroup'
+import { render } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import configureMockStore from 'redux-mock-store'
 
-describe('SinglesMenuGroup', () => {
-    const wrapper = props => shallow(<SinglesMenuGroup {...props} />)
+import SinglesMenuGroup from '../SinglesMenuGroup'
 
-    it('matches snapshot', () => {
-        const props = {
-            acAddDashboardItem: jest.fn(),
-            category: {
-                header: 'ponies',
-                items: [
-                    {
-                        type: 'colorful',
-                        name: 'Rainbow Dash',
-                    },
-                    {
-                        type: 'greytone',
-                        name: 'B&W',
-                    },
-                ],
-            },
-        }
-        expect(toJson(wrapper(props))).toMatchSnapshot()
-    })
+const mockStore = configureMockStore()
+
+test('renders SingleMenuGroup', () => {
+    const store = {}
+
+    const props = {
+        category: {
+            header: 'ponies',
+            items: [
+                {
+                    type: 'colorful',
+                    name: 'Rainbow Dash',
+                },
+                {
+                    type: 'greytone',
+                    name: 'Twilight',
+                },
+            ],
+        },
+    }
+
+    const { container } = render(
+        <Provider store={mockStore(store)}>
+            <SinglesMenuGroup {...props} />
+        </Provider>
+    )
+    expect(container).toMatchSnapshot()
 })

--- a/src/components/ItemSelector/__tests__/__snapshots__/SinglesMenuGroup.spec.js.snap
+++ b/src/components/ItemSelector/__tests__/__snapshots__/SinglesMenuGroup.spec.js.snap
@@ -1,21 +1,114 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SinglesMenuGroup matches snapshot 1`] = `
-<Fragment>
-  <HeaderMenuItem
-    title="ponies"
-  />
-  <ContentMenuItem
-    key="colorful"
-    name="Rainbow Dash"
-    onInsert={[Function]}
-    type="colorful"
-  />
-  <ContentMenuItem
-    key="greytone"
-    name="B&W"
-    onInsert={[Function]}
-    type="greytone"
-  />
-</Fragment>
+exports[`renders SingleMenuGroup 1`] = `
+<div>
+  <li
+    class="jsx-665727467 item disabled dense"
+    data-test="dhis2-uicore-menuitem"
+  >
+    <a
+      class="jsx-665727467"
+    >
+      <span
+        class="jsx-665727467 label"
+      >
+        <span
+          style="color: rgb(64, 75, 90); font-weight: 600;"
+        >
+          ponies
+        </span>
+      </span>
+    </a>
+  </li>
+  <li
+    class="jsx-665727467 dense"
+    data-test="menu-item-Rainbow Dash"
+  >
+    <a
+      class="jsx-665727467"
+    >
+      <span
+        class="jsx-665727467 label"
+      >
+        <div
+          class="menuItem"
+        >
+          <div
+            class="label"
+          >
+            <span
+              style="margin-right: 6px;"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root-1"
+                focusable="false"
+                role="presentation"
+                style="fill: #6e7a8a;"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8 0-1.85.63-3.55 1.69-4.9L16.9 18.31C15.55 19.37 13.85 20 12 20zm6.31-3.1L7.1 5.69C8.45 4.63 10.15 4 12 4c4.42 0 8 3.58 8 8 0 1.85-.63 3.55-1.69 4.9z"
+                />
+              </svg>
+            </span>
+            <span>
+              Rainbow Dash
+            </span>
+          </div>
+          <button
+            class="buttonInsert"
+          >
+            Insert
+          </button>
+        </div>
+      </span>
+    </a>
+  </li>
+  <li
+    class="jsx-665727467 dense"
+    data-test="menu-item-Twilight"
+  >
+    <a
+      class="jsx-665727467"
+    >
+      <span
+        class="jsx-665727467 label"
+      >
+        <div
+          class="menuItem"
+        >
+          <div
+            class="label"
+          >
+            <span
+              style="margin-right: 6px;"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root-1"
+                focusable="false"
+                role="presentation"
+                style="fill: #6e7a8a;"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8 0-1.85.63-3.55 1.69-4.9L16.9 18.31C15.55 19.37 13.85 20 12 20zm6.31-3.1L7.1 5.69C8.45 4.63 10.15 4 12 4c4.42 0 8 3.58 8 8 0 1.85-.63 3.55-1.69 4.9z"
+                />
+              </svg>
+            </span>
+            <span>
+              Twilight
+            </span>
+          </div>
+          <button
+            class="buttonInsert"
+          >
+            Insert
+          </button>
+        </div>
+      </span>
+    </a>
+  </li>
+</div>
 `;

--- a/src/components/ItemSelector/selectableItems.js
+++ b/src/components/ItemSelector/selectableItems.js
@@ -4,7 +4,6 @@ import {
     MAP,
     EVENT_CHART,
     EVENT_REPORT,
-    USERS,
     REPORTS,
     RESOURCES,
     APP,
@@ -43,11 +42,10 @@ export const categorizedItems = [
     MAP,
     EVENT_REPORT,
     EVENT_CHART,
-    USERS,
     REPORTS,
     RESOURCES,
     APP,
 ]
 
 // listItemTypes are included in a single dashboard item
-export const listItemTypes = [REPORTS, RESOURCES, USERS]
+export const listItemTypes = [REPORTS, RESOURCES]

--- a/src/modules/useDebounce.js
+++ b/src/modules/useDebounce.js
@@ -1,0 +1,16 @@
+import { useState, useEffect } from 'react'
+
+const useDebounce = (value, delay) => {
+    const [debouncedValue, setDebouncedValue] = useState(value)
+    useEffect(() => {
+        const handler = setTimeout(() => {
+            setDebouncedValue(value)
+        }, delay)
+        return () => {
+            clearTimeout(handler)
+        }
+    }, [value, delay])
+    return debouncedValue
+}
+
+export default useDebounce


### PR DESCRIPTION
Fix:
- prevent the item selector query from firing on every keystroke.


Refactor:
- useDataEngine instead of manually constructing the query
- SinglesMenuGroup exports was triggering eslint warning, so no longer export const SinglesMenuGroup (unit test had to be updated)
- remove USERS from ItemSelector as it is no longer meant to be used (confirmed with @janhenrikoverland )
- borrow the `useDebounce` hook from analytics. Have suggested to Austin that it could be added to app-runtime