### PR TITLE
fix: add onError cb to handle failed chart from DV plugin [DHIS2-11303] [v34]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-08-26T13:20:39.720Z\n"
-"PO-Revision-Date: 2020-08-26T13:20:39.720Z\n"
+"POT-Creation-Date: 2021-07-06T14:06:20.506Z\n"
+"PO-Revision-Date: 2021-07-06T14:06:20.506Z\n"
 
 msgid "Untitled dashboard"
 msgstr ""
@@ -116,6 +116,12 @@ msgid "View as Map"
 msgstr ""
 
 msgid "Open in {{appName}} app"
+msgstr ""
+
+msgid "There was an error loading data for this item"
+msgstr ""
+
+msgid "Open this item in {{appName}}"
 msgstr ""
 
 msgid "Confirm"

--- a/src/components/Item/VisualizationItem/VisualizationErrorMessage.js
+++ b/src/components/Item/VisualizationItem/VisualizationErrorMessage.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import i18n from '@dhis2/d2-i18n';
+
+import { extractFavorite } from './plugin';
+
+import { getAppName, itemTypeMap } from '../../../modules/itemTypes';
+
+import classes from './styles/VisualizationErrorMessage.module.css';
+
+const getErrorIcon = () => (
+    <svg
+        height="96"
+        viewBox="0 0 96 96"
+        width="96"
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <g fill="#d5dde5" transform="translate(3 3)">
+            <path d="m40.5 73.5000001c0 2.4852813 2.0147186 4.5 4.5 4.5s4.5-2.0147187 4.5-4.5c0-2.4142734-1.9012365-4.3844892-4.2881643-4.4951021l-.2128322-.0048979c-2.4848234.0005384-4.4990035 2.0150507-4.4990035 4.5z" />
+            <path d="m48 60v-30c0-1.6568542-1.3431458-3-3-3s-3 1.3431458-3 3v30c0 1.6568542 1.3431458 3 3 3s3-1.3431458 3-3z" />
+            <path d="m45-2.99904788c3.8985931 0 7.4578604 2.21715778 9.1770339 5.71709169l37.8912554 77.19048409c1.3845546 2.8165473 1.2171646 6.1482722-.4427191 8.811863-1.6598833 2.6635901-4.5771005 4.2816904-7.7135702 4.2796124h-77.82201115c-3.13845856.002078-6.05567574-1.6160223-7.71555901-4.2796124-1.65988369-2.6635908-1.82727377-5.9953157-.44346379-8.8103471l37.89234295-77.19269833c1.7188306-3.49923557 5.2780979-5.71639335 9.176691-5.71639335zm0 6c-1.6106864 0-3.0811818.91600885-3.7909661 2.36100407l-37.89274459 77.19351591c-.47005356.9562122-.41322496 2.0873262.15030227 2.99161.56352731.9042839 1.5539177 1.4529206 2.62140842 1.4529206h77.8259889c1.0655018 0 2.0558922-.5486367 2.6194195-1.4529206.5635272-.9042838.6203558-2.0353978.1495577-2.9931259l-37.8916571-77.19130167c-.7101272-1.44569356-2.1806226-2.36170241-3.791309-2.36170241z" />
+        </g>
+    </svg>
+);
+
+const VisualizationErrorMessage = ({ item, baseUrl }) => {
+    const visHref = `${baseUrl}/${itemTypeMap[item.type].appUrl(
+        extractFavorite(item).id
+    )}`;
+
+    return (
+        <div className={classes.center}>
+            {getErrorIcon()}
+            <p className={classes.errorMessage}>
+                {i18n.t('There was an error loading data for this item')}
+            </p>
+            <p className={classes.appLink}>
+                <a
+                    onClick={e => e.stopPropagation()}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href={visHref}
+                >
+                    {i18n.t('Open this item in {{appName}}', {
+                        appName: getAppName(item.type),
+                    })}
+                </a>
+            </p>
+        </div>
+    );
+};
+
+VisualizationErrorMessage.propTypes = {
+    baseUrl: PropTypes.string,
+    item: PropTypes.object,
+};
+
+export default VisualizationErrorMessage;

--- a/src/components/Item/VisualizationItem/styles/VisualizationErrorMessage.module.css
+++ b/src/components/Item/VisualizationItem/styles/VisualizationErrorMessage.module.css
@@ -1,0 +1,23 @@
+.center {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+}
+
+.errorMessage {
+    margin-top: var(--spacers-dp48);
+    margin-bottom: var(--spacers-dp8);
+    font-size: 16px;
+    font-weight: 600;
+}
+
+.appLink {
+    font-size: 16px;
+    margin-top: var(--spacers-dp8);
+}
+
+.appLink a {
+    color: var(--colors-grey700);
+}


### PR DESCRIPTION
Backport of #1826

Add callback for errors from DataVisualizerPlugin. The implementation is based on the sketch from DHIS2-2839.

![image](https://user-images.githubusercontent.com/6113918/124616327-46302680-de76-11eb-97d1-afa384c1fe5e.png)
