### PR TITLE
fix: restore z-index that makes the dashboards bar bottom shadow appear on top of the dashboard content [v36] 

### DIFF
--- a/src/components/ControlBar/ViewControlBar/styles/DashboardsBar.module.css
+++ b/src/components/ControlBar/ViewControlBar/styles/DashboardsBar.module.css
@@ -2,6 +2,7 @@
     position: relative;
     background-color: var(--colors-white);
     box-shadow: rgba(0, 0, 0, 0.2) 0 0 6px 3px;
+    z-index: 1;
     overflow: hidden;
     box-sizing: border-box;
     flex: none;


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-11685

![image](https://user-images.githubusercontent.com/6113918/132347857-0ca6af15-a267-4e28-a78c-c7086b43cc29.png)
