### PR TITLE
fix: reduce cypress test runners from 10 to 3 for better stability

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -111,7 +111,7 @@ jobs:
 
         strategy:
             matrix:
-                containers: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+                containers: [1, 2, 3]
 
         steps:
             - name: Checkout


### PR DESCRIPTION
Seeing a lot of random errors that may be concurrency related.