### PR TITLE
fix: avoid double rendering of chart visualizations

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "@dhis2/d2-ui-rich-text": "^7.1.6",
         "@dhis2/d2-ui-sharing-dialog": "^7.1.6",
         "@dhis2/d2-ui-translation-dialog": "^7.1.6",
-        "@dhis2/data-visualizer-plugin": "^35.20.19",
+        "@dhis2/data-visualizer-plugin": "^35.20.20",
         "@dhis2/ui": "^6.5.5",
         "@material-ui/core": "^3.9.2",
         "@material-ui/icons": "^4.9.1",

--- a/src/components/Item/VisualizationItem/Visualization/DataVisualizerPlugin.js
+++ b/src/components/Item/VisualizationItem/Visualization/DataVisualizerPlugin.js
@@ -1,6 +1,5 @@
-import React, { Suspense, useState } from 'react'
+import React, { Suspense, useState, useCallback } from 'react'
 import PropTypes from 'prop-types'
-import { useD2 } from '@dhis2/app-runtime-adapter-d2'
 import { useUserSettings } from '../../../UserSettingsProvider'
 import LoadingMask from './LoadingMask'
 
@@ -11,20 +10,21 @@ const VisualizationPlugin = React.lazy(() =>
 )
 
 const DataVisualizerPlugin = props => {
-    const d2 = useD2()
     const { userSettings } = useUserSettings()
     const [visualizationLoaded, setVisualizationLoaded] = useState(false)
+
+    const onLoadingComplete = useCallback(
+        () => setVisualizationLoaded(true),
+        []
+    )
 
     return (
         <Suspense fallback={<div />}>
             {!visualizationLoaded && <LoadingMask style={props.style} />}
             <VisualizationPlugin
-                d2={d2}
                 forDashboard={true}
-                userSettings={{
-                    displayProperty: userSettings.keyAnalysisDisplayProperty,
-                }}
-                onLoadingComplete={() => setVisualizationLoaded(true)}
+                userSettings={userSettings}
+                onLoadingComplete={onLoadingComplete}
                 {...props}
             />
         </Suspense>

--- a/src/components/UserSettingsProvider.js
+++ b/src/components/UserSettingsProvider.js
@@ -15,7 +15,10 @@ const UserSettingsProvider = ({ children }) => {
                 userSettings: userSettingsQuery,
             })
 
-            setSettings(userSettings)
+            setSettings({
+                ...userSettings,
+                displayProperty: userSettings.keyAnalysisDisplayProperty,
+            })
         }
         fetchData()
     }, [])

--- a/yarn.lock
+++ b/yarn.lock
@@ -1869,10 +1869,10 @@
     react-select "^2.0.0"
     rxjs "^5.5.7"
 
-"@dhis2/data-visualizer-plugin@^35.20.19":
-  version "35.20.19"
-  resolved "https://registry.yarnpkg.com/@dhis2/data-visualizer-plugin/-/data-visualizer-plugin-35.20.19.tgz#4cb2d00494e638d77d177831b67185eee9e4b8c7"
-  integrity sha512-Ozf/IHmABTjdTPmjMxAzvIqntn4LzjzvZ913p/EGWXCTIV1ecqT7ZQGQ3rJ3sEAd4zuoHZwb3wI45Ayc8OPXjQ==
+"@dhis2/data-visualizer-plugin@^35.20.20":
+  version "35.20.20"
+  resolved "https://registry.yarnpkg.com/@dhis2/data-visualizer-plugin/-/data-visualizer-plugin-35.20.20.tgz#1b1d9be10c5ac151ad6384c501386803b2bfc01d"
+  integrity sha512-RFhmmSTzIXyUpXXOEF9JaOWqgxsqnzx0U1vm62k59WZwmtW2Iw3SNNWsOTj+69Te52+qFma/CmJVbrLbhiyxbw==
   dependencies:
     "@dhis2/analytics" "^16.0.15"
     "@dhis2/app-runtime" "^2.8.0"


### PR DESCRIPTION
Requires: https://github.com/dhis2/data-visualizer-app/pull/1665

A few issues caused the double rendering of chart visualizations, which causes all the code for generating Highcharts config to run twice.
This is a problem especially for some chart types and options (scatter with outliers detection) which needs expensive computation.

* 2 props passed to `VisualizationPlugin` were not the same on subsequent rendering of the parent component, causing unwanted rendering and triggering effects
* the `id` prop is not passed to `VisualizationPlugin` and assumed `undefined` value, triggering a re-render in an effect which checks if `id` is different than `null` (the fix for this is in DV plugin, see PR linked above)