### PR TITLE
fix: disable dirty check on exit (DHIS2-11701)

### DIFF
--- a/cypress/integration/edit/edit_dashboard.feature
+++ b/cypress/integration/edit/edit_dashboard.feature
@@ -23,7 +23,7 @@ Feature: Creating, editing and deleting dashboard
         When I choose to edit dashboard
         And dashboard title is added
         And I click Exit without saving
-        And I decide to continue editing
+    #   And I decide to continue editing
         Then the dashboard displays in edit mode
 
     # @mutating
@@ -42,7 +42,7 @@ Feature: Creating, editing and deleting dashboard
         When I choose to edit dashboard
         And dashboard title is added
         And I click Exit without saving
-        And I confirm I want to discard changes
+    #   And I confirm I want to discard changes
         Then the dashboard displays in view mode
 
     @mutating

--- a/cypress/integration/edit/edit_dashboard.feature
+++ b/cypress/integration/edit/edit_dashboard.feature
@@ -17,14 +17,14 @@ Feature: Creating, editing and deleting dashboard
         And I click Exit without saving
         Then the dashboard displays in view mode
 
-    @mutating
-    Scenario: I cancel exit without saving when name changed
-        Given I open existing dashboard
-        When I choose to edit dashboard
-        And dashboard title is added
-        And I click Exit without saving
-    #   And I decide to continue editing
-        Then the dashboard displays in edit mode
+    # @mutating
+    # Scenario: I cancel exit without saving when name changed
+    #     Given I open existing dashboard
+    #     When I choose to edit dashboard
+    #     And dashboard title is added
+    #     And I click Exit without saving
+    #     And I decide to continue editing
+    #     Then the dashboard displays in edit mode
 
     # @mutating
     # Scenario: I cancel exit without saving when item added
@@ -42,7 +42,7 @@ Feature: Creating, editing and deleting dashboard
         When I choose to edit dashboard
         And dashboard title is added
         And I click Exit without saving
-    #   And I confirm I want to discard changes
+        #   And I confirm I want to discard changes
         Then the dashboard displays in view mode
 
     @mutating

--- a/cypress/integration/edit/filter_restrict.feature
+++ b/cypress/integration/edit/filter_restrict.feature
@@ -52,7 +52,7 @@ Feature: Editing Filter Restrictions
         And I add Facility Ownership to selected filters
         And I click Confirm
         And I click Exit without saving
-        And I confirm I want to discard changes
+        # And I confirm I want to discard changes
         Then the dashboard displays in view mode
         When I choose to edit dashboard
         And I click on Filter settings

--- a/cypress/integration/view/offline.feature
+++ b/cypress/integration/view/offline.feature
@@ -52,11 +52,11 @@ Feature: Offline dashboard
         When I click Exit without saving
         Then the cached dashboard is loaded and displayed in view mode
 
-    Scenario: The sharing dialog is open when connectivity is lost
-        Given I open a cached dashboard
-        When I open sharing settings
-        And connectivity is turned off
-        Then it is not possible to change sharing settings
+    # Scenario: The sharing dialog is open when connectivity is lost
+    #     Given I open a cached dashboard
+    #     When I open sharing settings
+    #     And connectivity is turned off
+    #     Then it is not possible to change sharing settings
 
     # Scenario: The interpretations panel is open when connectivity is lost
     #     Given I open a cached dashboard

--- a/src/pages/edit/ActionsBar.js
+++ b/src/pages/edit/ActionsBar.js
@@ -98,11 +98,13 @@ const EditBar = ({ dashboard, ...props }) => {
     }
 
     const onConfirmDiscard = () => {
-        if (props.isDirty) {
-            setConfirmDiscardDlgIsOpen(true)
-        } else {
-            onDiscardConfirmed()
-        }
+        // disabling dirty check in 2.37
+
+        // if (props.isDirty) {
+        //     setConfirmDiscardDlgIsOpen(true)
+        // } else {
+        onDiscardConfirmed()
+        // }
     }
 
     const onDiscardConfirmed = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2372,7 +2372,7 @@
     markdown-it "^8.4.2"
     prop-types "^15.6.2"
 
-"@dhis2/d2-ui-sharing-dialog@7.3.2", "@dhis2/d2-ui-sharing-dialog@^7.3.2":
+"@dhis2/d2-ui-sharing-dialog@7.3.2":
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-sharing-dialog/-/d2-ui-sharing-dialog-7.3.2.tgz#081cf3fcddb3b0095755263dc241ffda29bf6a85"
   integrity sha512-1vywqSJudJFYx5sxXVx+lO3IrApqqQlM2zykWFAcjNElYeYZvBycATk0szTQoJvhCP6M90rMNbuKPpYiTE6BgQ==
@@ -2522,7 +2522,7 @@
     "@dhis2/prop-types" "^1.6.4"
     classnames "^2.3.1"
 
-"@dhis2/ui@^6.19.0", "@dhis2/ui@^6.20.0":
+"@dhis2/ui@6.20.0", "@dhis2/ui@^6.19.0", "@dhis2/ui@^6.20.0":
   version "6.20.0"
   resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-6.20.0.tgz#00473fdec2dfb40d351fefcba379cc5f96472311"
   integrity sha512-l/ClExMi21FPIEfMg2bCvlLLUOx8r6s+3ZJudkMLtqSZvteZV9BYyPBUr2EyACBrtmwIbwvj71TBfZ3D6wSx8Q==
@@ -17860,8 +17860,10 @@ watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
+    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
+    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
Removing the "dirty" check which would display the "Discard changes?" modal when "Exit without saving" was clicked after making changes to the title/description.