### PR TITLE
feat: hide periods based on system settings (DHIS2-11161)

### DIFF
--- a/cypress/elements/dashboardFilter.js
+++ b/cypress/elements/dashboardFilter.js
@@ -3,7 +3,7 @@ export const filterBadgeSel = '[data-test="dashboard-filter-badge"]'
 export const filterDimensionsPanelSel = '[data-test="dashboard-filter-popover"]'
 
 export const unselectedItemsSel =
-    '[data-test="dhis2-uicore-transfer-sourceoptions"]'
+    '[data-test*="dimension-transfer-sourceoptions"]'
 
 export const orgUnitCheckboxesSel = '*[role="button"]'
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "license": "BSD-3-Clause",
     "dependencies": {
-        "@dhis2/analytics": "^17.1.0",
+        "@dhis2/analytics": "^18.0.0",
         "@dhis2/app-runtime": "^2.8.0",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/d2-i18n": "^1.1.0",
@@ -15,7 +15,7 @@
         "@dhis2/d2-ui-rich-text": "^7.3.0",
         "@dhis2/d2-ui-sharing-dialog": "^7.3.0",
         "@dhis2/d2-ui-translation-dialog": "^7.3.0",
-        "@dhis2/data-visualizer-plugin": "^37.1.0",
+        "@dhis2/data-visualizer-plugin": "^37.2.0",
         "@dhis2/ui": "^6.7.0",
         "classnames": "^2.3.1",
         "d2": "^31.10.0",

--- a/src/api/systemSettings.js
+++ b/src/api/systemSettings.js
@@ -12,6 +12,11 @@ const SYSTEM_SETTINGS = [
     'keyDashboardContextMenuItemSwitchViewType',
     'keyDashboardContextMenuItemViewFullscreen',
     'keyGatherAnalyticalObjectStatisticsInDashboardViews',
+    'keyHideBiMonthlyPeriods',
+    'keyHideDailyPeriods',
+    'keyHideMonthlyPeriods',
+    'keyHideWeeklyPeriods',
+    'keyHideBiWeeklyPeriods',
 ]
 
 const SYSTEM_SETTINGS_REMAPPINGS = {
@@ -20,6 +25,11 @@ const SYSTEM_SETTINGS_REMAPPINGS = {
         'allowVisShowInterpretations',
     keyDashboardContextMenuItemSwitchViewType: 'allowVisViewAs',
     keyDashboardContextMenuItemViewFullscreen: 'allowVisFullscreen',
+    keyHideBiMonthlyPeriods: 'hideBiMonthlyPeriods',
+    keyHideDailyPeriods: 'hideDailyPeriods',
+    keyHideMonthlyPeriods: 'hideMonthlyPeriods',
+    keyHideWeeklyPeriods: 'hideWeeklyPeriods',
+    keyHideBiWeeklyPeriods: 'hideBiWeeklyPeriods',
 }
 
 export const renameSystemSettings = settings => {

--- a/src/pages/view/TitleBar/FilterDialog.js
+++ b/src/pages/view/TitleBar/FilterDialog.js
@@ -17,6 +17,15 @@ import {
     OrgUnitDimension,
     DIMENSION_ID_PERIOD,
     DIMENSION_ID_ORGUNIT,
+    DAILY,
+    WEEKLY,
+    WEEKLYWED,
+    WEEKLYTHU,
+    WEEKLYSAT,
+    WEEKLYSUN,
+    BIWEEKLY,
+    MONTHLY,
+    BIMONTHLY,
 } from '@dhis2/analytics'
 import {
     acAddItemFilter,
@@ -24,6 +33,7 @@ import {
 } from '../../../actions/itemFilters'
 import { sGetItemFiltersRoot } from '../../../reducers/itemFilters'
 import { useUserSettings } from '../../../components/UserSettingsProvider'
+import { useSystemSettings } from '../../../components/SystemSettingsProvider'
 
 const FilterDialog = ({
     dimension,
@@ -35,6 +45,7 @@ const FilterDialog = ({
     const [filters, setFilters] = useState(initiallySelectedItems)
     const { d2 } = useD2()
     const { userSettings } = useUserSettings()
+    const { settings: systemSettings } = useSystemSettings()
 
     const onSelectItems = ({ dimensionId, items }) => {
         setFilters({ [dimensionId]: items })
@@ -74,6 +85,26 @@ const FilterDialog = ({
         onClose(id)
     }
 
+    const getExcludedPeriodTypes = (settings = {}) => {
+        const types = []
+        if (settings['hideDailyPeriods']) {
+            types.push(DAILY)
+        }
+        if (settings['hideWeeklyPeriods']) {
+            types.push(WEEKLY, WEEKLYWED, WEEKLYTHU, WEEKLYSAT, WEEKLYSUN)
+        }
+        if (settings['hideBiWeeklyPeriods']) {
+            types.push(BIWEEKLY)
+        }
+        if (settings['hideMonthlyPeriods']) {
+            types.push(MONTHLY)
+        }
+        if (settings['hideBiMonthlyPeriods']) {
+            types.push(BIMONTHLY)
+        }
+        return types
+    }
+
     const renderDialogContent = () => {
         const commonProps = {
             d2,
@@ -90,6 +121,9 @@ const FilterDialog = ({
                     <PeriodDimension
                         selectedPeriods={selectedItems}
                         onSelect={commonProps.onSelect}
+                        excludedPeriodTypes={getExcludedPeriodTypes(
+                            systemSettings
+                        )}
                     />
                 )
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1529,10 +1529,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@dhis2/analytics@^17.0.4", "@dhis2/analytics@^17.1.0":
-  version "17.1.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-17.1.0.tgz#c3c0e1250a352e709ef065c5e3f05066b65c5d2f"
-  integrity sha512-kfukdKTmnYs7r8o+4DeQ8MuwYkvuwlHxDRYy8bd+Beo5ERGtr4yGPfjHNCcxxgBbApNHHA5nMID1qBSAzGy9Qg==
+"@dhis2/analytics@^18.0.0":
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-18.0.0.tgz#0d03b9851708a8de3825a2c9824afe0380ccc597"
+  integrity sha512-IsJuXDgDw+DaYbxIDKGzx1PHWXx97qNquyBwszrpRfw++G2x/8bMPpJ2yGHU1KwuGEv0Io2J8Rnx0NPrRG4rSQ==
   dependencies:
     "@dhis2/d2-ui-favorites-dialog" "^7.2.0"
     "@dhis2/d2-ui-org-unit-dialog" "^7.2.0"
@@ -1867,12 +1867,12 @@
     react-select "^2.0.0"
     rxjs "^5.5.7"
 
-"@dhis2/data-visualizer-plugin@^37.1.0":
-  version "37.1.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/data-visualizer-plugin/-/data-visualizer-plugin-37.1.0.tgz#8d29313b3fec4cb817c808083361dae1cf0c6a2b"
-  integrity sha512-Lu4G98DRml+gb7rd1edTx4LybaKgQodN9nmkFa+3tfv+pVqUX5y3jE4hXCy/pAqdpZvb9+WqnQdI4SLlA0IZmQ==
+"@dhis2/data-visualizer-plugin@^37.2.0":
+  version "37.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/data-visualizer-plugin/-/data-visualizer-plugin-37.2.0.tgz#7ac548ee7540fb3ae06594d1b6a6fe482716a319"
+  integrity sha512-AJAHXw4Q8AQ197zGq/iuufAZD5De1VotjV2vZFsuuxxsk2gLMHzcqpQ4ZwtiR6KxD1TkkHwDaCifsAQ5UToj4A==
   dependencies:
-    "@dhis2/analytics" "^17.0.4"
+    "@dhis2/analytics" "^18.0.0"
     "@dhis2/app-runtime" "^2.8.0"
     "@dhis2/d2-i18n" "^1.1.0"
     "@dhis2/ui" "^6.5.5"


### PR DESCRIPTION
Implements [DHIS2-11161](https://jira.dhis2.org/browse/DHIS2-11161)

**Requires https://github.com/dhis2/analytics/pull/920**

Relates to https://github.com/dhis2/data-visualizer-app/pull/1721

---

### Key features

1. Populates `excludedPeriodTypes` with values from system settings
2. Changes all instances of `DAYS` and `WEEKS` from Analytics to `DAILY` and `WEEKLY`

---

### Description

Fetches props from system settings to be passed to `excludedPeriodTypes`. Based on the DV change (https://github.com/dhis2/data-visualizer-app/pull/1721). 

---

### TODO

- [ ] Move `getExcludedPeriodTypes` to Analytics?

---

### Screenshots

_see the Analytics PR_
