### PR TITLE
fix: use correct plugin for active type when resizing

### DIFF
--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -136,7 +136,11 @@ export class Item extends Component {
                 )
             }
             // call resize on Map item
-            pluginResize(this.props.item, this.state.isFullscreen)
+            pluginResize(
+                this.props.item.id,
+                this.getActiveType(),
+                this.state.isFullscreen
+            )
         }
     }
 
@@ -152,7 +156,12 @@ export class Item extends Component {
                     !!document.fullscreenElement ||
                     !!document.webkitFullscreenElement,
             },
-            () => pluginResize(this.props.item, this.state.isFullscreen)
+            () =>
+                pluginResize(
+                    this.props.item.id,
+                    this.getActiveType(),
+                    this.state.isFullscreen
+                )
         )
     }
 
@@ -197,7 +206,8 @@ export class Item extends Component {
             return (
                 height -
                 this.headerRef.current.clientHeight -
-                this.itemHeaderTotalMargin
+                this.itemHeaderTotalMargin -
+                this.itemContentPadding
             )
         }
 

--- a/src/components/Item/VisualizationItem/Visualization/plugin.js
+++ b/src/components/Item/VisualizationItem/Visualization/plugin.js
@@ -65,11 +65,11 @@ export const load = async (
     loadPlugin(plugin, config, credentials)
 }
 
-export const resize = (item, isFullscreen) => {
-    const plugin = getPlugin(item.type)
+export const resize = (id, type, isFullscreen = false) => {
+    const plugin = getPlugin(type)
 
-    if (plugin && plugin.resize) {
-        plugin.resize(getGridItemDomId(item.id), isFullscreen)
+    if (plugin?.resize) {
+        plugin.resize(getGridItemDomId(id), isFullscreen)
     }
 }
 

--- a/src/components/ItemGrid/EditItemGrid.js
+++ b/src/components/ItemGrid/EditItemGrid.js
@@ -64,7 +64,7 @@ const EditItemGrid = ({
 
         // call resize on the item component if it's a plugin type
         if (dashboardItem && isVisualizationType(dashboardItem)) {
-            pluginResize(dashboardItem)
+            pluginResize(dashboardItem.id, dashboardItem.type)
         }
     }
 


### PR DESCRIPTION
Fixes issue where switching view type, then activating fullscreen didn't present the visualization in fullscreen. Particular case when a chart or table was switched to map.

Fixed:

https://user-images.githubusercontent.com/6113918/110627192-f0868e80-81a1-11eb-9e06-23081706af00.mov

