### PR TITLE
fix: upgrade to @dhis2/cli-app-scripts@6 (DHIS2-9893)

### DIFF
--- a/d2.config.js
+++ b/d2.config.js
@@ -1,11 +1,11 @@
 const config = {
-    name: 'dashboard',
     type: 'app',
-    coreApp: true,
+    name: 'dashboard',
     title: 'Dashboard',
+    coreApp: true,
 
     entryPoints: {
-        app: './src/AppWrapper',
+        app: './src/AppWrapper.js',
     },
 }
 

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-03-10T13:31:54.830Z\n"
-"PO-Revision-Date: 2021-03-10T13:31:54.830Z\n"
+"POT-Creation-Date: 2021-03-11T18:02:28.225Z\n"
+"PO-Revision-Date: 2021-03-11T18:02:28.225Z\n"
 
 msgid "Untitled dashboard"
 msgstr ""
@@ -171,7 +171,13 @@ msgstr ""
 msgid "View as Chart"
 msgstr ""
 
+msgid "This map can't be displayed as a chart"
+msgstr ""
+
 msgid "View as Table"
+msgstr ""
+
+msgid "This map can't be displayed as a table"
 msgstr ""
 
 msgid "View as Map"

--- a/package.json
+++ b/package.json
@@ -6,16 +6,16 @@
     "license": "BSD-3-Clause",
     "dependencies": {
         "@dhis2/analytics": "^16.0.13",
-        "@dhis2/app-runtime": "^2.7.0",
+        "@dhis2/app-runtime": "^2.8.0",
         "@dhis2/app-runtime-adapter-d2": "^1.0.2",
-        "@dhis2/d2-i18n": "^1.0.6",
+        "@dhis2/d2-i18n": "^1.1.0",
         "@dhis2/d2-ui-core": "^7.1.6",
         "@dhis2/d2-ui-interpretations": "^7.1.6",
         "@dhis2/d2-ui-mentions-wrapper": "^7.1.6",
         "@dhis2/d2-ui-rich-text": "^7.1.6",
         "@dhis2/d2-ui-sharing-dialog": "^7.1.6",
         "@dhis2/d2-ui-translation-dialog": "^7.1.6",
-        "@dhis2/data-visualizer-plugin": "^35.20.16",
+        "@dhis2/data-visualizer-plugin": "^35.20.17",
         "@dhis2/ui": "^6.5.5",
         "@material-ui/core": "^3.9.2",
         "@material-ui/icons": "^4.9.1",
@@ -53,7 +53,7 @@
         "cy:capture": "cypress_dhis2_api_stub_mode=CAPTURE yarn d2-utils-cypress run --appStart 'yarn cypress:start'"
     },
     "devDependencies": {
-        "@dhis2/cli-app-scripts": "^5",
+        "@dhis2/cli-app-scripts": "^6.0.0",
         "@dhis2/cli-style": "^7.2.2",
         "@dhis2/cli-utils-cypress": "^7.0.0",
         "@dhis2/cypress-commands": "^5.1.1",
@@ -76,9 +76,5 @@
         "moduleNameMapper": {
             "^.+\\.(css|sass|scss)$": "identity-obj-proxy"
         }
-    },
-    "resolutions": {
-        "@dhis2/ui": "^6.5.5",
-        "styled-jsx": "3.3.2"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1529,7 +1529,7 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@dhis2/analytics@^16.0.11", "@dhis2/analytics@^16.0.13":
+"@dhis2/analytics@^16.0.13":
   version "16.0.13"
   resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-16.0.13.tgz#2be86f4734d52d1416262a1007c3ffb7d42bfc59"
   integrity sha512-qhjrhDrtm+fMZwLdqvPTT1yfsUQLbgkXuydahwDL30/W+DRWEDlHkoXhb+5aLQHyRRQr8DOHA8IxRT8DLhWCeQ==
@@ -1549,10 +1549,10 @@
     react-beautiful-dnd "^10.1.1"
     resize-observer-polyfill "^1.5.1"
 
-"@dhis2/app-adapter@5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-adapter/-/app-adapter-5.7.0.tgz#ff368e633840ab069830d76b5782217de10076fa"
-  integrity sha512-VGCjL77J8ppUJgHHCbLc1VpiOsBIhwUXuYZ/rvJDLbvirJwfxemEe9rGaBYphqr2p6RM1NV9gBwSFNqbop27ng==
+"@dhis2/app-adapter@6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-adapter/-/app-adapter-6.0.0.tgz#9d9c5120ab77020a8146dbcb3dff215dd76f1099"
+  integrity sha512-PcsBJWwmeRP2KcDbmTaOZ/meRPnMA7aME94ixpuOMYyl2+G3kx0v/SPc1DBM0FSjmliUfseVIMHyqwEuegj4jg==
   dependencies:
     moment "^2.24.0"
 
@@ -1564,41 +1564,41 @@
     "@dhis2/ui-core" "^4.6.1"
     prop-types "^15.7.2"
 
-"@dhis2/app-runtime@^2.6.1", "@dhis2/app-runtime@^2.7.0":
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-runtime/-/app-runtime-2.7.0.tgz#66f383a85f3c937c94d6e47375eddb673e7b5e47"
-  integrity sha512-VAe0YyzMC93md/Cx6lQ5UyqMAD0/SqUAMHHLfPDW7qrun/dWaeQjCV4cmipOgpL7QQKpkoq+E7okfvuYWIe3Yg==
+"@dhis2/app-runtime@^2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-runtime/-/app-runtime-2.8.0.tgz#83ca6e96c299686ee72eea3e1825e04aa53cd5d2"
+  integrity sha512-Ru6x9L61fD7ITzVaxFqx88kV5/ypB9xSr8nHgRj4EE/kHl/aVejXuwnSS2OIWh80J3mtD1dpNRN/GJ8o0x0HYg==
   dependencies:
-    "@dhis2/app-service-alerts" "2.7.0"
-    "@dhis2/app-service-config" "2.7.0"
-    "@dhis2/app-service-data" "2.7.0"
+    "@dhis2/app-service-alerts" "2.8.0"
+    "@dhis2/app-service-config" "2.8.0"
+    "@dhis2/app-service-data" "2.8.0"
 
-"@dhis2/app-service-alerts@2.7.0":
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-service-alerts/-/app-service-alerts-2.7.0.tgz#08657728797696e488439d88d84ca8b1578bf38a"
-  integrity sha512-D95z/RrAlNrTaUCPBlvKWRm+F0mG/nguxWOole/XTshNNnlLU41rP9QShcZqqKy88GuNBP0bq/DmuZHM8eBwXA==
+"@dhis2/app-service-alerts@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-service-alerts/-/app-service-alerts-2.8.0.tgz#f480043a15b5a2b7d90a6e74931ddd3ebb65aa1c"
+  integrity sha512-hpMqdxCG9w5H2EZyLPQKcKzCdp/Sof68ZGd85lNHo+1c10+1pWhKAjt/p3zoRllHppp17TbEgKoXa1oRx2NeHg==
 
-"@dhis2/app-service-config@2.7.0":
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-service-config/-/app-service-config-2.7.0.tgz#6579575b6481bcc95e346c70a912c6a3611eacf9"
-  integrity sha512-MT80E+OtHN8c/OotpjVL37UJIclid4hlmMwmueuDyIgP0EDsf3qzRR/MdjsCBuOeja2xuZpV/ivKu6/GWbQDPQ==
+"@dhis2/app-service-config@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-service-config/-/app-service-config-2.8.0.tgz#4ce7520e28a7700fa11ad7bcba6468a0a58751a4"
+  integrity sha512-SZnoa2EjsgV8a1QfnSk6fqxORV3pRcA+SYyz/H/nkr/VodkdgmO5CiwlZxXW8pG+4i6sbMGjGualam2jHF34wg==
 
-"@dhis2/app-service-data@2.7.0":
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-service-data/-/app-service-data-2.7.0.tgz#adf6f2ec8e7add19b97107309d7f35f67f2c4ffd"
-  integrity sha512-dkjKAeJ6zR0dszjgeWc5035wQ8QEJI0PH3cGoNwzV92m+YgIG7g4Wu0qDpzw6n2y+xZmeHl/iiH27Zq5eL/clg==
+"@dhis2/app-service-data@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-service-data/-/app-service-data-2.8.0.tgz#9cd347127968cb6f3c8a4ab0fc6699ea7058f835"
+  integrity sha512-5doyL4bxRMdMXY4RtWo2O3NVGwSDOSUY3hGPXaF1TeFWAqujlPTx17uDw6wEelN6LaryAnVwId2Ep3FOV8v5MA==
 
-"@dhis2/app-shell@5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-shell/-/app-shell-5.7.0.tgz#353fb6f5661c4709435db6d50b6ee0014087c1d2"
-  integrity sha512-ml5x+AKOYfQuX8Dy+VEOmjfirbsX8pxlgmrDUBui2GCq1p1Mzewl6X8AvVt7k51NwkpSA+Tdfy7lnyovBO8xPg==
+"@dhis2/app-shell@6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-shell/-/app-shell-6.0.0.tgz#3d9d9c5fb13dbf8b0887a38d10e543ab257f2af3"
+  integrity sha512-WpKBQHjRB2Kz6FKcLmoBTlgnouTA/154anVq8MXO1iHLhil49i7y5Ina9mEecBygM4enj9Nd4no51n187hkMVQ==
   dependencies:
-    "@dhis2/app-adapter" "5.7.0"
-    "@dhis2/app-runtime" "^2.6.1"
-    "@dhis2/d2-i18n" "^1.0.5"
-    "@dhis2/ui" "^5.7.2"
+    "@dhis2/app-adapter" "6.0.0"
+    "@dhis2/app-runtime" "^2.8.0"
+    "@dhis2/d2-i18n" "^1.1.0"
+    "@dhis2/ui" "^6.5.3"
     classnames "^2.2.6"
-    moment "^2.24.0"
+    moment "^2.29.1"
     prop-types "^15.7.2"
     react "^16.8.6"
     react-dom "^16.8.6"
@@ -1608,10 +1608,10 @@
     typeface-roboto "^0.0.75"
     typescript "^3.6.3"
 
-"@dhis2/cli-app-scripts@^5":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/cli-app-scripts/-/cli-app-scripts-5.7.0.tgz#f12afa01a17ecb0c140348a4f6a53300bdb28d81"
-  integrity sha512-JYUisJIxs3KZQodeNrsx9iUTDd0yfANvP5YbHNozl164Ti+TUzrk5HspUzdf7GVBIA/AQcv+HXEyJJwzXI+mRQ==
+"@dhis2/cli-app-scripts@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/cli-app-scripts/-/cli-app-scripts-6.0.0.tgz#1d44755db364851a1b0068ab5a73efccba533b21"
+  integrity sha512-QvMjsjt0wBMZ8nmA2+d8SBOztBlvo3ftk5UmUjq+kwTSqD5QwUxADK7LfGptYgH3V4WT9CiCgWEuV+bDdD5iCQ==
   dependencies:
     "@babel/core" "^7.6.2"
     "@babel/plugin-proposal-class-properties" "^7.8.3"
@@ -1620,7 +1620,7 @@
     "@babel/preset-env" "^7.9.0"
     "@babel/preset-react" "^7.0.0"
     "@babel/preset-typescript" "^7.6.0"
-    "@dhis2/app-shell" "5.7.0"
+    "@dhis2/app-shell" "6.0.0"
     "@dhis2/cli-helpers-engine" "^2.1.1"
     archiver "^3.1.1"
     axios "^0.20.0"
@@ -1727,10 +1727,10 @@
   dependencies:
     jscodeshift "^0.11.0"
 
-"@dhis2/d2-i18n@^1.0.5", "@dhis2/d2-i18n@^1.0.6":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n/-/d2-i18n-1.0.6.tgz#2914be8acf296f3a6bf7b51c76c46da6a120b0ff"
-  integrity sha512-7YdA4ppFosjuyf7ZMm47BrdsA5TWLM9lmS0lUPgjcCVeeWfUgagqzf4W5JGB9XQ3w1vzK+yy5zH2Ij8IgRAGhA==
+"@dhis2/d2-i18n@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n/-/d2-i18n-1.1.0.tgz#ec777c5091f747e4c5aa4f9801c62ba4d1ef3d16"
+  integrity sha512-x3u58goDQsMfBzy50koxNrJjofJTtjRZOfz6f6Py/wMMJfp/T6vZjWMQgcfWH0JrV6d04K1RTt6bI05wqsVQvg==
   dependencies:
     i18next "^10.3"
     moment "^2.24.0"
@@ -1869,13 +1869,15 @@
     react-select "^2.0.0"
     rxjs "^5.5.7"
 
-"@dhis2/data-visualizer-plugin@^35.20.16":
-  version "35.20.16"
-  resolved "https://registry.yarnpkg.com/@dhis2/data-visualizer-plugin/-/data-visualizer-plugin-35.20.16.tgz#45034d45f148057c2ab9c83df1ea0595c18a22fe"
-  integrity sha512-S5SbwODj8MNo1S6ckuTA4qkPMyS51J8+9Hi95rBebPRLRrNPipeZFJTcWxjBR407GZXj1ge0R2XKNINnwekPMg==
+"@dhis2/data-visualizer-plugin@^35.20.17":
+  version "35.20.17"
+  resolved "https://registry.yarnpkg.com/@dhis2/data-visualizer-plugin/-/data-visualizer-plugin-35.20.17.tgz#5c63dfd2e4b5cff9342a705495556d115af4b758"
+  integrity sha512-pm+a6LQa/v+YfuKTWJOjJPaLEgZ3gjb1e/TTgIfk4DgT7Za2l7OA6S+ZvqPjLkJwRD0FyXHfh7cFqwHXnwZCXg==
   dependencies:
-    "@dhis2/analytics" "^16.0.11"
-    "@dhis2/ui" "^6.5.1"
+    "@dhis2/analytics" "^16.0.13"
+    "@dhis2/app-runtime" "^2.8.0"
+    "@dhis2/d2-i18n" "^1.1.0"
+    "@dhis2/ui" "^6.5.5"
     lodash-es "^4.17.11"
 
 "@dhis2/prop-types@^1.6.4":
@@ -1939,7 +1941,7 @@
     "@dhis2/prop-types" "^1.6.4"
     classnames "^2.2.6"
 
-"@dhis2/ui@^5.7.2", "@dhis2/ui@^6.5.1", "@dhis2/ui@^6.5.5":
+"@dhis2/ui@^6.5.3", "@dhis2/ui@^6.5.5":
   version "6.5.5"
   resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-6.5.5.tgz#42ea27c8a22efb0059985cb8ec07a3dfca0241f9"
   integrity sha512-eB2hhhPYnEPwCIXxThBwpYg8WG+pUh2XEGXEV6qOPdbFUGlWQ9qLEPpDkn/WgXjRf10btkiwkKdnDbhazDJJUw==


### PR DESCRIPTION
Part of [DHIS2-9893](https://jira.dhis2.org/browse/DHIS2-9893)

Upgrades ui, cli-app-scripts, app-runtime, d2-i18n, and analytics

Tree shaking combined with lazy plugin loading gives us a savings of 1.5MB (!!!!) javascript payload (gzipped) when no EV or ER plugins are present.  Those add another ~1MB though.

Maps plugin slimming will increase the benefit here as well.

Before
![Screen Shot 2021-03-11 at 19 10 48](https://user-images.githubusercontent.com/947888/110836149-024e5b80-82a0-11eb-9444-e81e07bee1d9.png)

After
![Screen Shot 2021-03-11 at 19 10 41](https://user-images.githubusercontent.com/947888/110836130-fe223e00-829f-11eb-9fc1-2599d7da6801.png)

---

The initial render-blocking load (before plugin code is fetched) is reduced from 3.1MB gzipped 🥴   to just 547kb 🎉  -- still too much and we should look into non-js bloat but MUCH improved!

Before
![Screen Shot 2021-03-11 at 19 36 30](https://user-images.githubusercontent.com/947888/110837245-468e2b80-82a1-11eb-8e21-f4d3ea4acd05.png)

After
![Screen Shot 2021-03-11 at 19 35 58](https://user-images.githubusercontent.com/947888/110837252-4857ef00-82a1-11eb-9f63-a0ac813f03c1.png)