### PR TITLE
fix: restore cypress tests checking response code 201

### DIFF
--- a/cypress/integration/edit/edit_dashboard/show_description.js
+++ b/cypress/integration/edit/edit_dashboard/show_description.js
@@ -2,7 +2,7 @@ import { When, Then } from 'cypress-cucumber-preprocessor/steps'
 import { clickViewActionButton } from '../../../elements/viewDashboard'
 import { getApiBaseUrl } from '../../../support/server/utils'
 
-const SHOW_DESC_RESP_CODE_SUCCESS = 200
+const SHOW_DESC_RESP_CODE_SUCCESS = 201
 const SHOW_DESC_RESP_CODE_FAIL = 409
 
 before(() => {

--- a/cypress/integration/view/view_errors/error_while_show_description.js
+++ b/cypress/integration/view/view_errors/error_while_show_description.js
@@ -12,7 +12,7 @@ before(() => {
             'content-type': 'application/json',
         },
         body: 'false',
-    }).then(response => expect(response.status).to.equal(200))
+    }).then(response => expect(response.status).to.equal(201))
 })
 
 When('clicking to show description fails', () => {


### PR DESCRIPTION
Backend restored the code to 201 from 200

Reverting this PR: https://github.com/dhis2/dashboard-app/pull/1896. (not an exact match, thus a new commit rather than a "revert" commit)