### PR TITLE
fix: adjust z-index so Show more/fewer dashboards tooltip is visible [aDHIS2-11647]

### DIFF
--- a/src/pages/view/DashboardsBar/ShowMoreButton.js
+++ b/src/pages/view/DashboardsBar/ShowMoreButton.js
@@ -34,7 +34,12 @@ const ShowMoreButton = ({ onClick, dashboardBarIsExpanded, disabled }) => {
                     <ChevronDown />
                 </div>
             ) : (
-                <Tooltip content={buttonLabel} placement="bottom">
+                <Tooltip
+                    content={buttonLabel}
+                    placement="top"
+                    openDelay={500}
+                    closeDelay={0}
+                >
                     {({ onMouseOver, onMouseOut, ref }) => (
                         <button
                             className={classes.showMore}

--- a/src/pages/view/DashboardsBar/styles/DashboardsBar.module.css
+++ b/src/pages/view/DashboardsBar/styles/DashboardsBar.module.css
@@ -23,7 +23,7 @@
 
 .expanded .container {
     height: var(--max-rows-height);
-    z-index: 2001;
+    z-index: 1999;
 }
 
 .spacer {

--- a/src/pages/view/ViewDashboard.js
+++ b/src/pages/view/ViewDashboard.js
@@ -3,7 +3,6 @@ import {
     Layer,
     CenteredContent,
     CircularLoader,
-    ComponentCover,
     AlertStack,
     AlertBar,
 } from '@dhis2/ui'
@@ -101,9 +100,8 @@ const ViewDashboard = props => {
                 ) : (
                     <DashboardContainer covered={controlbarExpanded}>
                         {controlbarExpanded && (
-                            <ComponentCover
+                            <div
                                 className={classes.cover}
-                                translucent
                                 onClick={() => setControlbarExpanded(false)}
                             />
                         )}

--- a/src/pages/view/styles/ViewDashboard.module.css
+++ b/src/pages/view/styles/ViewDashboard.module.css
@@ -4,8 +4,14 @@
     height: 100%;
     position: relative;
 }
-
 .cover {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 1998;
+    background: rgba(33, 43, 54, 0.4);
     display: none;
 }
 


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-11647

Because of competing z-indexes on the component cover and tooltip, the tooltip was hidden when the dashboards bar was expanded.

Components should be stacked from bottom to top:  cover, dashboards bar, tooltip.
Previously, the z-index of these was: 2000, 2001, 2000 which means the tooltip wasn't visible.
With the new code, the z-index is: 1998, 1999, 2000. (Cannot use ui ComponentCover since z-index is not configurable).

Regular screen:

https://user-images.githubusercontent.com/6113918/130608062-db8da82b-5441-4208-9504-5d960c584228.mov

Small screen:



https://user-images.githubusercontent.com/6113918/130612293-5ceb9b59-c984-4469-8c77-9bd4f6875777.mov

