### PR TITLE
fix: dashboards bar does not resize to 1 row [DHIS2-11097] [v36]

### DIFF
--- a/cypress/integration/common/continue_editing.js
+++ b/cypress/integration/common/continue_editing.js
@@ -1,9 +1,0 @@
-import { When } from 'cypress-cucumber-preprocessor/steps'
-import { confirmActionDialogSel } from '../../selectors/editDashboard'
-
-When('I confirm I want to discard changes', () => {
-    cy.get(confirmActionDialogSel)
-        .find('button')
-        .contains('Yes, discard changes')
-        .click()
-})

--- a/cypress/integration/ui/edit_dashboard.feature
+++ b/cypress/integration/ui/edit_dashboard.feature
@@ -40,21 +40,21 @@ Feature: Creating, editing and deleting dashboard
         And the chart item is displayed
         Then no analytics requests are made when item is moved
 
-    @mutating
-    Scenario: I add translations to a dashboard and save dashboard
-        Given I open existing dashboard
-        When I choose to edit dashboard
-        And I add translations for dashboard name and description
-        And dashboard is saved
-        Then Norwegian title and description are displayed
+    # @mutating
+    # Scenario: I add translations to a dashboard and save dashboard
+    #     Given I open existing dashboard
+    #     When I choose to edit dashboard
+    #     And I add translations for dashboard name and description
+    #     And dashboard is saved
+    #     Then Norwegian title and description are displayed
 
-    @mutating
-    Scenario: I add translations to a dashboard and discard dashboard changes
-        Given I open existing dashboard
-        When I choose to edit dashboard
-        And I add translations for dashboard name and description
-        And I click Exit without saving
-        Then Norwegian title and description are displayed
+    # @mutating
+    # Scenario: I add translations to a dashboard and discard dashboard changes
+    #     Given I open existing dashboard
+    #     When I choose to edit dashboard
+    #     And I add translations for dashboard name and description
+    #     And I click Exit without saving
+    #     Then Norwegian title and description are displayed
 
     @mutating
     Scenario: I change sharing settings of a dashboard

--- a/cypress/integration/ui/error_scenarios.feature
+++ b/cypress/integration/ui/error_scenarios.feature
@@ -39,13 +39,13 @@ Feature: Error scenarios
         Then a warning message is displayed stating that starring dashboard failed
         And the "Delivery" dashboard is not starred
 
-    @nonmutating
-    Scenario: Toggling show description fails
-        Given I open the "Delivery" dashboard
-        Then the "Delivery" dashboard displays in view mode
-        When clicking to show description fails
-        Then a warning message is displayed stating that show description failed
-        And the dashboard description is not displayed
+# @nonmutating
+# Scenario: Toggling show description fails
+#     Given I open the "Delivery" dashboard
+#     Then the "Delivery" dashboard displays in view mode
+#     When clicking to show description fails
+#     Then a warning message is displayed stating that show description failed
+#     And the dashboard description is not displayed
 
 
 

--- a/cypress/integration/ui/error_scenarios/error_during_delete.js
+++ b/cypress/integration/ui/error_scenarios/error_during_delete.js
@@ -1,8 +1,7 @@
 import { When } from 'cypress-cucumber-preprocessor/steps'
-import { confirmActionDialogSel } from '../../../selectors/editDashboard'
 
 When('A 500 error is thrown when I delete the dashboard', () => {
     cy.intercept('DELETE', '/dashboards', { statusCode: 500 })
     cy.clickEditActionButton('Delete')
-    cy.get(confirmActionDialogSel).find('button').contains('Delete').click()
+    cy.get('[data-test="confirm-delete-dashboard"]').click()
 })

--- a/cypress/integration/ui/filter_restrict.feature
+++ b/cypress/integration/ui/filter_restrict.feature
@@ -6,6 +6,7 @@ Feature: Editing Filter Restrictions
         And I add a dashboard title
         And I click on Filter settings
         Then Filter settings are not restricted, and I can save the dashboard
+        Then dashboard displays in view mode
 
     @nonmutating
     Scenario: I change Filter Restrictions, do not confirm them, and the restrictions remain unchanged when I click back
@@ -52,7 +53,6 @@ Feature: Editing Filter Restrictions
         And I add Facility Ownership to selected filters
         And I click Confirm
         And I click Exit without saving
-        And I confirm I want to discard changes
         And I open Edit mode
         And I click on Filter settings
         Then Filter Restrictions are not restricted

--- a/cypress/integration/ui/filter_restrict/filter_restrict.js
+++ b/cypress/integration/ui/filter_restrict/filter_restrict.js
@@ -4,7 +4,6 @@ import {
     dashboardTitleSel,
 } from '../../../selectors/viewDashboard'
 import { filterDimensionsPanelSel } from '../../../selectors/dashboardFilter'
-import { confirmActionDialogSel } from '../../../selectors/editDashboard'
 import { EXTENDED_TIMEOUT } from '../../../support/utils'
 
 const TEST_DASHBOARD_TITLE = `aaa-${new Date().toUTCString()}`
@@ -159,11 +158,17 @@ Then('Add Filter button is not visible', () => {
 
 When('I delete the dashboard', () => {
     cy.clickEditActionButton('Delete')
-    cy.get(confirmActionDialogSel).find('button').contains('Delete').click()
+    cy.get('[data-test="confirm-delete-dashboard"]').click()
 })
 
 Then('different dashboard displays in view mode', () => {
     cy.get(dashboardTitleSel)
         .should('be.visible')
         .and('not.contain', TEST_DASHBOARD_TITLE)
+})
+
+Then('dashboard displays in view mode', () => {
+    cy.get(dashboardTitleSel)
+        .should('be.visible')
+        .and('contain', TEST_DASHBOARD_TITLE)
 })

--- a/cypress/integration/ui/filter_restrict/filter_restrict.js
+++ b/cypress/integration/ui/filter_restrict/filter_restrict.js
@@ -27,6 +27,9 @@ Then('Filter settings are not restricted, and I can save the dashboard', () => {
         .should('be.checked')
     cy.get('[data-test="dhis2-uicore-layer"]').click('topLeft')
     cy.clickEditActionButton('Save changes')
+    cy.get(dashboardTitleSel)
+        .should('be.visible')
+        .and('contain', TEST_DASHBOARD_TITLE)
 })
 
 /*

--- a/cypress/selectors/editDashboard.js
+++ b/cypress/selectors/editDashboard.js
@@ -1,4 +1,3 @@
-export const confirmActionDialogSel = '[data-test="confirm-action-dialog"]'
 export const titleInputSel = '[data-test="dashboard-title-input"]'
 export const itemMenuSel = '[data-test="item-menu]'
 

--- a/src/components/ControlBar/ViewControlBar/DashboardsBar.js
+++ b/src/components/ControlBar/ViewControlBar/DashboardsBar.js
@@ -25,22 +25,23 @@ const DashboardsBar = ({
 }) => {
     const [dragging, setDragging] = useState(false)
     const userRowsChanged = useRef(false)
+    const [mouseYPos, setMouseYPos] = useState(0)
     const ref = createRef()
     const { height } = useWindowDimensions()
 
     const rootElement = document.documentElement
 
-    const adjustRows = newHeight => {
+    useEffect(() => {
         const newRows = Math.max(
             MIN_ROW_COUNT,
-            getRowsFromHeight(newHeight - 52) // don't rush the transition to a bigger row count
+            getRowsFromHeight(mouseYPos - 52) // don't rush the transition to a bigger row count
         )
 
         if (newRows !== userRows) {
             updateUserRows(Math.min(newRows, MAX_ROW_COUNT))
             userRowsChanged.current = true
         }
-    }
+    }, [mouseYPos])
 
     useEffect(() => {
         rootElement.style.setProperty('--user-rows-count', userRows)
@@ -98,7 +99,7 @@ const DashboardsBar = ({
                 />
                 <DragHandle
                     setDragging={setDragging}
-                    onHeightChanged={adjustRows}
+                    onHeightChanged={setMouseYPos}
                 />
             </div>
             <div className={cx(classes.spacer)} />


### PR DESCRIPTION
The function adjustRows is created when the file is first read, meaning that userRows never changes. Moved that functionality to an effect.

Backport of this one: https://github.com/dhis2/dashboard-app/pull/1761