### PR TITLE
chore: update base url for cypress e2e tests

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -145,8 +145,8 @@ jobs:
                   SERVER_START_CMD: 'yarn cypress:start'
                   SERVER_URL: 'http://localhost:3000'
                   cypress_dhis2_api_stub_mode: 'DISABLED'
-                  REACT_APP_DHIS2_BASE_URL: ${{ secrets.CYPRESS_DHIS2_BASE_URL }}
-                  cypress_dhis2_base_url: ${{ secrets.CYPRESS_DHIS2_BASE_URL }}
+                  REACT_APP_DHIS2_BASE_URL: ${{ secrets.CYPRESS_DHIS2_BASE_URL_36 }}
+                  cypress_dhis2_base_url: ${{ secrets.CYPRESS_DHIS2_BASE_URL_36 }}
                   cypress_dhis2_username: ${{ secrets.CYPRESS_DHIS2_USERNAME }}
                   cypress_dhis2_password: ${{ secrets.CYPRESS_DHIS2_PASSWORD }}
 


### PR DESCRIPTION
Run cypress tests against a 2.36 instance