### PR TITLE
fix: include hideTitle property when loading map [DHIS2-11302]

### DIFF
--- a/src/components/Item/VisualizationItem/Visualization/DefaultPlugin.js
+++ b/src/components/Item/VisualizationItem/Visualization/DefaultPlugin.js
@@ -48,6 +48,7 @@ const DefaultPlugin = ({
             load(item, visualization, {
                 credentials,
                 activeType,
+                options,
             })
         }
 


### PR DESCRIPTION
Make sure to include `options` which contains `hideTitle` when loading the map

![image](https://user-images.githubusercontent.com/6113918/121865667-8597a700-ccfe-11eb-902f-e7d15961e7e1.png)
