### PR TITLE
chore: move getLink functionality to only place it is used in ItemContextMenu

### DIFF
--- a/src/components/Item/VisualizationItem/ItemContextMenu/ItemContextMenu.js
+++ b/src/components/Item/VisualizationItem/ItemContextMenu/ItemContextMenu.js
@@ -26,8 +26,8 @@ import { useWindowDimensions } from '../../../WindowDimensionsProvider'
 import { isSmallScreen } from '../../../../modules/smallScreen'
 import { isElementFullscreen } from '../isElementFullscreen'
 
-import { getLink } from '../Visualization/plugin'
-import { getAppName } from '../../../../modules/itemTypes'
+import { getAppName, itemTypeMap } from '../../../../modules/itemTypes'
+import { getVisualizationId } from '../../../../modules/item'
 import { useSystemSettings } from '../../../SystemSettingsProvider'
 
 const ItemContextMenu = props => {
@@ -91,6 +91,10 @@ const ItemContextMenu = props => {
 
     const buttonRef = createRef()
 
+    const itemHref = `${baseUrl}/${itemTypeMap[item.type].appUrl(
+        getVisualizationId(item)
+    )}`
+
     return isElementFullscreen(item.id) ? (
         <Button small secondary onClick={props.onToggleFullscreen}>
             <span data-testid="exit-fullscreen-button">
@@ -141,7 +145,7 @@ const ItemContextMenu = props => {
                                 label={i18n.t('Open in {{appName}} app', {
                                     appName: getAppName(item.type),
                                 })}
-                                href={getLink(item, baseUrl)}
+                                href={itemHref}
                                 target="_blank"
                             />
                         )}

--- a/src/components/Item/VisualizationItem/Visualization/plugin.js
+++ b/src/components/Item/VisualizationItem/Visualization/plugin.js
@@ -4,9 +4,7 @@ import {
     MAP,
     EVENT_REPORT,
     EVENT_CHART,
-    itemTypeMap,
 } from '../../../../modules/itemTypes'
-import { getVisualizationId } from '../../../../modules/item'
 import getVisualizationContainerDomId from '../getVisualizationContainerDomId'
 import { loadExternalScript } from './loadExternalScript'
 
@@ -85,12 +83,6 @@ const loadPlugin = async (type, config, credentials) => {
         plugin.auth = credentials.auth
     }
     plugin.load(config)
-}
-
-export const getLink = (item, baseUrl) => {
-    const appUrl = itemTypeMap[item.type].appUrl(getVisualizationId(item))
-
-    return `${baseUrl}/${appUrl}`
 }
 
 export const load = async (


### PR DESCRIPTION
The `getLink` function was only used by ItemContextMenu for the "View in [Visualizer/Maps] app" menu option. So moved that functionality because some other changes are coming to `plugin.js`
Cypress test coverage: https://github.com/dhis2/dashboard-app/blob/master/cypress/integration/ui/item_context_menu.feature#L25

https://user-images.githubusercontent.com/6113918/118972031-62344300-b970-11eb-9819-c832a540ec1a.mov

