### PR TITLE
fix: remove div around edit dashboard content that caused the grid not to be scrollable

### DIFF
--- a/src/components/Dashboard/NewDashboard.js
+++ b/src/components/Dashboard/NewDashboard.js
@@ -21,7 +21,7 @@ const NewDashboard = props => {
     }, [])
 
     return (
-        <div>
+        <>
             <div className={classes.container}>
                 <EditBar />
                 {props.isPrintPreviewView ? (
@@ -41,7 +41,7 @@ const NewDashboard = props => {
                     )}
                 />
             </div>
-        </div>
+        </>
     )
 }
 

--- a/src/components/Dashboard/__tests__/__snapshots__/NewDashboard.spec.js.snap
+++ b/src/components/Dashboard/__tests__/__snapshots__/NewDashboard.spec.js.snap
@@ -2,70 +2,68 @@
 
 exports[`NewDashboard renders dashboard 1`] = `
 <div>
-  <div>
-    <div
-      class="container"
-    >
-      <div>
-        EditBar
-      </div>
-      <div
-        class="container dashboard-scroll-container"
-      >
-        <div>
-          EditTitleBar
-        </div>
-        <div>
-          EditItemGrid
-        </div>
-      </div>
+  <div
+    class="container"
+  >
+    <div>
+      EditBar
     </div>
     <div
-      class="notice"
+      class="container dashboard-scroll-container"
+    >
+      <div>
+        EditTitleBar
+      </div>
+      <div>
+        EditItemGrid
+      </div>
+    </div>
+  </div>
+  <div
+    class="notice"
+  >
+    <div
+      class="jsx-761413583 centered-content top"
+      data-test="dhis2-uicore-centeredcontent"
     >
       <div
-        class="jsx-761413583 centered-content top"
-        data-test="dhis2-uicore-centeredcontent"
+        class="jsx-761413583 centered-inner-content"
       >
         <div
-          class="jsx-761413583 centered-inner-content"
+          class="noticeContainer"
         >
           <div
-            class="noticeContainer"
+            class="jsx-3561221191 root warning"
+            data-test="dhis2-uicore-noticebox"
           >
             <div
-              class="jsx-3561221191 root warning"
-              data-test="dhis2-uicore-noticebox"
+              data-test="dhis2-uicore-noticebox-icon"
             >
-              <div
-                data-test="dhis2-uicore-noticebox-icon"
+              <svg
+                class="jsx-884574500 jsx-1769496071"
+                viewBox="0 0 48 48"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  class="jsx-884574500 jsx-1769496071"
-                  viewBox="0 0 48 48"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    class="jsx-884574500"
-                    d="M2 42h44L24 4 2 42zm24-6h-4v-4h4v4zm0-8h-4v-8h4v8z"
-                  />
-                </svg>
-              </div>
-              <div
-                class="jsx-3561221191"
+                <path
+                  class="jsx-884574500"
+                  d="M2 42h44L24 4 2 42zm24-6h-4v-4h4v4zm0-8h-4v-8h4v8z"
+                />
+              </svg>
+            </div>
+            <div
+              class="jsx-3561221191"
+            >
+              <h6
+                class="jsx-1234954849"
+                data-test="dhis2-uicore-noticebox-title"
               >
-                <h6
-                  class="jsx-1234954849"
-                  data-test="dhis2-uicore-noticebox-title"
-                >
-                  Not supported
-                </h6>
-                <div
-                  class="jsx-3638294246"
-                  data-test="dhis2-uicore-noticebox-message"
-                >
-                  Creating dashboards on small screens is not supported. Resize your screen to return to create mode.
-                </div>
+                Not supported
+              </h6>
+              <div
+                class="jsx-3638294246"
+                data-test="dhis2-uicore-noticebox-message"
+              >
+                Creating dashboards on small screens is not supported. Resize your screen to return to create mode.
               </div>
             </div>
           </div>
@@ -78,63 +76,61 @@ exports[`NewDashboard renders dashboard 1`] = `
 
 exports[`NewDashboard renders print preview 1`] = `
 <div>
-  <div>
-    <div
-      class="container"
-    >
-      <div>
-        EditBar
-      </div>
-      <div>
-        LayoutPrintPreview
-      </div>
+  <div
+    class="container"
+  >
+    <div>
+      EditBar
     </div>
+    <div>
+      LayoutPrintPreview
+    </div>
+  </div>
+  <div
+    class="notice"
+  >
     <div
-      class="notice"
+      class="jsx-761413583 centered-content top"
+      data-test="dhis2-uicore-centeredcontent"
     >
       <div
-        class="jsx-761413583 centered-content top"
-        data-test="dhis2-uicore-centeredcontent"
+        class="jsx-761413583 centered-inner-content"
       >
         <div
-          class="jsx-761413583 centered-inner-content"
+          class="noticeContainer"
         >
           <div
-            class="noticeContainer"
+            class="jsx-3561221191 root warning"
+            data-test="dhis2-uicore-noticebox"
           >
             <div
-              class="jsx-3561221191 root warning"
-              data-test="dhis2-uicore-noticebox"
+              data-test="dhis2-uicore-noticebox-icon"
             >
-              <div
-                data-test="dhis2-uicore-noticebox-icon"
+              <svg
+                class="jsx-884574500 jsx-1769496071"
+                viewBox="0 0 48 48"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  class="jsx-884574500 jsx-1769496071"
-                  viewBox="0 0 48 48"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    class="jsx-884574500"
-                    d="M2 42h44L24 4 2 42zm24-6h-4v-4h4v4zm0-8h-4v-8h4v8z"
-                  />
-                </svg>
-              </div>
-              <div
-                class="jsx-3561221191"
+                <path
+                  class="jsx-884574500"
+                  d="M2 42h44L24 4 2 42zm24-6h-4v-4h4v4zm0-8h-4v-8h4v8z"
+                />
+              </svg>
+            </div>
+            <div
+              class="jsx-3561221191"
+            >
+              <h6
+                class="jsx-1234954849"
+                data-test="dhis2-uicore-noticebox-title"
               >
-                <h6
-                  class="jsx-1234954849"
-                  data-test="dhis2-uicore-noticebox-title"
-                >
-                  Not supported
-                </h6>
-                <div
-                  class="jsx-3638294246"
-                  data-test="dhis2-uicore-noticebox-message"
-                >
-                  Creating dashboards on small screens is not supported. Resize your screen to return to create mode.
-                </div>
+                Not supported
+              </h6>
+              <div
+                class="jsx-3638294246"
+                data-test="dhis2-uicore-noticebox-message"
+              >
+                Creating dashboards on small screens is not supported. Resize your screen to return to create mode.
               </div>
             </div>
           </div>

--- a/src/components/TitleBar/EditTitleBar.js
+++ b/src/components/TitleBar/EditTitleBar.js
@@ -14,7 +14,7 @@ import { sGetEditDashboardRoot } from '../../reducers/editDashboard'
 
 import classes from './styles/EditTitleBar.module.css'
 
-export const EditTitleBar = ({
+const EditTitleBar = ({
     name,
     description,
     onChangeTitle,

--- a/src/components/TitleBar/__tests__/EditTitleBar.spec.js
+++ b/src/components/TitleBar/__tests__/EditTitleBar.spec.js
@@ -1,35 +1,43 @@
 import React from 'react'
-import { shallow } from 'enzyme'
-import toJson from 'enzyme-to-json'
-import { EditTitleBar } from '../EditTitleBar'
+import { render } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import configureMockStore from 'redux-mock-store'
+
+import EditTitleBar from '../EditTitleBar'
+
+const mockStore = configureMockStore()
 
 jest.mock('../../ItemSelector/ItemSelector', () => 'ItemSelector')
 
 describe('EditTitleBar', () => {
-    const props = {
-        name: 'Rainbow Dash',
-        description: 'The blue one',
-        onChangeTitle: Function.prototype,
-        onChangeDescription: Function.prototype,
-        classes: {
-            section: 'section',
-            titleDescription: 'titledesc',
-            title: 'title',
-            description: 'description',
-            underline: 'underline',
-            input: 'input',
-            itemSelector: 'itemSelector',
-        },
-    }
-
-    it('renders correctly', () => {
-        const tree = shallow(<EditTitleBar {...props} />)
-        expect(toJson(tree)).toMatchSnapshot()
+    it('renders correctly with name and description', () => {
+        const store = {
+            editDashboard: {
+                name: 'Rainbow Dash',
+                description: 'A very colorful pony',
+            },
+        }
+        const { container } = render(
+            <Provider store={mockStore(store)}>
+                <EditTitleBar />
+            </Provider>
+        )
+        expect(container).toMatchSnapshot()
     })
 
-    it('renders correctly when no name', () => {
-        props.name = ''
-        const tree = shallow(<EditTitleBar {...props} />)
-        expect(toJson(tree)).toMatchSnapshot()
+    it('renders correctly when no name or description', () => {
+        const store = {
+            editDashboard: {
+                name: '',
+                description: '',
+            },
+        }
+
+        const { container } = render(
+            <Provider store={mockStore(store)}>
+                <EditTitleBar />
+            </Provider>
+        )
+        expect(container).toMatchSnapshot()
     })
 })

--- a/src/components/TitleBar/__tests__/__snapshots__/EditTitleBar.spec.js.snap
+++ b/src/components/TitleBar/__tests__/__snapshots__/EditTitleBar.spec.js.snap
@@ -1,75 +1,203 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EditTitleBar renders correctly 1`] = `
-<section
-  className="section"
->
-  <div
-    className="titleDescription"
+exports[`EditTitleBar renders correctly when no name or description 1`] = `
+<div>
+  <section
+    class="section"
   >
-    <InputField
-      className="title"
-      dataTest="dashboard-title-input"
-      label="Dashboard title"
-      name="Dashboard title input"
-      onChange={[Function]}
-      placeholder="Untitled dashboard"
-      type="text"
-      value="Rainbow Dash"
-    />
-    <TextAreaField
-      className="description"
-      dataTest="dashboard-description-input"
-      label="Dashboard description"
-      name="Dashboard description input"
-      onChange={[Function]}
-      resize="vertical"
-      rows={4}
-      value="The blue one"
-      width="100%"
-    />
-  </div>
-  <div
-    className="itemSelector"
-  >
-    <ItemSelector />
-  </div>
-</section>
+    <div
+      class="titleDescription"
+    >
+      <div
+        class="jsx-1141087211 title"
+        data-test="dashboard-title-input"
+      >
+        <label
+          class="jsx-2718078600 "
+          data-test="dashboard-title-input-label"
+          for="Dashboard title input"
+        >
+          <span
+            class="jsx-2718078600"
+          >
+            Dashboard title
+          </span>
+        </label>
+        <div
+          class="jsx-3111771310 "
+          data-test="dashboard-title-input-content"
+        >
+          <div
+            class="jsx-1220078726 "
+            data-test="dhis2-uicore-box"
+          >
+            <div
+              class="jsx-3353877153 jsx-1090541828 input"
+              data-test="dhis2-uicore-input"
+            >
+              <input
+                class="jsx-3353877153 jsx-1090541828 "
+                id="Dashboard title input"
+                name="Dashboard title input"
+                placeholder="Untitled dashboard"
+                type="text"
+                value=""
+              />
+              <div
+                class="jsx-3353877153 jsx-1090541828 status-icon"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="jsx-1141087211 description"
+        data-test="dashboard-description-input"
+      >
+        <label
+          class="jsx-2718078600 "
+          data-test="dashboard-description-input-label"
+          for="Dashboard description input"
+        >
+          <span
+            class="jsx-2718078600"
+          >
+            Dashboard description
+          </span>
+        </label>
+        <div
+          class="jsx-3111771310 "
+          data-test="dashboard-description-input-content"
+        >
+          <div
+            class="jsx-2954617683 "
+            data-test="dhis2-uicore-box"
+          >
+            <div
+              class="jsx-829628532 jsx-2961587785 textarea"
+              data-test="dhis2-uicore-textarea"
+            >
+              <textarea
+                class="jsx-829628532 jsx-2961587785 "
+                id="Dashboard description input"
+                name="Dashboard description input"
+                rows="4"
+              />
+              <div
+                class="jsx-829628532 jsx-2961587785 status-icon"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="itemSelector"
+    >
+      <itemselector />
+    </div>
+  </section>
+</div>
 `;
 
-exports[`EditTitleBar renders correctly when no name 1`] = `
-<section
-  className="section"
->
-  <div
-    className="titleDescription"
+exports[`EditTitleBar renders correctly with name and description 1`] = `
+<div>
+  <section
+    class="section"
   >
-    <InputField
-      className="title"
-      dataTest="dashboard-title-input"
-      label="Dashboard title"
-      name="Dashboard title input"
-      onChange={[Function]}
-      placeholder="Untitled dashboard"
-      type="text"
-      value=""
-    />
-    <TextAreaField
-      className="description"
-      dataTest="dashboard-description-input"
-      label="Dashboard description"
-      name="Dashboard description input"
-      onChange={[Function]}
-      resize="vertical"
-      rows={4}
-      value="The blue one"
-      width="100%"
-    />
-  </div>
-  <div
-    className="itemSelector"
-  >
-    <ItemSelector />
-  </div>
-</section>
+    <div
+      class="titleDescription"
+    >
+      <div
+        class="jsx-1141087211 title"
+        data-test="dashboard-title-input"
+      >
+        <label
+          class="jsx-2718078600 "
+          data-test="dashboard-title-input-label"
+          for="Dashboard title input"
+        >
+          <span
+            class="jsx-2718078600"
+          >
+            Dashboard title
+          </span>
+        </label>
+        <div
+          class="jsx-3111771310 "
+          data-test="dashboard-title-input-content"
+        >
+          <div
+            class="jsx-1220078726 "
+            data-test="dhis2-uicore-box"
+          >
+            <div
+              class="jsx-3353877153 jsx-1090541828 input"
+              data-test="dhis2-uicore-input"
+            >
+              <input
+                class="jsx-3353877153 jsx-1090541828 "
+                id="Dashboard title input"
+                name="Dashboard title input"
+                placeholder="Untitled dashboard"
+                type="text"
+                value="Rainbow Dash"
+              />
+              <div
+                class="jsx-3353877153 jsx-1090541828 status-icon"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="jsx-1141087211 description"
+        data-test="dashboard-description-input"
+      >
+        <label
+          class="jsx-2718078600 "
+          data-test="dashboard-description-input-label"
+          for="Dashboard description input"
+        >
+          <span
+            class="jsx-2718078600"
+          >
+            Dashboard description
+          </span>
+        </label>
+        <div
+          class="jsx-3111771310 "
+          data-test="dashboard-description-input-content"
+        >
+          <div
+            class="jsx-2954617683 "
+            data-test="dhis2-uicore-box"
+          >
+            <div
+              class="jsx-829628532 jsx-2961587785 textarea"
+              data-test="dhis2-uicore-textarea"
+            >
+              <textarea
+                class="jsx-829628532 jsx-2961587785 "
+                id="Dashboard description input"
+                name="Dashboard description input"
+                rows="4"
+              >
+                A very colorful pony
+              </textarea>
+              <div
+                class="jsx-829628532 jsx-2961587785 status-icon"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="itemSelector"
+    >
+      <itemselector />
+    </div>
+  </section>
+</div>
 `;


### PR DESCRIPTION
Fix: remove div around new dashboard that blocked scrolling when new items were added

Refactor:
* fixed lint error caused by the import of EditTitleBar which was also a const export (no more). As a result, the jest test needed to be updated to testing-library with a mock redux store. This resulted in several snapshot updates.

Bad - no scrolling

https://user-images.githubusercontent.com/6113918/109155135-7e5c8580-776f-11eb-86a0-f401a2d2ece7.mov


Good - scrolling fixed


https://user-images.githubusercontent.com/6113918/109155260-a51abc00-776f-11eb-9186-8ac8efbcc106.mov


