### PR TITLE
fix: include hideTitle property when loading map [DHIS2-11302] [v36]

### DIFF
--- a/src/components/Item/VisualizationItem/Visualization/DefaultPlugin.js
+++ b/src/components/Item/VisualizationItem/Visualization/DefaultPlugin.js
@@ -45,6 +45,7 @@ const DefaultPlugin = ({
             load(item, visualization, {
                 credentials,
                 activeType,
+                options,
             })
         }
 


### PR DESCRIPTION
Make sure to include `options` which contains `hideTitle` when loading the map
![image](https://user-images.githubusercontent.com/6113918/121866046-dc9d7c00-ccfe-11eb-8ce0-62234c21a2ad.png)
