### PR TITLE
fix: disable cypress test for restrict filters until the whole suite is fixed

### DIFF
--- a/cypress/integration/ui/filter_restrict.feature
+++ b/cypress/integration/ui/filter_restrict.feature
@@ -1,11 +1,11 @@
 Feature: Editing Filter Restrictions
 
-    @mutating
-    Scenario: I create a new dashboard and have no Filter Restrictions
-        Given I choose to create new dashboard
-        And I add a dashboard title
-        And I click on Filter settings
-        Then Filter settings are not restricted, and I can save the dashboard
+# @mutating
+# Scenario: I create a new dashboard and have no Filter Restrictions
+#     Given I choose to create new dashboard
+#     And I add a dashboard title
+#     And I click on Filter settings
+#     Then Filter settings are not restricted, and I can save the dashboard
 
 # @nonmutating
 # Scenario: I change Filter Restrictions, do not confirm them, and the restrictions remain unchanged when I click back


### PR DESCRIPTION
This test is resulting in a lot of new dashboards on the test instance, which eventually causes the other test runs to fail.