### PR TITLE
fix: close the More options menu when an option has been selected [v37]

### DIFF
--- a/src/components/DropdownButton/DropdownButton.js
+++ b/src/components/DropdownButton/DropdownButton.js
@@ -19,7 +19,7 @@ const DropdownButton = ({
     return (
         <div ref={anchorRef}>
             <OfflineTooltip disabledWhenOffline={disabledWhenOffline}>
-                <Button onClick={onClick} {...rest}>
+                <Button onClick={onClick} type="button" {...rest}>
                     {children}
                     <ArrowIconComponent className={styles.arrow} />
                 </Button>

--- a/src/pages/view/TitleBar/ActionsBar.js
+++ b/src/pages/view/TitleBar/ActionsBar.js
@@ -64,6 +64,11 @@ const ViewActions = ({
             ? setMoreOptionsSmallIsOpen(!moreOptionsSmallIsOpen)
             : setMoreOptionsIsOpen(!moreOptionsIsOpen)
 
+    const closeMoreOptions = () => {
+        setMoreOptionsSmallIsOpen(false)
+        setMoreOptionsIsOpen(false)
+    }
+
     if (redirectUrl) {
         return <Redirect to={redirectUrl} />
     }
@@ -86,12 +91,12 @@ const ViewActions = ({
     }
 
     const onRemoveFromOffline = () => {
-        toggleMoreOptions()
+        closeMoreOptions()
         lastUpdated && remove()
     }
 
     const onAddToOffline = () => {
-        toggleMoreOptions()
+        closeMoreOptions()
         return filtersLength
             ? setConfirmCacheDialogIsOpen(true)
             : startRecording({
@@ -101,7 +106,7 @@ const ViewActions = ({
 
     const onToggleShowDescription = () => {
         updateShowDescription(!showDescription)
-        toggleMoreOptions()
+        closeMoreOptions()
         !offline && apiPostShowDescription(!showDescription)
     }
 
@@ -109,9 +114,7 @@ const ViewActions = ({
         apiStarDashboard(dataEngine, id, !starred)
             .then(() => {
                 setDashboardStarred(id, !starred)
-                if (moreOptionsIsOpen) {
-                    toggleMoreOptions()
-                }
+                closeMoreOptions()
             })
             .catch(() => {
                 const msg = starred


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-11773

The More options button and menu is complicated because there are 2 copies (of both the button and the menu) - one for small screen and one for not-small screen. So in order to toggle that menu, the small/not-small flag was being provided to the toggle function, but that flag was only available if clicking on the More button. When selecting an option in the menu, the menu should always be closed, so the solution was to trigger close on both menus.

This code should probably be refactored for a cleaner solution than having 2 copies of the menu. But for now, this works.

Cypress tests coming... but maybe do that in a separate PR and focus on getting this one in by freeze?

https://user-images.githubusercontent.com/6113918/133400185-af488374-d6eb-4461-b4cb-685268393192.mov

