### PR TITLE
fix: add onError callback to handle failed chart from DV plugin [DHIS2-11303] [v36]

### DIFF
--- a/cypress/assets/backends/sierraLeone_236.js
+++ b/cypress/assets/backends/sierraLeone_236.js
@@ -7,6 +7,7 @@ export const dashboards = {
                 itemUid: 'ILRTXgXvurM',
             },
             chart: {
+                name: 'ANC: ANC 3 coverage by districts last 12 months',
                 itemUid: 'azz0KRlHgLs',
             },
         },
@@ -15,9 +16,20 @@ export const dashboards = {
         id: 'iMnYyBfSxmM',
         route: '#/iMnYyBfSxmM',
         items: {
-            chart: { itemUid: 'GaVhJpqABYX', visUid: 'HDEDqV3yv3H' },
-            table: { itemUid: 'qXsjttMYuoZ' },
-            map: { itemUid: 'G3EtzSWNP9o' },
+            chart: {
+                name: 'Delivery: Institutional delivery rates Yearly',
+                itemUid: 'GaVhJpqABYX',
+                visUid: 'HDEDqV3yv3H',
+            },
+            table: {
+                name: 'Delivery: Live births in facilities last 4 quarters',
+                itemUid: 'qXsjttMYuoZ',
+            },
+            map: {
+                name:
+                    'Delivery: PHU delivery rate (by pop) by chiefdom last year',
+                itemUid: 'G3EtzSWNP9o',
+            },
         },
     },
     Immunization: {

--- a/cypress/integration/common/exit_print_layout.js
+++ b/cypress/integration/common/exit_print_layout.js
@@ -1,0 +1,8 @@
+import { When } from 'cypress-cucumber-preprocessor/steps'
+import { dashboardTitleSel } from '../../selectors/viewDashboard'
+
+When('I click to exit print preview', () => {
+    cy.get('button').not('.small').contains('Exit print preview').click()
+
+    cy.get(dashboardTitleSel).should('be.visible')
+})

--- a/cypress/integration/ui/error_scenarios.feature
+++ b/cypress/integration/ui/error_scenarios.feature
@@ -56,6 +56,37 @@ Feature: Error scenarios
         Then the print layout displays for "Delivery" dashboard
         And the items missing type are displayed with a warning
 
+    Scenario: Item visualization fails when filter applied [DHIS2-11303]
+        Given I create a dashboard with a chart that will fail
+        When I apply a "Diagnosis" filter of type "Burns"
+        Then an error message is displayed on the item
+        When I click to preview the print layout
+        Then an error message not including a link is displayed on the item
+        When I click to exit print preview
+        And I remove the filter
+        Then the "chart" is displayed correctly
+
+    Scenario: Item visualization fails when filter applied and viewed as table [DHIS2-11303]
+        Given I open a dashboard with a chart that will fail
+        When I apply a "Diagnosis" filter of type "Burns"
+        Then an error message is displayed on the item
+        When I view as table
+        Then an error message is displayed on the item
+        When I remove the filter
+        Then the "table" is displayed correctly
+
+    Scenario: Item visualization fails when filter applied and viewed as table then viewed as chart [DHIS2-11303]
+        Given I open a dashboard with a chart that will fail
+        When I apply a "Diagnosis" filter of type "Burns"
+        Then an error message is displayed on the item
+        When I view as table
+        Then an error message is displayed on the item
+        When I view as chart
+        Then an error message is displayed on the item
+        When I remove the filter
+        Then the "chart" is displayed correctly
+        And I delete the dashboard
+
 # TODO unflake this flaky test
 # @nonmutating
 # Scenario: Toggling show description fails

--- a/cypress/integration/ui/error_scenarios/item_chart_fails_to_render.js
+++ b/cypress/integration/ui/error_scenarios/item_chart_fails_to_render.js
@@ -1,0 +1,118 @@
+import { Given, Then, When } from 'cypress-cucumber-preprocessor/steps'
+import { EXTENDED_TIMEOUT } from '../../../support/utils'
+import {
+    clickViewActionButton,
+    dashboardChipSel,
+    dashboardTitleSel,
+} from '../../../selectors/viewDashboard'
+import {
+    clickEditActionButton,
+    confirmActionDialogSel,
+    createDashboard,
+} from '../../../selectors/editDashboard'
+import {
+    dimensionsModalSel,
+    filterDimensionsPanelSel,
+    filterBadgeSel,
+} from '../../../selectors/dashboardFilter'
+import {
+    chartSel,
+    tableSel,
+    itemMenuButtonSel,
+} from '../../../selectors/dashboardItem'
+
+const TEST_DASHBOARD_TITLE = '0filter-fail-' + new Date().toUTCString()
+
+// Scenario: Item visualization fails when filter applied [DHIS2-11303]
+
+const VIS_NAME =
+    'ANC: ANC reporting rate, coverage and visits last 4 quarters dual-axis'
+
+Given('I create a dashboard with a chart that will fail', () => {
+    createDashboard(TEST_DASHBOARD_TITLE, [VIS_NAME])
+})
+
+Given('I open a dashboard with a chart that will fail', () => {
+    cy.get(dashboardChipSel, EXTENDED_TIMEOUT)
+        .contains(TEST_DASHBOARD_TITLE)
+        .click()
+
+    cy.get(dashboardTitleSel)
+        .should('be.visible')
+        .and('contain', TEST_DASHBOARD_TITLE)
+})
+
+When(
+    'I apply a {string} filter of type {string}',
+    (dimensionType, filterName) => {
+        cy.contains('Add filter').click()
+        cy.get(filterDimensionsPanelSel).contains(dimensionType).click()
+        cy.get(dimensionsModalSel, EXTENDED_TIMEOUT).should('be.visible')
+
+        cy.contains(filterName).dblclick()
+
+        cy.get('button').contains('Confirm').click()
+    }
+)
+
+Then('an error message is displayed on the item', () => {
+    cy.contains('There was an error loading data for this item').should(
+        'be.visible'
+    )
+
+    cy.contains('Open this item in Data Visualizer').should('be.visible')
+
+    cy.get(chartSel).should('not.exist')
+})
+
+Then('an error message not including a link is displayed on the item', () => {
+    cy.contains('There was an error loading data for this item')
+        .scrollIntoView()
+        .should('be.visible')
+
+    cy.contains('Open this item in Data Visualizer').should('not.exist')
+
+    cy.get(chartSel).should('not.exist')
+})
+
+When('I view as chart', () => {
+    cy.get(itemMenuButtonSel).click()
+    cy.contains('View as Chart').click()
+})
+
+When('I view as table', () => {
+    cy.get(itemMenuButtonSel).click()
+    cy.contains('View as Table').click()
+})
+
+When('I remove the filter', () => {
+    cy.wait(4000) // eslint-disable-line cypress/no-unnecessary-waiting
+    cy.get(filterBadgeSel).scrollIntoView().contains('Remove').click()
+
+    cy.get(filterBadgeSel).should('not.exist')
+    cy.wait(4000) // eslint-disable-line cypress/no-unnecessary-waiting
+})
+
+Then('the {string} is displayed correctly', visType => {
+    if (visType === 'chart') {
+        cy.get(chartSel, EXTENDED_TIMEOUT).should('be.visible')
+    } else if (visType === 'table') {
+        cy.get(tableSel, EXTENDED_TIMEOUT).should('be.visible')
+    }
+
+    //TODO - add snapshot testing
+})
+
+Then('I delete the dashboard', () => {
+    //now cleanup
+    clickViewActionButton('Edit')
+    clickEditActionButton('Delete')
+    cy.contains(
+        `Deleting dashboard "${TEST_DASHBOARD_TITLE}" will remove it for all users`
+    ).should('be.visible')
+
+    cy.get(confirmActionDialogSel).find('button').contains('Delete').click()
+    cy.get(dashboardChipSel).contains(TEST_DASHBOARD_TITLE).should('not.exist')
+
+    cy.get(dashboardTitleSel).should('exist').should('not.be.empty')
+})

--- a/cypress/integration/ui/fullscreen/fullscreen.js
+++ b/cypress/integration/ui/fullscreen/fullscreen.js
@@ -1,14 +1,14 @@
 import { Then } from 'cypress-cucumber-preprocessor/steps'
 import {
     getDashboardItem,
-    itemMenuButton,
+    itemMenuButtonSel,
     clickMenuButton,
 } from '../../../selectors/dashboardItem'
 import { dashboards } from '../../../assets/backends'
 
 Then('the text item does not have a context menu', () => {
     getDashboardItem(dashboards['Antenatal Care'].items.text.itemUid)
-        .find(itemMenuButton)
+        .find(itemMenuButtonSel)
         .should('not.exist')
 })
 

--- a/cypress/integration/ui/view_dashboard/print.js
+++ b/cypress/integration/ui/view_dashboard/print.js
@@ -1,10 +1,6 @@
 import { When, Then } from 'cypress-cucumber-preprocessor/steps'
 import { dashboards } from '../../../assets/backends/sierraLeone_236'
 
-When('I click to exit print preview', () => {
-    cy.get('button').not('.small').contains('Exit print preview').click()
-})
-
 When('I click to preview the print one-item-per-page', () => {
     cy.clickMoreButton()
     cy.get('[data-test="print-menu-item"]').click()

--- a/cypress/selectors/dashboardItem.js
+++ b/cypress/selectors/dashboardItem.js
@@ -1,3 +1,5 @@
+import { EXTENDED_TIMEOUT } from '../support/utils'
+
 export const chartSel = '.highcharts-container'
 export const chartSubtitleSel = '.highcharts-subtitle'
 export const chartXAxisLabelSel = '.highcharts-xaxis-labels'
@@ -6,13 +8,13 @@ export const tableSel = '.pivot-table-container'
 export const gridItemSel = '.react-grid-item'
 
 export const itemDetailsSel = '[data-test="dashboarditem-footer"]'
-export const itemMenuButton = '[data-test="dashboarditem-menu-button"]'
+export const itemMenuButtonSel = '[data-test="dashboarditem-menu-button"]'
 
 export const getDashboardItem = itemUid =>
-    cy.get(`[data-test="dashboarditem-${itemUid}"]`)
+    cy.get(`[data-test="dashboarditem-${itemUid}"]`, EXTENDED_TIMEOUT)
 
 export const clickMenuButton = itemUid =>
-    getDashboardItem(itemUid).scrollIntoView().find(itemMenuButton).click()
+    getDashboardItem(itemUid).scrollIntoView().find(itemMenuButtonSel).click()
 
 export const clickItemDeleteButton = itemUid =>
     getDashboardItem(itemUid)

--- a/cypress/selectors/editDashboard.js
+++ b/cypress/selectors/editDashboard.js
@@ -1,4 +1,35 @@
+import { EXTENDED_TIMEOUT } from '../support/utils'
+import { newDashboardLinkSel } from './viewDashboard'
+
+export const confirmActionDialogSel = '[data-test="confirm-action-dialog"]'
 export const titleInputSel = '[data-test="dashboard-title-input"]'
 export const itemMenuSel = '[data-test="item-menu]'
 
 export const actionsBarSel = '[data-test="edit-control-bar"]'
+
+export const clickEditActionButton = action =>
+    cy
+        .get(actionsBarSel, EXTENDED_TIMEOUT)
+        .find('button')
+        .contains(action, EXTENDED_TIMEOUT)
+        .click()
+
+export const createDashboard = (title, items) => {
+    cy.get(newDashboardLinkSel, EXTENDED_TIMEOUT).click()
+    // add title
+    cy.get(titleInputSel).type(title)
+
+    // add the item
+    items.forEach(itemName => {
+        cy.get('[data-test="item-search"]').click()
+        cy.get('[data-test="item-search"]')
+            .find('input')
+            .type(itemName, { force: true })
+
+        cy.get(`[data-test="menu-item-${itemName}"]`).click()
+
+        cy.get('[data-test="dhis2-uicore-layer"]').click('topLeft')
+    })
+
+    cy.get('button').contains('Save changes', EXTENDED_TIMEOUT).click()
+}

--- a/cypress/selectors/viewDashboard.js
+++ b/cypress/selectors/viewDashboard.js
@@ -1,3 +1,5 @@
+import { EXTENDED_TIMEOUT } from '../support/utils'
+
 // Dashboards bar
 export const dashboardChipSel = '[data-test="dashboard-chip"]'
 export const newDashboardLinkSel = '[data-test="link-new-dashboard"]'
@@ -21,3 +23,10 @@ export const outerScrollContainerSel = '[data-test="outer-scroll-container"]'
 export const innerScrollContainerSel = '[data-test="inner-scroll-container"]'
 
 export const editControlBarSel = '[data-test="edit-control-bar"]'
+
+export const clickViewActionButton = action =>
+    cy
+        .get(titleBarSel, EXTENDED_TIMEOUT)
+        .find('button')
+        .contains(action, EXTENDED_TIMEOUT)
+        .click()

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -92,8 +92,14 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-msgid "dashboard layout"
-msgstr ""
+msgid "There was an error loading data for this item"
+msgstr "There was an error loading data for this item"
+
+msgid "Open this item in {{appName}}"
+msgstr "Open this item in {{appName}}"
+
+msgid "Visualizations"
+msgstr "Visualizations"
 
 msgid "one item per page"
 msgstr ""

--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -234,25 +234,33 @@ export class Item extends Component {
                     )}
                     onFatalError={this.onFatalError}
                 >
-                    <div
-                        className="dashboard-item-content"
-                        ref={ref => (this.contentRef = ref)}
-                    >
+                    <div ref={ref => (this.contentRef = ref)}>
                         {this.state.configLoaded && (
                             <WindowDimensionsCtx.Consumer>
                                 {dimensions => (
-                                    <Visualization
-                                        item={item}
-                                        activeType={activeType}
-                                        itemFilters={itemFilters}
-                                        availableHeight={this.getAvailableHeight(
-                                            dimensions
-                                        )}
-                                        availableWidth={this.getAvailableWidth()}
-                                        isFullscreen={this.state.isFullscreen}
-                                        gridWidth={this.props.gridWidth}
-                                        dashboardMode={dashboardMode}
-                                    />
+                                    <div
+                                        className="dashboard-item-content"
+                                        style={{
+                                            height: this.getAvailableHeight(
+                                                dimensions
+                                            ),
+                                        }}
+                                    >
+                                        <Visualization
+                                            item={item}
+                                            activeType={activeType}
+                                            itemFilters={itemFilters}
+                                            availableHeight={this.getAvailableHeight(
+                                                dimensions
+                                            )}
+                                            availableWidth={this.getAvailableWidth()}
+                                            isFullscreen={
+                                                this.state.isFullscreen
+                                            }
+                                            gridWidth={this.props.gridWidth}
+                                            dashboardMode={dashboardMode}
+                                        />
+                                    </div>
                                 )}
                             </WindowDimensionsCtx.Consumer>
                         )}

--- a/src/components/Item/VisualizationItem/Visualization/DataVisualizerPlugin.js
+++ b/src/components/Item/VisualizationItem/Visualization/DataVisualizerPlugin.js
@@ -1,7 +1,8 @@
-import React, { Suspense, useState, useCallback } from 'react'
+import React, { Suspense, useState, useEffect, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { useUserSettings } from '../../../UserSettingsProvider'
 import LoadingMask from './LoadingMask'
+import VisualizationErrorMessage from './VisualizationErrorMessage'
 
 const VisualizationPlugin = React.lazy(() =>
     import(
@@ -9,30 +10,58 @@ const VisualizationPlugin = React.lazy(() =>
     )
 )
 
-const DataVisualizerPlugin = props => {
+const DataVisualizerPlugin = ({
+    filterVersion,
+    item,
+    style,
+    visualization,
+    dashboardMode,
+}) => {
     const { userSettings } = useUserSettings()
     const [visualizationLoaded, setVisualizationLoaded] = useState(false)
+    const [error, setError] = useState(false)
 
     const onLoadingComplete = useCallback(
         () => setVisualizationLoaded(true),
         []
     )
 
+    const onError = () => setError(true)
+
+    useEffect(() => {
+        setError(false)
+    }, [filterVersion, visualization.type])
+
+    if (error) {
+        return (
+            <VisualizationErrorMessage
+                item={item}
+                dashboardMode={dashboardMode}
+            />
+        )
+    }
+
     return (
         <Suspense fallback={<div />}>
-            {!visualizationLoaded && <LoadingMask style={props.style} />}
+            {!visualizationLoaded && <LoadingMask style={style} />}
             <VisualizationPlugin
+                visualization={visualization}
                 forDashboard={true}
                 userSettings={userSettings}
+                style={style}
                 onLoadingComplete={onLoadingComplete}
-                {...props}
+                onError={onError}
             />
         </Suspense>
     )
 }
 
 DataVisualizerPlugin.propTypes = {
+    dashboardMode: PropTypes.string,
+    filterVersion: PropTypes.string,
+    item: PropTypes.object,
     style: PropTypes.object,
+    visualization: PropTypes.object,
 }
 
 export default DataVisualizerPlugin

--- a/src/components/Item/VisualizationItem/Visualization/Visualization.js
+++ b/src/components/Item/VisualizationItem/Visualization/Visualization.js
@@ -80,6 +80,9 @@ class Visualization extends React.Component {
                             itemFilters
                         )}
                         style={style}
+                        filterVersion={filterVersion}
+                        item={item}
+                        dashboardMode={this.props.dashboardMode}
                     />
                 )
             }
@@ -126,6 +129,7 @@ Visualization.propTypes = {
     activeType: PropTypes.string,
     availableHeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     availableWidth: PropTypes.number,
+    dashboardMode: PropTypes.string,
     item: PropTypes.object,
     itemFilters: PropTypes.object,
     visualization: PropTypes.object,

--- a/src/components/Item/VisualizationItem/Visualization/VisualizationErrorMessage.js
+++ b/src/components/Item/VisualizationItem/Visualization/VisualizationErrorMessage.js
@@ -1,0 +1,65 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import i18n from '@dhis2/d2-i18n'
+import { useConfig } from '@dhis2/app-runtime'
+import { colors } from '@dhis2/ui'
+
+import { getVisualizationId } from '../../../../modules/item'
+import { isPrintMode } from '../../../Dashboard/dashboardModes'
+
+import { getAppName, itemTypeMap } from '../../../../modules/itemTypes'
+
+import classes from './styles/VisualizationErrorMessage.module.css'
+
+const getErrorIcon = () => (
+    <svg
+        height="96"
+        viewBox="0 0 96 96"
+        width="96"
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <g fill={colors.grey400} transform="translate(3 3)">
+            <path d="m40.5 73.5000001c0 2.4852813 2.0147186 4.5 4.5 4.5s4.5-2.0147187 4.5-4.5c0-2.4142734-1.9012365-4.3844892-4.2881643-4.4951021l-.2128322-.0048979c-2.4848234.0005384-4.4990035 2.0150507-4.4990035 4.5z" />
+            <path d="m48 60v-30c0-1.6568542-1.3431458-3-3-3s-3 1.3431458-3 3v30c0 1.6568542 1.3431458 3 3 3s3-1.3431458 3-3z" />
+            <path d="m45-2.99904788c3.8985931 0 7.4578604 2.21715778 9.1770339 5.71709169l37.8912554 77.19048409c1.3845546 2.8165473 1.2171646 6.1482722-.4427191 8.811863-1.6598833 2.6635901-4.5771005 4.2816904-7.7135702 4.2796124h-77.82201115c-3.13845856.002078-6.05567574-1.6160223-7.71555901-4.2796124-1.65988369-2.6635908-1.82727377-5.9953157-.44346379-8.8103471l37.89234295-77.19269833c1.7188306-3.49923557 5.2780979-5.71639335 9.176691-5.71639335zm0 6c-1.6106864 0-3.0811818.91600885-3.7909661 2.36100407l-37.89274459 77.19351591c-.47005356.9562122-.41322496 2.0873262.15030227 2.99161.56352731.9042839 1.5539177 1.4529206 2.62140842 1.4529206h77.8259889c1.0655018 0 2.0558922-.5486367 2.6194195-1.4529206.5635272-.9042838.6203558-2.0353978.1495577-2.9931259l-37.8916571-77.19130167c-.7101272-1.44569356-2.1806226-2.36170241-3.791309-2.36170241z" />
+        </g>
+    </svg>
+)
+
+const VisualizationErrorMessage = ({ item, dashboardMode }) => {
+    const { baseUrl } = useConfig()
+
+    const visHref = `${baseUrl}/${itemTypeMap[item.type].appUrl(
+        getVisualizationId(item)
+    )}`
+
+    return (
+        <div className={classes.center}>
+            {getErrorIcon()}
+            <p className={classes.errorMessage}>
+                {i18n.t('There was an error loading data for this item')}
+            </p>
+            {!isPrintMode(dashboardMode) ? (
+                <p className={classes.appLink}>
+                    <a
+                        onClick={e => e.stopPropagation()}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        href={visHref}
+                    >
+                        {i18n.t('Open this item in {{appName}}', {
+                            appName: getAppName(item.type),
+                        })}
+                    </a>
+                </p>
+            ) : null}
+        </div>
+    )
+}
+
+VisualizationErrorMessage.propTypes = {
+    dashboardMode: PropTypes.string,
+    item: PropTypes.object,
+}
+
+export default VisualizationErrorMessage

--- a/src/components/Item/VisualizationItem/Visualization/styles/VisualizationErrorMessage.module.css
+++ b/src/components/Item/VisualizationItem/Visualization/styles/VisualizationErrorMessage.module.css
@@ -1,0 +1,18 @@
+.center {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+}
+
+.errorMessage {
+    margin-bottom: var(--spacers-dp8);
+    font-size: 16px;
+    font-weight: 600;
+}
+
+.appLink {
+    font-size: 16px;
+    margin-top: var(--spacers-dp8);
+}

--- a/src/components/Item/VisualizationItem/__tests__/__snapshots__/Item.spec.js.snap
+++ b/src/components/Item/VisualizationItem/__tests__/__snapshots__/Item.spec.js.snap
@@ -36,9 +36,7 @@ exports[`VisualizationItem/Item does not render Visualization if config not load
     message="There was a problem loading this dashboard item"
     onFatalError={[Function]}
   >
-    <div
-      className="dashboard-item-content"
-    />
+    <div />
   </FatalErrorBoundary>
 </Fragment>
 `;


### PR DESCRIPTION
Backport of https://github.com/dhis2/dashboard-app/pull/1826

Add callback for errors from DataVisualizerPlugin. The implementation is based on the sketch from DHIS2-2839.

Changes to VisualizationItem/Item look like a lot, but the only change was to nest another <div> so that the error message could be centered vertically.

The key part of the fix is in DataVisualizerPlugin with the error handler, and resetting the error state when either the filter or the visualization type changes (i.e., View As Table).