### PR TITLE
fix: show/hide description regardless of whether offline

### DIFF
--- a/cypress/integration/view/offline.feature
+++ b/cypress/integration/view/offline.feature
@@ -65,6 +65,12 @@ Feature: Offline dashboard
         When connectivity is turned off
         Then it is not possible to interact with interpretations
 
+    Scenario: I show the description while offline
+        Given I open an uncached dashboard
+        And connectivity is turned off
+        When I choose Show Description
+        Then the description is shown along with a warning
+
 
     Scenario: I delete the cached and uncached dashboard
         Given I delete the cached and uncached dashboard

--- a/cypress/integration/view/offline/offline.js
+++ b/cypress/integration/view/offline/offline.js
@@ -242,7 +242,10 @@ When('I click to open an uncached dashboard', () => {
 })
 
 When('I click to open an uncached dashboard when offline', () =>
-    openDashboard(UNCACHED_DASHBOARD_TITLE)
+    cy
+        .get(dashboardChipSel, EXTENDED_TIMEOUT)
+        .contains(UNCACHED_DASHBOARD_TITLE)
+        .click()
 )
 
 When('I click to open a cached dashboard when offline', () =>

--- a/cypress/integration/view/offline/offline.js
+++ b/cypress/integration/view/offline/offline.js
@@ -58,7 +58,7 @@ const createDashboard = cacheState => {
 }
 
 const openDashboard = title => {
-    cy.get(dashboardChipSel).contains(title).click()
+    cy.get(dashboardChipSel, EXTENDED_TIMEOUT).contains(title).click()
     checkDashboardIsVisible(title)
 }
 
@@ -241,13 +241,13 @@ When('I click to open an uncached dashboard', () => {
     cy.contains(OFFLINE_DATA_LAST_UPDATED_TEXT).should('not.exist')
 })
 
-When('I click to open an uncached dashboard when offline', () => {
-    cy.get(dashboardChipSel).contains(UNCACHED_DASHBOARD_TITLE).click()
-})
+When('I click to open an uncached dashboard when offline', () =>
+    openDashboard(UNCACHED_DASHBOARD_TITLE)
+)
 
-When('I click to open a cached dashboard when offline', () => {
-    cy.get(dashboardChipSel).contains(CACHED_DASHBOARD_TITLE).click()
-})
+When('I click to open a cached dashboard when offline', () =>
+    openDashboard(CACHED_DASHBOARD_TITLE)
+)
 
 // Scenario: I am offline and switch to a cached dashboard
 Then('the cached dashboard is loaded and displayed in view mode', () => {

--- a/cypress/integration/view/offline/offline.js
+++ b/cypress/integration/view/offline/offline.js
@@ -13,6 +13,7 @@ import {
     clickViewActionButton,
     dashboardTitleSel,
     dashboardChipSel,
+    dashboardDescriptionSel,
 } from '../../../elements/viewDashboard'
 import { EXTENDED_TIMEOUT, goOnline, goOffline } from '../../../support/utils'
 
@@ -94,7 +95,10 @@ const checkCorrectMoreOptionsEnabledState = (online, cacheState) => {
         cy.contains('li', 'Print').should('not.have.class', 'disabled')
     } else {
         cy.contains('li', 'Star dashboard').should('have.class', 'disabled')
-        cy.contains('li', 'Show description').should('have.class', 'disabled')
+        cy.contains('li', 'Show description').should(
+            'not.have.class',
+            'disabled'
+        )
         if (cacheState === CACHED) {
             cy.contains('li', 'Print').should('not.have.class', 'disabled')
         } else {
@@ -312,4 +316,13 @@ Then('it is not possible to interact with interpretations', () => {
 Given('I delete the cached and uncached dashboard', () => {
     deleteDashboard(UNCACHED_DASHBOARD_TITLE)
     deleteDashboard(CACHED_DASHBOARD_TITLE)
+})
+
+// Scenario: I show the description while offline
+When('I choose Show Description', () => {
+    clickViewActionButton('More')
+    cy.contains('Show description').click()
+})
+Then('the description is shown along with a warning', () => {
+    cy.get(dashboardDescriptionSel).should('be.visible')
 })

--- a/cypress/integration/view/offline/offline.js
+++ b/cypress/integration/view/offline/offline.js
@@ -241,16 +241,15 @@ When('I click to open an uncached dashboard', () => {
     cy.contains(OFFLINE_DATA_LAST_UPDATED_TEXT).should('not.exist')
 })
 
-When('I click to open an uncached dashboard when offline', () =>
-    cy
-        .get(dashboardChipSel, EXTENDED_TIMEOUT)
+When('I click to open an uncached dashboard when offline', () => {
+    cy.get(dashboardChipSel, EXTENDED_TIMEOUT)
         .contains(UNCACHED_DASHBOARD_TITLE)
         .click()
-)
+})
 
-When('I click to open a cached dashboard when offline', () =>
+When('I click to open a cached dashboard when offline', () => {
     openDashboard(CACHED_DASHBOARD_TITLE)
-)
+})
 
 // Scenario: I am offline and switch to a cached dashboard
 Then('the cached dashboard is loaded and displayed in view mode', () => {
@@ -326,14 +325,17 @@ When('I choose Show Description', () => {
     clickViewActionButton('More')
     cy.contains('Show description').click()
 })
+
 Then('the description is shown along with a warning', () => {
     cy.get(dashboardDescriptionSel).should('be.visible')
+})
 
 // Scenario: I remove a dashboard from cache while offline
 When('I click to Remove from offline storage', () => {
     clickViewActionButton('More')
     cy.contains('Remove from offline storage').click()
 })
+
 Then('the dashboard is not cached', () => {
     cy.contains(OFFLINE_DATA_LAST_UPDATED_TEXT).should('not.exist')
 })

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-09-07T13:08:57.602Z\n"
-"PO-Revision-Date: 2021-09-07T13:08:57.602Z\n"
+"POT-Creation-Date: 2021-09-08T13:07:16.333Z\n"
+"PO-Revision-Date: 2021-09-08T13:07:16.333Z\n"
 
 msgid "Untitled dashboard"
 msgstr "Untitled dashboard"
@@ -425,12 +425,6 @@ msgstr "Yes, remove filters"
 
 msgid "The dashboard couldn't be made available offline. Try again."
 msgstr "The dashboard couldn't be made available offline. Try again."
-
-msgid "Failed to hide description"
-msgstr "Failed to hide description"
-
-msgid "Failed to show description"
-msgstr "Failed to show description"
 
 msgid "Failed to unstar the dashboard"
 msgstr "Failed to unstar the dashboard"

--- a/src/components/MenuItemWithTooltip.js
+++ b/src/components/MenuItemWithTooltip.js
@@ -25,7 +25,10 @@ const MenuItemWithTooltip = ({
             dense
             disabled={notAllowed}
             label={
-                <OfflineTooltip content={tooltipContent}>
+                <OfflineTooltip
+                    content={tooltipContent}
+                    disabledWhenOffline={disabledWhenOffline}
+                >
                     {label}
                 </OfflineTooltip>
             }

--- a/src/components/OfflineTooltip.js
+++ b/src/components/OfflineTooltip.js
@@ -7,9 +7,9 @@ import React from 'react'
 import classes from './styles/Tooltip.module.css'
 
 const Tooltip = ({ disabledWhenOffline, content, children }) => {
-    const { online } = useOnlineStatus()
+    const { offline } = useOnlineStatus()
 
-    const notAllowed = disabledWhenOffline && !online
+    const notAllowed = disabledWhenOffline && offline
 
     return (
         <UiTooltip

--- a/src/pages/view/TitleBar/ActionsBar.js
+++ b/src/pages/view/TitleBar/ActionsBar.js
@@ -109,12 +109,7 @@ const ViewActions = ({
     const onToggleShowDescription = () => {
         updateShowDescription(!showDescription)
         toggleMoreOptions()
-        apiPostShowDescription(!showDescription).catch(() =>
-            show({
-                msg: i18n.t('Failed to save show/hide description preference.'),
-                isCritical: false,
-            })
-        )
+        !offline && apiPostShowDescription(!showDescription)
     }
 
     const onToggleStarredDashboard = () =>

--- a/src/pages/view/TitleBar/ActionsBar.js
+++ b/src/pages/view/TitleBar/ActionsBar.js
@@ -95,18 +95,15 @@ const ViewActions = ({
             : startRecording({})
     }
 
-    const onToggleShowDescription = () =>
-        apiPostShowDescription(!showDescription)
-            .then(() => {
-                updateShowDescription(!showDescription)
-                toggleMoreOptions()
+    const onToggleShowDescription = () => {
+        updateShowDescription(!showDescription)
+        toggleMoreOptions()
+        apiPostShowDescription(!showDescription).catch(() =>
+            warningAlert.show({
+                msg: i18n.t('Failed to save show/hide description preference.'),
             })
-            .catch(() => {
-                const msg = showDescription
-                    ? i18n.t('Failed to hide description')
-                    : i18n.t('Failed to show description')
-                warningAlert.show({ msg })
-            })
+        )
+    }
 
     const onToggleStarredDashboard = () =>
         apiStarDashboard(dataEngine, id, !starred)
@@ -160,7 +157,7 @@ const ViewActions = ({
             />
             <MenuItem
                 dense
-                disabled={offline}
+                disabledWhenOffline={false}
                 label={
                     showDescription
                         ? i18n.t('Hide description')

--- a/src/pages/view/TitleBar/ActionsBar.js
+++ b/src/pages/view/TitleBar/ActionsBar.js
@@ -112,7 +112,7 @@ const ViewActions = ({
         apiPostShowDescription(!showDescription).catch(() =>
             show({
                 msg: i18n.t('Failed to save show/hide description preference.'),
-                isCritical: false
+                isCritical: false,
             })
         )
     }

--- a/src/pages/view/TitleBar/__tests__/__snapshots__/FilterSelector.spec.js.snap
+++ b/src/pages/view/TitleBar/__tests__/__snapshots__/FilterSelector.spec.js.snap
@@ -7,7 +7,7 @@ exports[`is disabled when offline 1`] = `
   >
     <div>
       <span
-        class="span notAllowed"
+        class="span"
       >
         <button
           class="jsx-3597138218 "
@@ -67,7 +67,7 @@ exports[`is enabled when online 1`] = `
   >
     <div>
       <span
-        class="span notAllowed"
+        class="span"
       >
         <button
           class="jsx-3597138218 "


### PR DESCRIPTION
fixes https://jira.dhis2.org/browse/DHIS2-11723

Note that once the user shows/hides while offline, then the database and app may be out of sync until the next time the user reloads the app or changes the setting once online again.

Previously there was a warning message if the api request for showDescription preference failed, but that has been removed, per UX.

In this video, the user is offline:


https://user-images.githubusercontent.com/6113918/132518752-5640ac73-ed85-4397-9bf7-60a064ce5bf4.mov


