### PR TITLE
fix: get value for margins and padding from css when calculating item available height

### DIFF
--- a/src/components/App.css
+++ b/src/components/App.css
@@ -1,5 +1,5 @@
-/* control bar variables */
 :root {
+    /* control bar variables */
     --user-rows-count: 1;
     --controlbar-padding: 31px;
     --row-height: 40px;
@@ -12,6 +12,11 @@
     --user-rows-height: calc(
         var(--controlbar-padding) + (var(--user-rows-count) * var(--row-height))
     );
+
+    /* item variables */
+    --item-header-margin-top: 8px;
+    --item-header-margin-bottom: 8px;
+    --item-content-padding: 4px;
 }
 
 body {

--- a/src/components/Item/ItemHeader/ItemHeader.js
+++ b/src/components/Item/ItemHeader/ItemHeader.js
@@ -18,9 +18,6 @@ const getItemActionsMap = isShortened => {
     }
 }
 
-// This is the margin-top + margin-bottom defined in the css file
-export const HEADER_MARGIN_HEIGHT = 12
-
 const ItemHeader = React.forwardRef(
     ({ dashboardMode, title, isShortened, ...rest }, ref) => {
         const Actions = getItemActionsMap(isShortened)[dashboardMode]

--- a/src/components/Item/ItemHeader/styles/ItemHeader.module.css
+++ b/src/components/Item/ItemHeader/styles/ItemHeader.module.css
@@ -1,7 +1,7 @@
 .itemHeaderWrap {
     display: flex;
-    margin: var(--spacers-dp8) var(--spacers-dp4) var(--spacers-dp8)
-        var(--spacers-dp8);
+    margin: var(--item-header-margin-top) var(--spacers-dp4)
+        var(--item-header-margin-bottom) var(--spacers-dp8);
 }
 
 .itemTitle {

--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -5,7 +5,7 @@ import uniqueId from 'lodash/uniqueId'
 
 import Visualization from './Visualization/Visualization'
 import FatalErrorBoundary from './FatalErrorBoundary'
-import ItemHeader, { HEADER_MARGIN_HEIGHT } from '../ItemHeader/ItemHeader'
+import ItemHeader from '../ItemHeader/ItemHeader'
 import ItemHeaderButtons from './ItemHeaderButtons'
 import ItemFooter from './ItemFooter'
 import { WindowDimensionsCtx } from '../../WindowDimensionsProvider'
@@ -36,9 +36,6 @@ import {
 import { getItemHeightPx } from '../../../modules/gridUtil'
 import getGridItemDomId from '../../../modules/getGridItemDomId'
 
-// this is set in the .dashboard-item-content css
-const ITEM_CONTENT_PADDING = 4
-
 export class Item extends Component {
     state = {
         showFooter: false,
@@ -52,6 +49,23 @@ export class Item extends Component {
         this.contentRef = React.createRef()
         this.headerRef = React.createRef()
         this.itemDomElSelector = `.reactgriditem-${this.props.item.id}`
+
+        const style = window.getComputedStyle(document.documentElement)
+        this.itemContentPadding = parseInt(
+            style.getPropertyValue('--item-content-padding').replace('px', '')
+        )
+
+        this.itemHeaderTotalMargin =
+            parseInt(
+                style
+                    .getPropertyValue('--item-header-margin-top')
+                    .replace('px', '')
+            ) +
+            parseInt(
+                style
+                    .getPropertyValue('--item-header-margin-bottom')
+                    .replace('px', '')
+            )
 
         this.memoizedGetContentHeight = memoizeOne(
             (calculatedHeight, measuredHeight, preferMeasured) =>
@@ -186,8 +200,8 @@ export class Item extends Component {
         const calculatedHeight =
             getItemHeightPx(this.props.item, width) -
             this.headerRef.current.clientHeight -
-            HEADER_MARGIN_HEIGHT -
-            ITEM_CONTENT_PADDING
+            this.itemHeaderTotalMargin -
+            this.itemContentPadding
 
         return this.memoizedGetContentHeight(
             calculatedHeight,
@@ -201,7 +215,7 @@ export class Item extends Component {
         const rect = document
             .querySelector(this.itemDomElSelector)
             ?.getBoundingClientRect()
-        return rect && rect.width - ITEM_CONTENT_PADDING * 2
+        return rect && rect.width - this.itemContentPadding * 2
     }
 
     render() {

--- a/src/components/ItemGrid/styles/ItemGrid.css
+++ b/src/components/ItemGrid/styles/ItemGrid.css
@@ -51,7 +51,7 @@
 /* dashboard item - content */
 
 .dashboard-item-content {
-    margin: 0 4px 4px;
+    margin: 0 var(--item-content-padding) var(--item-content-padding);
     overflow: auto;
 }
 


### PR DESCRIPTION
Previously the values margins and padding needed for calculating item height were stored in duplicate (value in js and in css). This was error prone since one value could be changed leading to a mismatch. Now, the javascript gets the value from the stylesheet.

Before:
![image](https://user-images.githubusercontent.com/6113918/108979340-d8cfe600-768a-11eb-9f54-564953df61e6.png)

After fix:

![image](https://user-images.githubusercontent.com/6113918/108978754-3e6fa280-768a-11eb-9d3d-056bf32d6763.png)
