### PR TITLE
fix: dashboard crashes when dashboard item type missing [v36] [TECH-588]

### DIFF
--- a/cypress/integration/common/open_print_layout.js
+++ b/cypress/integration/common/open_print_layout.js
@@ -1,0 +1,7 @@
+import { When } from 'cypress-cucumber-preprocessor/steps'
+
+When('I click to preview the print layout', () => {
+    cy.clickMoreButton()
+    cy.get('[data-test="print-menu-item"]').click()
+    cy.get('[data-test="print-layout-menu-item"]').click()
+})

--- a/cypress/integration/common/print_layout_displays.js
+++ b/cypress/integration/common/print_layout_displays.js
@@ -1,0 +1,12 @@
+import { Then } from 'cypress-cucumber-preprocessor/steps'
+import { dashboards } from '../../assets/backends/sierraLeone_236'
+
+Then('the print layout displays for {string} dashboard', title => {
+    //check the url
+    cy.location().should(loc => {
+        expect(loc.hash).to.equal(`${dashboards[title].route}/printlayout`)
+    })
+
+    //check for some elements
+    cy.get('[data-test="print-layout-page"]').should('be.visible')
+})

--- a/cypress/integration/ui/error_scenarios.feature
+++ b/cypress/integration/ui/error_scenarios.feature
@@ -39,6 +39,24 @@ Feature: Error scenarios
         Then a warning message is displayed stating that starring dashboard failed
         And the "Delivery" dashboard is not starred
 
+    Scenario: View dashboard containing item that is missing type
+        Given I open the Delivery dashboard with items missing a type
+        Then the "Delivery" dashboard displays in view mode
+        And the items missing type are displayed with a warning
+
+    Scenario: Edit dashboard containing item that is missing type
+        Given I open the Delivery dashboard with items missing a type
+        When I choose to edit dashboard
+        Then the items missing type are displayed with a warning
+        And I can delete the items
+
+    Scenario: Print dashboard containing item that is missing type
+        Given I open the Delivery dashboard with items missing a type
+        When I click to preview the print layout
+        Then the print layout displays for "Delivery" dashboard
+        And the items missing type are displayed with a warning
+
+# TODO unflake this flaky test
 # @nonmutating
 # Scenario: Toggling show description fails
 #     Given I open the "Delivery" dashboard

--- a/cypress/integration/ui/error_scenarios/dashboard_item_missing_type.js
+++ b/cypress/integration/ui/error_scenarios/dashboard_item_missing_type.js
@@ -1,0 +1,69 @@
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+import { EXTENDED_TIMEOUT } from '../../../support/utils'
+import {
+    dashboardChipSel,
+    dashboardTitleSel,
+} from '../../../selectors/viewDashboard'
+import {
+    getDashboardItem,
+    clickItemDeleteButton,
+} from '../../../selectors/dashboardItem'
+
+const ITEM_1_UID = 'GaVhJpqABYX'
+const ITEM_2_UID = 'qXsjttMYuoZ'
+const ITEM_3_UID = 'Rwb3oXJ3bZ9'
+
+const interceptDashboardRequest = () => {
+    cy.intercept(/dashboards\/iMnYyBfSxmM/, req => {
+        req.reply(res => {
+            // modify 3 items with different styles of "missing" type property
+            res.body.dashboardItems.find(
+                item => item.id === ITEM_1_UID
+            ).type = null
+
+            const item = res.body.dashboardItems.find(
+                item => item.id === ITEM_2_UID
+            )
+
+            delete item.type
+
+            res.body.dashboardItems.find(item => item.id === ITEM_3_UID).type =
+                'Unrecognized'
+
+            res.send({ body: res.body })
+        })
+    })
+}
+
+Given('I open the Delivery dashboard with items missing a type', () => {
+    interceptDashboardRequest()
+    cy.get(dashboardChipSel, EXTENDED_TIMEOUT).contains('Delivery').click()
+    cy.get(dashboardTitleSel).should('be.visible').and('contain', 'Delivery')
+})
+
+Then('the items missing type are displayed with a warning', () => {
+    getDashboardItem(ITEM_1_UID)
+        .scrollIntoView()
+        .contains('The item type is missing')
+        .should('be.visible')
+
+    getDashboardItem(ITEM_2_UID)
+        .scrollIntoView()
+        .contains('The item type is missing')
+        .should('be.visible')
+
+    getDashboardItem(ITEM_3_UID)
+        .scrollIntoView()
+        .contains('Item type "Unrecognized" is not supported')
+        .should('be.visible')
+})
+
+Then('I can delete the items', () => {
+    clickItemDeleteButton(ITEM_1_UID)
+    clickItemDeleteButton(ITEM_2_UID)
+    clickItemDeleteButton(ITEM_3_UID)
+
+    getDashboardItem(ITEM_1_UID).should('not.exist')
+    getDashboardItem(ITEM_2_UID).should('not.exist')
+    getDashboardItem(ITEM_3_UID).should('not.exist')
+})

--- a/cypress/integration/ui/view_dashboard/print.js
+++ b/cypress/integration/ui/view_dashboard/print.js
@@ -1,22 +1,6 @@
 import { When, Then } from 'cypress-cucumber-preprocessor/steps'
 import { dashboards } from '../../../assets/backends/sierraLeone_236'
 
-When('I click to preview the print layout', () => {
-    cy.clickMoreButton()
-    cy.get('[data-test="print-menu-item"]').click()
-    cy.get('[data-test="print-layout-menu-item"]').click()
-})
-
-Then('the print layout displays for {string} dashboard', title => {
-    //check the url
-    cy.location().should(loc => {
-        expect(loc.hash).to.equal(`${dashboards[title].route}/printlayout`)
-    })
-
-    //check for some elements
-    cy.get('[data-test="print-layout-page"]').should('be.visible')
-})
-
 When('I click to exit print preview', () => {
     cy.get('button').not('.small').contains('Exit print preview').click()
 })

--- a/cypress/selectors/dashboardItem.js
+++ b/cypress/selectors/dashboardItem.js
@@ -12,7 +12,13 @@ export const getDashboardItem = itemUid =>
     cy.get(`[data-test="dashboarditem-${itemUid}"]`)
 
 export const clickMenuButton = itemUid =>
-    getDashboardItem(itemUid).find(itemMenuButton).click()
+    getDashboardItem(itemUid).scrollIntoView().find(itemMenuButton).click()
+
+export const clickItemDeleteButton = itemUid =>
+    getDashboardItem(itemUid)
+        .scrollIntoView()
+        .find('[data-test="delete-item-button"]')
+        .click()
 
 //map
 

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-03-11T18:02:28.225Z\n"
-"PO-Revision-Date: 2021-03-11T18:02:28.225Z\n"
+"POT-Creation-Date: 2021-06-10T13:31:39.680Z\n"
+"PO-Revision-Date: 2021-06-10T13:31:39.680Z\n"
 
 msgid "Untitled dashboard"
 msgstr ""
@@ -135,7 +135,10 @@ msgstr ""
 msgid "See all messages"
 msgstr ""
 
-msgid "Item type \"{{type}}\" not supported"
+msgid "Item type \"{{type}}\" is not supported"
+msgstr ""
+
+msgid "The item type is missing"
 msgstr ""
 
 msgid "Filters applied"

--- a/src/components/Item/AppItem/__tests__/__snapshots__/Item.spec.js.snap
+++ b/src/components/Item/AppItem/__tests__/__snapshots__/Item.spec.js.snap
@@ -37,6 +37,7 @@ exports[`renders a valid App item with filter in edit mode 1`] = `
     >
       <button
         class="deleteItemButton"
+        data-test="delete-item-button"
         title="Delete item"
         type="button"
       >
@@ -103,6 +104,7 @@ exports[`renders a valid App item with title in edit mode irrespective of app se
     >
       <button
         class="deleteItemButton"
+        data-test="delete-item-button"
         title="Delete item"
         type="button"
       >

--- a/src/components/Item/ItemHeader/DeleteItemButton.js
+++ b/src/components/Item/ItemHeader/DeleteItemButton.js
@@ -12,6 +12,7 @@ const DeleteItemButton = ({ onClick }) => (
         className={classes.deleteItemButton}
         onClick={onClick}
         title={i18n.t(`Delete item`)}
+        data-test="delete-item-button"
     >
         <DeleteIcon style={{ fill: colors.red500 }} />
     </button>

--- a/src/components/Item/NotSupportedItem/Item.js
+++ b/src/components/Item/NotSupportedItem/Item.js
@@ -16,7 +16,7 @@ const NotSupportedItem = ({ item, dashboardMode }) => {
             <ItemHeader
                 itemId={item.id}
                 dashboardMode={dashboardMode}
-                isShortened={false}
+                isShortened={item.shortened}
             />
             <div
                 style={{

--- a/src/components/Item/NotSupportedItem/Item.js
+++ b/src/components/Item/NotSupportedItem/Item.js
@@ -4,31 +4,38 @@ import i18n from '@dhis2/d2-i18n'
 import ItemHeader from '../ItemHeader/ItemHeader'
 import NotInterestedIcon from '@material-ui/icons/NotInterested'
 
-const NotSupportedItem = props => (
-    <>
-        <ItemHeader
-            title={i18n.t('Item type "{{type}}" not supported', {
-                type: props.item.type,
-            })}
-            itemId={props.item.id}
-            dashboardMode={props.dashboardMode}
-            isShortened={props.item.shortened}
-        />
-        <div
-            style={{
-                display: 'flex',
-                justifyContent: 'center',
-                alignItems: 'center',
-                height: '90%',
-            }}
-        >
-            <NotInterestedIcon
-                style={{ width: 100, height: 100, align: 'center' }}
-                color="disabled"
+const NotSupportedItem = ({ item, dashboardMode }) => {
+    const message = item.type
+        ? i18n.t('Item type "{{type}}" is not supported', {
+              type: item.type,
+          })
+        : i18n.t('The item type is missing')
+
+    return (
+        <>
+            <ItemHeader
+                itemId={item.id}
+                dashboardMode={dashboardMode}
+                isShortened={false}
             />
-        </div>
-    </>
-)
+            <div
+                style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    justifyContent: 'center',
+                    alignItems: 'center',
+                    height: '90%',
+                }}
+            >
+                <p>{message}</p>
+                <NotInterestedIcon
+                    style={{ width: 100, height: 100, align: 'center' }}
+                    color="disabled"
+                />
+            </div>
+        </>
+    )
+}
 
 NotSupportedItem.propTypes = {
     dashboardMode: PropTypes.string,

--- a/src/components/ItemGrid/PrintLayoutItemGrid.js
+++ b/src/components/ItemGrid/PrintLayoutItemGrid.js
@@ -51,7 +51,11 @@ export class PrintLayoutItemGrid extends Component {
         })
 
         return (
-            <div key={item.i} className={itemClassNames}>
+            <div
+                key={item.i}
+                className={itemClassNames}
+                data-test={`dashboarditem-${item.id}`}
+            >
                 <Item item={item} dashboardMode={PRINT_LAYOUT} />
             </div>
         )

--- a/src/modules/itemTypes.js
+++ b/src/modules/itemTypes.js
@@ -32,7 +32,7 @@ const DOMAIN_TYPE_TRACKER = 'TRACKER'
 
 // Dashboard helpers
 export const isVisualizationType = item =>
-    !!itemTypeMap[item.type].isVisualizationType
+    !!itemTypeMap[item.type]?.isVisualizationType
 export const hasMapView = itemType =>
     itemTypeMap[itemType].domainType === DOMAIN_TYPE_AGGREGATE
 export const isTrackerDomainType = itemType =>
@@ -48,6 +48,7 @@ export const itemTypeMap = {
         endPointName: 'visualizations',
         propName: 'visualization',
         pluralTitle: i18n.t('Visualizations'),
+        isVisualizationType: true,
         appUrl: id => `dhis-web-data-visualizer/#/${id}`,
         appName: 'Data Visualizer',
         defaultItemCount: 10,


### PR DESCRIPTION
One character fix in itemTypes.js

The rest is support for new cypress tests that mock a request with missing or unrecognized item types.

Look at errors.feature for a summary of what the new new cypress tests do. Some cypress changes are just moving functions to common so that all tests can access the function