### PR TITLE
fix: restore z-index that makes the dashboards bar bottom shadow appear on top of the dashboard content [v37]

### DIFF
--- a/src/pages/view/DashboardsBar/styles/DashboardsBar.module.css
+++ b/src/pages/view/DashboardsBar/styles/DashboardsBar.module.css
@@ -13,6 +13,7 @@
     flex-direction: column;
     height: var(--user-rows-height);
     width: 100%;
+    z-index: 1;
 }
 
 .content {


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-11685

![image](https://user-images.githubusercontent.com/6113918/132349213-a5e9b283-eab7-49cd-b69a-ba36684a546a.png)

