### PR TITLE
fix: add callback for when recording fails

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-08-31T20:31:16.412Z\n"
-"PO-Revision-Date: 2021-08-31T20:31:16.412Z\n"
+"POT-Creation-Date: 2021-09-07T13:08:57.602Z\n"
+"PO-Revision-Date: 2021-09-07T13:08:57.602Z\n"
 
 msgid "Untitled dashboard"
 msgstr "Untitled dashboard"
@@ -420,6 +420,9 @@ msgstr "No, cancel"
 
 msgid "Yes, remove filters"
 msgstr "Yes, remove filters"
+
+msgid "The dashboard couldn't be made available offline. Try again."
+msgstr "The dashboard couldn't be made available offline. Try again."
 
 msgid "Failed to hide description"
 msgstr "Failed to hide description"

--- a/src/pages/view/TitleBar/ActionsBar.js
+++ b/src/pages/view/TitleBar/ActionsBar.js
@@ -70,29 +70,35 @@ const ViewActions = ({
         return <Redirect to={redirectUrl} />
     }
 
+    const onRecordError = () => {
+        warningAlert.show({
+            msg: i18n.t('The dashboard could not be cached. Please try again'),
+        })
+    }
+
     const onCacheDashboardConfirmed = () => {
         setConfirmCacheDialogIsOpen(false)
         removeAllFilters()
-        startRecording({})
+        startRecording({
+            onError: onRecordError,
+        })
     }
 
     const onToggleOfflineStatus = () => {
-        toggleMoreOptions()
-
         if (lastUpdated) {
             return remove()
         }
 
-        return filtersLength
-            ? setConfirmCacheDialogIsOpen(true)
-            : startRecording({})
+        onUpdateOfflineCache()
     }
 
     const onUpdateOfflineCache = () => {
         toggleMoreOptions()
         return filtersLength
             ? setConfirmCacheDialogIsOpen(true)
-            : startRecording({})
+            : startRecording({
+                  onError: onRecordError,
+              })
     }
 
     const onToggleShowDescription = () =>

--- a/src/pages/view/TitleBar/ActionsBar.js
+++ b/src/pages/view/TitleBar/ActionsBar.js
@@ -72,7 +72,7 @@ const ViewActions = ({
 
     const onRecordError = () => {
         warningAlert.show({
-            msg: i18n.t('The dashboard could not be cached. Please try again'),
+            msg: i18n.t('The dashboard could not be cached. Please try again.'),
         })
     }
 

--- a/src/pages/view/TitleBar/ActionsBar.js
+++ b/src/pages/view/TitleBar/ActionsBar.js
@@ -57,9 +57,11 @@ const ViewActions = ({
     const { lastUpdated, isCached, startRecording, remove } =
         useCacheableSection(id)
 
-    const warningAlert = useAlert(({ msg }) => msg, {
-        warning: true,
-    })
+    const { show } = useAlert(
+        ({ msg }) => msg,
+        ({ isCritical }) =>
+            isCritical ? { critical: true } : { warning: true }
+    )
 
     const toggleMoreOptions = small =>
         small
@@ -71,8 +73,11 @@ const ViewActions = ({
     }
 
     const onRecordError = () => {
-        warningAlert.show({
-            msg: i18n.t('The dashboard could not be cached. Please try again.'),
+        show({
+            msg: i18n.t(
+                "The dashboard couldn't be made available offline. Try again."
+            ),
+            isCritical: true,
         })
     }
 
@@ -111,7 +116,7 @@ const ViewActions = ({
                 const msg = showDescription
                     ? i18n.t('Failed to hide description')
                     : i18n.t('Failed to show description')
-                warningAlert.show({ msg })
+                show({ msg, isCritical: false })
             })
 
     const onToggleStarredDashboard = () =>
@@ -126,7 +131,7 @@ const ViewActions = ({
                 const msg = starred
                     ? i18n.t('Failed to unstar the dashboard')
                     : i18n.t('Failed to star the dashboard')
-                warningAlert.show({ msg })
+                show({ msg, isCritical: false })
             })
 
     const onToggleSharingDialog = () =>


### PR DESCRIPTION
The callback does not trigger in cases of 40x from the backend.

Update:
![image](https://user-images.githubusercontent.com/6113918/132351971-49f7b859-1248-4fa4-8ba5-3cdbea8c5b32.png)


https://user-images.githubusercontent.com/6113918/132322509-51ff5e06-16b1-4d3a-855a-c09c9dbab62e.mov

