### PR TITLE
fix: controlbar should always take full width, and other minor position adjustments

### DIFF
--- a/src/components/ControlBar/ViewControlBar/styles/ClearButton.module.css
+++ b/src/components/ControlBar/ViewControlBar/styles/ClearButton.module.css
@@ -24,5 +24,6 @@
 @media only screen and (max-width: 480px) {
     .button {
         margin-bottom: var(--spacers-dp4);
+        margin-right: 1px;
     }
 }

--- a/src/components/ControlBar/ViewControlBar/styles/Content.module.css
+++ b/src/components/ControlBar/ViewControlBar/styles/Content.module.css
@@ -53,6 +53,7 @@
 
     .chipsContainer {
         margin-bottom: -4px;
+        padding-right: 2px;
     }
 
     .expanded .chipsContainer {

--- a/src/components/ControlBar/ViewControlBar/styles/Content.module.css
+++ b/src/components/ControlBar/ViewControlBar/styles/Content.module.css
@@ -24,6 +24,7 @@
 
     .controlsSmall {
         display: block;
+        margin-bottom: var(--spacers-dp4);
     }
 
     .controlsLarge {

--- a/src/components/ControlBar/ViewControlBar/styles/DashboardsBar.module.css
+++ b/src/components/ControlBar/ViewControlBar/styles/DashboardsBar.module.css
@@ -9,6 +9,7 @@
     display: flex;
     flex-direction: column;
     height: var(--user-rows-height);
+    width: 100%;
 }
 
 .content {

--- a/src/components/ControlBar/ViewControlBar/styles/Filter.module.css
+++ b/src/components/ControlBar/ViewControlBar/styles/Filter.module.css
@@ -1,3 +1,7 @@
+.container {
+    vertical-align: super;
+}
+
 .searchArea {
     width: 200px;
     height: 30px;
@@ -13,7 +17,7 @@
     width: 100%;
     min-width: 0;
     margin: 0;
-    padding: 6px 0 7px;
+    padding: 2px 0 0 0;
 }
 
 .input::placeholder {
@@ -53,6 +57,11 @@
 .searchIconSmall,
 .searchIconLarge {
     fill: var(--colors-grey700);
+}
+
+.searchIconLarge {
+    width: 20px;
+    height: 20px;
 }
 
 .searchButton {
@@ -96,6 +105,7 @@
 @media only screen and (max-width: 480px) {
     .input {
         width: 100%;
+        padding-bottom: 2px;
     }
 
     .searchIconSmall {


### PR DESCRIPTION
Controlbar wasn't taking full width when searching:
![image](https://user-images.githubusercontent.com/6113918/108695355-7b0f9280-7500-11eb-9a5e-39d686fa746d.png)

After:
![image](https://user-images.githubusercontent.com/6113918/108695418-9084bc80-7500-11eb-8d7a-8a8e8c7b9e40.png)


Get rid of scrollbar when chips don't take full width:
Before: 
![image](https://user-images.githubusercontent.com/6113918/108695470-9e3a4200-7500-11eb-9b0e-4b71533a100c.png)
After:

![image](https://user-images.githubusercontent.com/6113918/108695523-ab573100-7500-11eb-89a2-2be85f3dc9d9.png)


Position of search icon was too low
Before: 
![image](https://user-images.githubusercontent.com/6113918/108695599-c4f87880-7500-11eb-8669-76c74701726a.png)

After: 
![image](https://user-images.githubusercontent.com/6113918/108695642-d04ba400-7500-11eb-8512-be8b26979ad8.png)


