### PR TITLE
test: cypress - set showDescription to false before running tests that change the setting

### DIFF
--- a/cypress/integration/ui/edit_dashboard/show_description.js
+++ b/cypress/integration/ui/edit_dashboard/show_description.js
@@ -1,17 +1,17 @@
 import { When, Then } from 'cypress-cucumber-preprocessor/steps'
-// import { getApiBaseUrl } from '../../../support/server/utils'
+import { getApiBaseUrl } from '../../../support/server/utils'
 
-// TODO this request currently fails with 415 Unsupported media type
-// goal is to add this step
-// Given('the description is not shown', () => {
-//     cy.request(
-//         'PUT',
-//         `${getApiBaseUrl()}/api/userDataStore/dashboard/showDescription`,
-//         false
-//     ).then(response => {
-//         expect(response.status).to.equal(201)
-//     })
-// })
+before(() => {
+    //ensure that the description is not currently shown
+    cy.request({
+        method: 'PUT',
+        url: `${getApiBaseUrl()}/api/userDataStore/dashboard/showDescription`,
+        headers: {
+            'content-type': 'application/json',
+        },
+        body: 'false',
+    }).then(response => expect(response.status).to.equal(201))
+})
 
 When('I click to show description', () => {
     cy.intercept('PUT', 'userDataStore/dashboard/showDescription').as(

--- a/cypress/integration/ui/edit_dashboard/translate_dashboard.js
+++ b/cypress/integration/ui/edit_dashboard/translate_dashboard.js
@@ -10,6 +10,18 @@ import {
 let norwegianTitle = ''
 let norwegianDesc = ''
 
+beforeEach(() => {
+    //ensure that the description is not currently shown
+    cy.request({
+        method: 'PUT',
+        url: `${getApiBaseUrl()}/api/userDataStore/dashboard/showDescription`,
+        headers: {
+            'content-type': 'application/json',
+        },
+        body: 'false',
+    }).then(response => expect(response.status).to.equal(201))
+})
+
 When('I add translations for dashboard name and description', () => {
     const now = new Date().toUTCString()
     norwegianTitle = 'nor title ' + now


### PR DESCRIPTION
Cypress tests that check the description have been flaky and are causing a lot of headaches with the release pipeline.  By ensuring that showDescription is false before running tests that change that setting, these tests should become more stable.

Regarding the duplicated code, I am planning a refactor of the tests now that they've grown in number and patterns are starting to emerge. So the main objective for now is to stop the flakiness rather than worry about duplication.