### PR TITLE
fix: when loading a dashboard set the loaded flag after the fetch so state doesn't toggle back and forth [v37]

### DIFF
--- a/src/pages/view/ViewDashboard.js
+++ b/src/pages/view/ViewDashboard.js
@@ -33,7 +33,7 @@ const ViewDashboard = props => {
     const [loaded, setLoaded] = useState(false)
     const [loadFailed, setLoadFailed] = useState(false)
     const { online } = useOnlineStatus()
-    const { isCached, recordingState } = useCacheableSection(props.requestedId)
+    const { isCached } = useCacheableSection(props.requestedId)
 
     useEffect(() => {
         setHeaderbarVisible(true)
@@ -76,9 +76,8 @@ const ViewDashboard = props => {
             }, 500)
 
             try {
-                setLoaded(true)
                 await props.fetchDashboard(props.requestedId, props.username)
-
+                setLoaded(true)
                 setLoadFailed(false)
                 setLoadingMessage(null)
                 clearTimeout(alertTimeout)
@@ -93,16 +92,14 @@ const ViewDashboard = props => {
 
         const requestedIsAvailable = online || isCached
         const switchingDashboard = props.requestedId !== props.currentId
-        if (
-            requestedIsAvailable &&
-            (recordingState === 'recording' || !loaded)
-        ) {
+
+        if (requestedIsAvailable && !loaded) {
             loadDashboard()
         } else if (!requestedIsAvailable && switchingDashboard) {
             setLoaded(false)
             props.setSelectedAsOffline(props.requestedId, props.username)
         }
-    }, [props.requestedId, props.currentId, loaded, recordingState, online])
+    }, [props.requestedId, props.currentId, loaded, online])
 
     const onExpandedChanged = expanded => setControlbarExpanded(expanded)
 


### PR DESCRIPTION
Backport of https://github.com/dhis2/dashboard-app/pull/1975

loaded was set to true before firing the fetch dashboards request. When that request failed due to the cache being hacked and deleted, then catch set loaded back to false. The result was that loaded kept toggling between true and false.

In addition, after discussion with Kai, it is not necessary to listen to recordingState to determine if loading is necessary. Note that removal of that recordingState doesn't impact any behavior.