### PR TITLE
fix: DashboardsBar onExpandedChanged must be a function

### DIFF
--- a/cypress/integration/ui/error_scenarios.feature
+++ b/cypress/integration/ui/error_scenarios.feature
@@ -9,6 +9,8 @@ Feature: Error scenarios
     Scenario: I navigate to a dashboard that doesn't exist or I don't have access to
         Given I type an invalid dashboard id in the browser url
         Then a message displays informing that the dashboard is not found
+        When I open the "Delivery" dashboard
+        Then the "Delivery" dashboard displays in view mode
 
     @nonmutating
     Scenario: An error occurs while saving a dashboard that I don't have access to

--- a/cypress/integration/ui/error_scenarios/error_while_show_description.js
+++ b/cypress/integration/ui/error_scenarios/error_while_show_description.js
@@ -1,6 +1,20 @@
 import { When, Then } from 'cypress-cucumber-preprocessor/steps'
+import { getApiBaseUrl } from '../../../support/server/utils'
 
 // Error scenario
+
+before(() => {
+    //first ensure that the description is not currently shown
+    cy.request({
+        method: 'PUT',
+        url: `${getApiBaseUrl()}/api/userDataStore/dashboard/showDescription`,
+        headers: {
+            'content-type': 'application/json',
+        },
+        body: 'false',
+    }).then(response => expect(response.status).to.equal(201))
+})
+
 When('clicking to show description fails', () => {
     cy.intercept('PUT', 'userDataStore/dashboard/showDescription', {
         statusCode: 409,

--- a/src/components/ControlBar/ViewControlBar/DashboardsBar.js
+++ b/src/components/ControlBar/ViewControlBar/DashboardsBar.js
@@ -106,6 +106,11 @@ DashboardsBar.propTypes = {
     onExpandedChanged: PropTypes.func,
 }
 
+DashboardsBar.defaultProps = {
+    expanded: false,
+    onExpandedChanged: Function.prototype,
+}
+
 const mapStateToProps = state => ({
     userRows: sGetControlBarUserRows(state),
 })


### PR DESCRIPTION
Fixed scenario:
User navigates to non-existing dashboard (i.e., bad uid). Then user clicks on a dashboard chip for a different dashboard.  App crashes because onExpandedChanged did not exist.