### PR TITLE
fix: all cypress tests in edit mode should check that view mode is displayed first

### DIFF
--- a/cypress/integration/ui/edit_dashboard.feature
+++ b/cypress/integration/ui/edit_dashboard.feature
@@ -13,7 +13,6 @@ Feature: Creating, editing and deleting dashboard
     @mutating
     Scenario: I exit without saving when no changes
         Given I open existing dashboard
-        Then the dashboard displays in view mode
         When I choose to edit dashboard
         And I click Exit without saving
         Then the dashboard displays in view mode
@@ -21,7 +20,6 @@ Feature: Creating, editing and deleting dashboard
     @mutating
     Scenario: I cancel exit without saving when name changed
         Given I open existing dashboard
-        Then the dashboard displays in view mode
         When I choose to edit dashboard
         And dashboard title is added
         And I click Exit without saving
@@ -31,7 +29,6 @@ Feature: Creating, editing and deleting dashboard
     @mutating
     Scenario: I cancel exit without saving when item added
         Given I open existing dashboard
-        Then the dashboard displays in view mode
         When I choose to edit dashboard
         And dashboard items are added
         And I click outside menu
@@ -42,7 +39,6 @@ Feature: Creating, editing and deleting dashboard
     @mutating
     Scenario: I exit without saving when name changed
         Given I open existing dashboard
-        Then the dashboard displays in view mode
         When I choose to edit dashboard
         And dashboard title is added
         And I click Exit without saving
@@ -52,7 +48,6 @@ Feature: Creating, editing and deleting dashboard
     @mutating
     Scenario: I star the dashboard
         Given I open existing dashboard
-        Then the dashboard displays in view mode
         And the dashboard is not starred
         When I click to star the dashboard
         Then the dashboard is starred
@@ -64,7 +59,6 @@ Feature: Creating, editing and deleting dashboard
     Scenario: I toggle show description
         Given I open existing dashboard
         # And the description is not shown
-        Then the dashboard displays in view mode
         And the dashboard description is not displayed
         When I click to show description
         Then the dashboard description is displayed
@@ -106,7 +100,6 @@ Feature: Creating, editing and deleting dashboard
     @mutating
     Scenario: I save a starred dashboard
         Given I open existing dashboard
-        Then the dashboard displays in view mode
         And the dashboard is not starred
         When I click to star the dashboard
         Then the dashboard is starred

--- a/cypress/integration/ui/edit_dashboard/edit_dashboard.js
+++ b/cypress/integration/ui/edit_dashboard/edit_dashboard.js
@@ -95,6 +95,16 @@ Given('I open existing dashboard', () => {
     cy.get(dashboardChipSel, EXTENDED_TIMEOUT)
         .contains(TEST_DASHBOARD_TITLE)
         .click()
+
+    cy.location().should(loc => {
+        const currentRoute = getRouteFromHash(loc.hash)
+
+        expect(nonViewRoutes).not.to.include(currentRoute)
+        expect([ROOT_ROUTE_LENGTH, UID_LENGTH]).to.include(currentRoute.length)
+    })
+    cy.get(dashboardTitleSel)
+        .should('be.visible')
+        .and('contain', TEST_DASHBOARD_TITLE)
 })
 
 When('I choose to delete dashboard', () => {


### PR DESCRIPTION
Some tests occasionally fail because a button (e.g. Share) is not yet visible. This change adds a check for each test that ensures that view mode has been rendered before moving on with the rest of the test.