### PR TITLE
chore: add a few cypress tests

### DIFF
--- a/cypress/integration/ui/error_scenarios.feature
+++ b/cypress/integration/ui/error_scenarios.feature
@@ -13,6 +13,27 @@ Feature: Error scenarios
         Then the "Delivery" dashboard displays in view mode
 
     @nonmutating
+    Scenario: I navigate to edit dashboard that doesn't exist
+        Given I type an invalid edit dashboard id in the browser url
+        Then a message displays informing that the dashboard is not found
+        When I open the "Delivery" dashboard
+        Then the "Delivery" dashboard displays in view mode
+
+    @nonmutating
+    Scenario: I navigate to print dashboard that doesn't exist
+        Given I type an invalid print dashboard id in the browser url
+        Then a message displays informing that the dashboard is not found
+        When I open the "Delivery" dashboard
+        Then the "Delivery" dashboard displays in view mode
+
+    @nonmutating
+    Scenario: I navigate to print layout dashboard that doesn't exist
+        Given I type an invalid print layout dashboard id in the browser url
+        Then a message displays informing that the dashboard is not found
+        When I open the "Delivery" dashboard
+        Then the "Delivery" dashboard displays in view mode
+
+    @nonmutating
     Scenario: An error occurs while saving a dashboard that I don't have access to
         Given I open the "Delivery" dashboard
         When I choose to edit dashboard

--- a/cypress/integration/ui/error_scenarios/invalid_dashboard_id.js
+++ b/cypress/integration/ui/error_scenarios/invalid_dashboard_id.js
@@ -10,3 +10,18 @@ Then('a message displays informing that the dashboard is not found', () => {
     cy.contains('Requested dashboard not found').should('be.visible')
     cy.get(dashboardTitleSel).should('not.exist')
 })
+
+//Scenario: edit Dashboard id is invalid
+Given('I type an invalid edit dashboard id in the browser url', () => {
+    cy.visit('#/invalid/edit', EXTENDED_TIMEOUT)
+})
+
+//Scenario: print Dashboard id is invalid
+Given('I type an invalid print dashboard id in the browser url', () => {
+    cy.visit('#/invalid/printoipp', EXTENDED_TIMEOUT)
+})
+
+//Scenario: print layout Dashboard id is invalid
+Given('I type an invalid print layout dashboard id in the browser url', () => {
+    cy.visit('#/invalid/printlayout', EXTENDED_TIMEOUT)
+})

--- a/cypress/integration/ui/view_dashboard.feature
+++ b/cypress/integration/ui/view_dashboard.feature
@@ -39,6 +39,13 @@ Feature: Viewing dashboards
         When I click to exit print preview
         Then the "Delivery" dashboard displays in view mode
 
+    @nonmutating
+    Scenario: I view a dashboard with items lacking shape
+        Given I open the "Delivery" dashboard with shapes removed
+        Then the "Delivery" dashboard displays in view mode
+
+
+
 # TODO: flaky test
 # @mutating
 # Scenario: I change the height of the control bar

--- a/cypress/integration/ui/view_dashboard/dashboard_items_without_shape.js
+++ b/cypress/integration/ui/view_dashboard/dashboard_items_without_shape.js
@@ -1,0 +1,21 @@
+import { Given } from 'cypress-cucumber-preprocessor/steps'
+import { EXTENDED_TIMEOUT } from '../../../support/utils'
+import { dashboards } from '../../../assets/backends'
+import { dashboardChipSel } from '../../../selectors/viewDashboard'
+
+Given('I open the {string} dashboard with shapes removed', title => {
+    const regex = new RegExp(`dashboards/${dashboards[title].id}`, 'g')
+    cy.intercept(regex, req => {
+        req.reply(res => {
+            res.body.dashboardItems.forEach(item => {
+                delete item.x
+                delete item.y
+                delete item.w
+                delete item.h
+            })
+
+            res.send({ body: res.body })
+        })
+    })
+    cy.get(dashboardChipSel, EXTENDED_TIMEOUT).contains(title).click()
+})


### PR DESCRIPTION
Add tests to check for invalid print, printlayout and edit routes.

Add a test that ensures that the dashboard displays normally when items don't have shapes (x,y,w,h) (this could be the case for older dashboards that were created before the new dashboard app)