### PR TITLE
chore: move showDescription to root of redux structure

### DIFF
--- a/src/actions/selected.js
+++ b/src/actions/selected.js
@@ -1,7 +1,6 @@
 import {
     SET_SELECTED_ID,
     SET_SELECTED_ISLOADING,
-    SET_SELECTED_SHOWDESCRIPTION,
     SET_SELECTED_ITEM_ACTIVE_TYPE,
     CLEAR_SELECTED_ITEM_ACTIVE_TYPES,
     NON_EXISTING_DASHBOARD_ID,
@@ -19,8 +18,6 @@ import {
     getPreferredDashboardId,
     storePreferredDashboardId,
 } from '../modules/localStorage'
-import { apiGetShowDescription } from '../api/description'
-
 import { withShape } from '../modules/gridUtil'
 import { getCustomDashboards } from '../modules/getCustomDashboards'
 
@@ -35,11 +32,6 @@ export const acSetSelectedId = value => ({
 
 export const acSetSelectedIsLoading = value => ({
     type: SET_SELECTED_ISLOADING,
-    value,
-})
-
-export const acSetSelectedShowDescription = value => ({
-    type: SET_SELECTED_SHOWDESCRIPTION,
     value,
 })
 
@@ -103,18 +95,4 @@ export const tSetSelectedDashboardById = (requestedId, mode, username) => (
             console.error('Error: ', err)
             return err
         })
-}
-
-export const tSetShowDescription = () => async dispatch => {
-    const onSuccess = value => {
-        dispatch(acSetSelectedShowDescription(value))
-    }
-
-    try {
-        const showDescription = await apiGetShowDescription()
-        return onSuccess(showDescription)
-    } catch (err) {
-        console.error('Error (apiGetShowDescription): ', err)
-        return err
-    }
 }

--- a/src/actions/showDescription.js
+++ b/src/actions/showDescription.js
@@ -1,0 +1,21 @@
+import { SET_SHOW_DESCRIPTION } from '../reducers/showDescription'
+import { apiGetShowDescription } from '../api/description'
+
+export const acSetShowDescription = value => ({
+    type: SET_SHOW_DESCRIPTION,
+    value,
+})
+
+export const tSetShowDescription = () => async dispatch => {
+    const onSuccess = value => {
+        dispatch(acSetShowDescription(value))
+    }
+
+    try {
+        const showDescription = await apiGetShowDescription()
+        return onSuccess(showDescription)
+    } catch (err) {
+        console.error('Error (apiGetShowDescription): ', err)
+        return err
+    }
+}

--- a/src/api/description.js
+++ b/src/api/description.js
@@ -2,14 +2,14 @@ import {
     apiGetUserDataStoreValue,
     apiPostUserDataStoreValue,
 } from './userDataStore'
-import { DEFAULT_STATE_SELECTED_SHOWDESCRIPTION } from '../reducers/selected'
+import { DEFAULT_STATE_SHOW_DESCRIPTION } from '../reducers/showDescription'
 
 const KEY_SHOW_DESCRIPTION = 'showDescription'
 
 export const apiGetShowDescription = async () =>
     await apiGetUserDataStoreValue(
         KEY_SHOW_DESCRIPTION,
-        DEFAULT_STATE_SELECTED_SHOWDESCRIPTION
+        DEFAULT_STATE_SHOW_DESCRIPTION
     )
 
 export const apiPostShowDescription = value =>

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -6,7 +6,7 @@ import Dashboard from './Dashboard'
 
 import { tFetchDashboards } from '../actions/dashboards'
 import { tSetControlBarRows } from '../actions/controlBar'
-import { tSetShowDescription } from '../actions/selected'
+import { tSetShowDescription } from '../actions/showDescription'
 
 import { EDIT, VIEW, NEW, PRINT, PRINT_LAYOUT } from '../modules/dashboardModes'
 

--- a/src/components/Item/PrintTitlePageItem/Item.js
+++ b/src/components/Item/PrintTitlePageItem/Item.js
@@ -3,10 +3,8 @@ import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import i18n from '@dhis2/d2-i18n'
 
-import {
-    sGetSelectedId,
-    sGetSelectedShowDescription,
-} from '../../../reducers/selected'
+import { sGetSelectedId } from '../../../reducers/selected'
+import { sGetShowDescription } from '../../../reducers/showDescription'
 import {
     sGetDashboardById,
     EMPTY_DASHBOARD,
@@ -84,7 +82,7 @@ const mapStateToProps = state => {
         name,
         description,
         itemFilters: sGetNamedItemFilters(state),
-        showDescription: sGetSelectedShowDescription(state),
+        showDescription: sGetShowDescription(state),
     }
 }
 

--- a/src/pages/view/TitleBar.js
+++ b/src/pages/view/TitleBar.js
@@ -23,13 +23,11 @@ import { apiStarDashboard } from './starDashboard'
 import { apiPostShowDescription } from '../../api/description'
 
 import { acSetDashboardStarred } from '../../actions/dashboards'
-import { acSetSelectedShowDescription } from '../../actions/selected'
+import { acSetShowDescription } from '../../actions/showDescription'
 import FilterSelector from './ItemFilter/FilterSelector'
 import DropdownButton from '../../components/DropdownButton/DropdownButton'
-import {
-    sGetSelectedId,
-    sGetSelectedShowDescription,
-} from '../../reducers/selected'
+import { sGetSelectedId } from '../../reducers/selected'
+import { sGetShowDescription } from '../../reducers/showDescription'
 import {
     sGetDashboardById,
     sGetDashboardItems,
@@ -276,7 +274,7 @@ const mapStateToProps = state => {
         name: dashboard.displayName,
         description: dashboard.displayDescription,
         dashboardItems: sGetDashboardItems(state),
-        showDescription: sGetSelectedShowDescription(state),
+        showDescription: sGetShowDescription(state),
         starred: dashboard.starred,
         access: dashboard.access,
         restrictFilters: dashboard.restrictFilters,
@@ -286,5 +284,5 @@ const mapStateToProps = state => {
 
 export default connect(mapStateToProps, {
     setDashboardStarred: acSetDashboardStarred,
-    updateShowDescription: acSetSelectedShowDescription,
+    updateShowDescription: acSetShowDescription,
 })(ViewTitleBar)

--- a/src/reducers/__tests__/selected.spec.js
+++ b/src/reducers/__tests__/selected.spec.js
@@ -1,7 +1,6 @@
 import reducer, {
     SET_SELECTED_ID,
     SET_SELECTED_ISLOADING,
-    SET_SELECTED_SHOWDESCRIPTION,
     SET_SELECTED_ITEM_ACTIVE_TYPE,
     CLEAR_SELECTED_ITEM_ACTIVE_TYPES,
     DEFAULT_STATE_SELECTED_ITEM_ACTIVE_TYPES,
@@ -11,7 +10,6 @@ describe('selected dashboard reducer', () => {
     const defaultState = {
         id: null,
         isLoading: false,
-        showDescription: false,
         itemActiveTypes: {},
     }
 
@@ -36,20 +34,6 @@ describe('selected dashboard reducer', () => {
         const actualState = reducer(defaultState, {
             type: SET_SELECTED_ISLOADING,
             value: isLoading,
-        })
-
-        expect(actualState).toEqual(expectedState)
-    })
-
-    it('sets the selected dashboard showDescription state', () => {
-        const showDescription = true
-        const expectedState = Object.assign({}, defaultState, {
-            showDescription,
-        })
-
-        const actualState = reducer(defaultState, {
-            type: SET_SELECTED_SHOWDESCRIPTION,
-            value: showDescription,
         })
 
         expect(actualState).toEqual(expectedState)

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -12,6 +12,7 @@ import itemFilters from './itemFilters'
 import dimensions from './dimensions'
 import activeModalDimension from './activeModalDimension'
 import passiveViewRegistered from './passiveViewRegistered'
+import showDescription from './showDescription'
 
 export default combineReducers({
     dashboards,
@@ -26,4 +27,5 @@ export default combineReducers({
     dimensions,
     activeModalDimension,
     passiveViewRegistered,
+    showDescription,
 })

--- a/src/reducers/selected.js
+++ b/src/reducers/selected.js
@@ -5,14 +5,12 @@ import { validateReducer } from '../modules/util'
 
 export const SET_SELECTED_ID = 'SET_SELECTED_ID'
 export const SET_SELECTED_ISLOADING = 'SET_SELECTED_ISLOADING'
-export const SET_SELECTED_SHOWDESCRIPTION = 'SET_SELECTED_SHOWDESCRIPTION'
 export const SET_SELECTED_ITEM_ACTIVE_TYPE = 'SET_SELECTED_ITEM_ACTIVE_TYPE'
 export const CLEAR_SELECTED_ITEM_ACTIVE_TYPES =
     'CLEAR_SELECTED_ITEM_ACTIVE_TYPES'
 
 export const DEFAULT_STATE_SELECTED_ID = null
 export const DEFAULT_STATE_SELECTED_ISLOADING = false
-export const DEFAULT_STATE_SELECTED_SHOWDESCRIPTION = false
 export const DEFAULT_STATE_SELECTED_ITEM_ACTIVE_TYPES = {}
 
 export const NON_EXISTING_DASHBOARD_ID = '0'
@@ -32,21 +30,6 @@ const isLoading = (state = DEFAULT_STATE_SELECTED_ISLOADING, action) => {
             return validateReducer(
                 action.value,
                 DEFAULT_STATE_SELECTED_ISLOADING
-            )
-        default:
-            return state
-    }
-}
-
-const showDescription = (
-    state = DEFAULT_STATE_SELECTED_SHOWDESCRIPTION,
-    action
-) => {
-    switch (action.type) {
-        case SET_SELECTED_SHOWDESCRIPTION:
-            return validateReducer(
-                action.value,
-                DEFAULT_STATE_SELECTED_SHOWDESCRIPTION
             )
         default:
             return state
@@ -75,7 +58,6 @@ const itemActiveTypes = (
 export default combineReducers({
     id,
     isLoading,
-    showDescription,
     itemActiveTypes,
 })
 
@@ -86,9 +68,6 @@ export const sGetSelectedRoot = state => state.selected
 export const sGetSelectedId = state => sGetSelectedRoot(state).id
 
 export const sGetSelectedIsLoading = state => sGetSelectedRoot(state).isLoading
-
-export const sGetSelectedShowDescription = state =>
-    sGetSelectedRoot(state).showDescription
 
 export const sGetSelectedItemActiveType = (state, id) =>
     sGetSelectedRoot(state).itemActiveTypes[id]

--- a/src/reducers/showDescription.js
+++ b/src/reducers/showDescription.js
@@ -1,0 +1,15 @@
+export const SET_SHOW_DESCRIPTION = 'SET_SHOW_DESCRIPTION'
+
+export const DEFAULT_STATE_SHOW_DESCRIPTION = false
+
+export default (state = DEFAULT_STATE_SHOW_DESCRIPTION, action) => {
+    switch (action.type) {
+        case SET_SHOW_DESCRIPTION: {
+            return action.value
+        }
+        default:
+            return state
+    }
+}
+
+export const sGetShowDescription = state => state.showDescription


### PR DESCRIPTION
`showDescription` has been stored within the redux property `selected` even though it has nothing to do with the selected dashboard (it is a user preference). Makes most sense to keep it at the root of the redux structure. This is also in preparation to needed changes to `selected` for the offline dashboard features