### PR TITLE
fix: do not request current dashboard when NEW route

### DIFF
--- a/src/components/Dashboard/Dashboard.js
+++ b/src/components/Dashboard/Dashboard.js
@@ -86,7 +86,7 @@ const Dashboard = ({
     }, [mode])
 
     useEffect(() => {
-        if (dashboardsLoaded && !dashboardsIsEmpty) {
+        if (dashboardsLoaded && !dashboardsIsEmpty && mode !== NEW) {
             selectDashboard(routeId, mode)
         }
     }, [dashboardsLoaded, dashboardsIsEmpty, routeId, mode])


### PR DESCRIPTION
The route handler was unnecessarily fetching the current dashboard again before displaying Edit mode. 

Note that with the current solution, the `visualizations` property in the redux store will contain the visualizations of the dashboard that was active before going to NEW, as well as any visualizations that get added to the new dashboard. This won't have any impact on the app. In past versions, visualizations were never cleared from redux so that property potentially had visualizations for many dashboards. Now, visualizations are cleared whenever user switches dashboard with the chips.

This process is up for refactoring at the next opportunity. For now, the current fix should do the job of removing the unnecessary api request.
