### PR TITLE
fix: set correct item height when adding dashboard items in edit mode (#1869)

### DIFF
--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -234,33 +234,25 @@ export class Item extends Component {
                     )}
                     onFatalError={this.onFatalError}
                 >
-                    <div ref={ref => (this.contentRef = ref)}>
+                    <div
+                        className="dashboard-item-content"
+                        ref={ref => (this.contentRef = ref)}
+                    >
                         {this.state.configLoaded && (
                             <WindowDimensionsCtx.Consumer>
                                 {dimensions => (
-                                    <div
-                                        className="dashboard-item-content"
-                                        style={{
-                                            height: this.getAvailableHeight(
-                                                dimensions
-                                            ),
-                                        }}
-                                    >
-                                        <Visualization
-                                            item={item}
-                                            activeType={activeType}
-                                            itemFilters={itemFilters}
-                                            availableHeight={this.getAvailableHeight(
-                                                dimensions
-                                            )}
-                                            availableWidth={this.getAvailableWidth()}
-                                            isFullscreen={
-                                                this.state.isFullscreen
-                                            }
-                                            gridWidth={this.props.gridWidth}
-                                            dashboardMode={dashboardMode}
-                                        />
-                                    </div>
+                                    <Visualization
+                                        item={item}
+                                        activeType={activeType}
+                                        itemFilters={itemFilters}
+                                        availableHeight={this.getAvailableHeight(
+                                            dimensions
+                                        )}
+                                        availableWidth={this.getAvailableWidth()}
+                                        isFullscreen={this.state.isFullscreen}
+                                        gridWidth={this.props.gridWidth}
+                                        dashboardMode={dashboardMode}
+                                    />
                                 )}
                             </WindowDimensionsCtx.Consumer>
                         )}

--- a/src/components/Item/VisualizationItem/Visualization/DataVisualizerPlugin.js
+++ b/src/components/Item/VisualizationItem/Visualization/DataVisualizerPlugin.js
@@ -34,10 +34,12 @@ const DataVisualizerPlugin = ({
 
     if (error) {
         return (
-            <VisualizationErrorMessage
-                item={item}
-                dashboardMode={dashboardMode}
-            />
+            <div style={style}>
+                <VisualizationErrorMessage
+                    item={item}
+                    dashboardMode={dashboardMode}
+                />
+            </div>
         )
     }
 

--- a/src/components/Item/VisualizationItem/Visualization/styles/VisualizationErrorMessage.module.css
+++ b/src/components/Item/VisualizationItem/Visualization/styles/VisualizationErrorMessage.module.css
@@ -7,6 +7,7 @@
 }
 
 .errorMessage {
+    margin-top: var(--spacers-dp48);
     margin-bottom: var(--spacers-dp8);
     font-size: 16px;
     font-weight: 600;
@@ -15,4 +16,8 @@
 .appLink {
     font-size: 16px;
     margin-top: var(--spacers-dp8);
+}
+
+.appLink a {
+    color: var(--colors-grey700);
 }

--- a/src/components/Item/VisualizationItem/__tests__/__snapshots__/Item.spec.js.snap
+++ b/src/components/Item/VisualizationItem/__tests__/__snapshots__/Item.spec.js.snap
@@ -36,7 +36,9 @@ exports[`VisualizationItem/Item does not render Visualization if config not load
     message="There was a problem loading this dashboard item"
     onFatalError={[Function]}
   >
-    <div />
+    <div
+      className="dashboard-item-content"
+    />
   </FatalErrorBoundary>
 </Fragment>
 `;


### PR DESCRIPTION
Backport of #1868

Remove the nested div that was causing the height for a visualization to not be set during edit mode. Fix was to restore the previous DOM structure, and just add a div around the error message with the needed height.

This bug was introduced by the fix for DHIS2-11303. PR that introduced the bug: #1832
The other change in this PR is to improve the styling of the error message.