### PR TITLE
fix(deps): use latest app scripts to fix infinite update error

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "@dhis2/ui": "6.20.0"
     },
     "devDependencies": {
-        "@dhis2/cli-app-scripts": "^7.6.2",
+        "@dhis2/cli-app-scripts": "^7.6.4",
         "@dhis2/cli-style": "^9.1.0",
         "@dhis2/cli-utils-cypress": "^7.0.1",
         "@dhis2/cypress-commands": "^7.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2120,12 +2120,12 @@
     react-beautiful-dnd "^10.1.1"
     resize-observer-polyfill "^1.5.1"
 
-"@dhis2/app-adapter@7.6.2":
-  version "7.6.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-adapter/-/app-adapter-7.6.2.tgz#b2aa4bd76fa1e628692dd38887aec4a1ba90cb5b"
-  integrity sha512-cQvhgWMINcYsz6KkaSmCNkpdFuwC0BdUDN7iHrWVo/8DdiCb5zkH2RDuIOChtYQSpcvUeLnCJR/Drh99KiPCFg==
+"@dhis2/app-adapter@7.6.4":
+  version "7.6.4"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-adapter/-/app-adapter-7.6.4.tgz#8f53e1d0332f4ce3bfd92b78cf102c8e647129a1"
+  integrity sha512-0qfYwtvSYs5tWJPINrRXsz7Bz3k6Ksdz4ZGEy7w4K7Su+7rUWTIvEfUv/5TroJ5KLwLBf2QJDi/p3J1LQEuV9Q==
   dependencies:
-    "@dhis2/pwa" "7.6.2"
+    "@dhis2/pwa" "7.6.4"
     moment "^2.24.0"
 
 "@dhis2/app-runtime-adapter-d2@^1.1.0":
@@ -2167,15 +2167,15 @@
   dependencies:
     lodash "^4.17.21"
 
-"@dhis2/app-shell@7.6.2":
-  version "7.6.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-shell/-/app-shell-7.6.2.tgz#dfdd91184db600e9af93d09c78043e78eaa54946"
-  integrity sha512-9dh1Gv3F8C0eaolnjuqygaNPzPYV39E16ufbzDmV15uDq3UZ/N1rD/SOhRjimNYGvIthGg5oWDaIj6TE5d81ow==
+"@dhis2/app-shell@7.6.4":
+  version "7.6.4"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-shell/-/app-shell-7.6.4.tgz#b06d6a742429c4fbdbcef7687867253779e25e43"
+  integrity sha512-gFsj4KCvwgLdldNBVSbZaPhtbi2SRjCC0vzwWzwAWVDg0FP5xTFY8dRmswXAJfw4sw3slgqCFaFmoVTzAxFirQ==
   dependencies:
-    "@dhis2/app-adapter" "7.6.2"
+    "@dhis2/app-adapter" "7.6.4"
     "@dhis2/app-runtime" "^2.11.0"
     "@dhis2/d2-i18n" "^1.1.0"
-    "@dhis2/pwa" "7.6.2"
+    "@dhis2/pwa" "7.6.4"
     "@dhis2/ui" "^6.19.0"
     classnames "^2.2.6"
     moment "^2.29.1"
@@ -2188,10 +2188,10 @@
     typeface-roboto "^0.0.75"
     typescript "^3.6.3"
 
-"@dhis2/cli-app-scripts@^7.6.2":
-  version "7.6.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/cli-app-scripts/-/cli-app-scripts-7.6.2.tgz#279f288861d32b8eff6ab7f50d9e29c5e2fb927e"
-  integrity sha512-j53s3xjNMzgMzktB7jVn4UVsQtE1n3N0E6UYv1lSMrinxPhYRtbOCAmWqj/8YUAPkTb73AcHL4A7qnqPYv5NXQ==
+"@dhis2/cli-app-scripts@^7.6.4":
+  version "7.6.4"
+  resolved "https://registry.yarnpkg.com/@dhis2/cli-app-scripts/-/cli-app-scripts-7.6.4.tgz#796f946e41f770a9d90d5c4dc104b0817e56a43a"
+  integrity sha512-OtNJ/Bb857lx6n8rKVY9p4Jq+g2Z1HT/aOnme0jQdl33hS0aJ/trb1/S4J2k8qlzkBTTFwyfiqjdgPpmeAQrZQ==
   dependencies:
     "@babel/core" "^7.6.2"
     "@babel/plugin-proposal-class-properties" "^7.8.3"
@@ -2200,7 +2200,7 @@
     "@babel/preset-env" "^7.14.7"
     "@babel/preset-react" "^7.0.0"
     "@babel/preset-typescript" "^7.6.0"
-    "@dhis2/app-shell" "7.6.2"
+    "@dhis2/app-shell" "7.6.4"
     "@dhis2/cli-helpers-engine" "^3.0.0"
     archiver "^3.1.1"
     axios "^0.20.0"
@@ -2429,10 +2429,10 @@
   dependencies:
     prop-types "^15"
 
-"@dhis2/pwa@7.6.2":
-  version "7.6.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/pwa/-/pwa-7.6.2.tgz#a491814d8d11f652541060545955136843eb2f5c"
-  integrity sha512-+nQql4LMaLkqjGP/2KXc1sMFyLmCNmewD196wZwr4OyUc7SZTdgFFcqI/mPd5T4a/8VkWxSOuCZbQfO5s29JJA==
+"@dhis2/pwa@7.6.4":
+  version "7.6.4"
+  resolved "https://registry.yarnpkg.com/@dhis2/pwa/-/pwa-7.6.4.tgz#a1eee94278c28aaacd108f5eb15e5ff7b7e6971c"
+  integrity sha512-vd1vFRlTwTLrfpuWcSEyp3cEzdFt6WHqGRXq9yhwV4iTmACD30b3aoLN8kKtQF81Mhdr/8zDMCDPRRHpCiKmig==
   dependencies:
     idb "^6.0.0"
     workbox-core "^6.1.5"
@@ -17871,10 +17871,8 @@ watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
-    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
-    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
See this slack [thread](https://dhis2.slack.com/archives/C3VLBMCTH/p1630922990074600)

Uses latest `@dhis2/cli-app-scripts` to fix some bugs, including the infinite update error in Chrome when a SW registers for the first time and 'Update on reload' is checked in the dev tools