### PR TITLE
fix: position loading spinner at top of item

### DIFF
--- a/cypress/integration/ui/view_dashboard.feature
+++ b/cypress/integration/ui/view_dashboard.feature
@@ -9,7 +9,7 @@ Feature: Viewing dashboards
 
     @nonmutating
     Scenario: I search for a dashboard
-        Given I open the "Delivery" dashboard
+        Given I open the "Antenatal Care" dashboard
         When I search for dashboards containing Immunization
         Then Immunization and Immunization data dashboards are choices
         When I press enter in the search dashboard field

--- a/src/components/Item/VisualizationItem/Visualization/styles/LoadingMask.module.css
+++ b/src/components/Item/VisualizationItem/Visualization/styles/LoadingMask.module.css
@@ -2,5 +2,5 @@
     display: flex;
     justify-content: center;
     height: 100%;
-    align-items: center;
+    margin-top: var(--spacers-dp8);
 }


### PR DESCRIPTION
This is so that items near the bottom of the viewport can be seen to be loading, rather than looking like nothing is happening.

![image](https://user-images.githubusercontent.com/6113918/108714427-cf733c00-7519-11eb-9f5d-2f42e7bb53fd.png)


![image](https://user-images.githubusercontent.com/6113918/108714493-e31ea280-7519-11eb-8679-3bb6a897fc70.png)
