### PR TITLE
fix: reduce the size of the item menu (DHIS2-11750)

### DIFF
--- a/src/pages/edit/ItemSelector/styles/ItemSelector.module.css
+++ b/src/pages/edit/ItemSelector/styles/ItemSelector.module.css
@@ -1,5 +1,5 @@
 .menu {
-    height: 70vh;
+    height: 50vh;
     width: 700px;
 }
 


### PR DESCRIPTION
Fixes [DHIS2-11750](https://jira.dhis2.org/browse/DHIS2-11750)

The item selector is too tall on a small laptop screen (13"), which made the popover cover the input field.
By reducing the size to `50vh`, its now small enough to fit on a small laptop but becomes large enough to be useful on a larger screen (in contrast to using a fixed size in `px`)

_before_
![image](https://user-images.githubusercontent.com/12590483/132690503-74265848-1e28-48ff-8b66-37f5d846657e.png)

_after_
![image](https://user-images.githubusercontent.com/12590483/132690441-7406b216-568f-4f9f-add1-85fb3cc890f5.png)
