### PR TITLE
fix: restore dashboard filter tests

### DIFF
--- a/cypress/integration/view/dashboard_filter.feature
+++ b/cypress/integration/view/dashboard_filter.feature
@@ -1,0 +1,33 @@
+Feature: Dashboard filter
+
+    Scenario: I add a Period filter
+        When I start a new dashboard
+        And I add a MAP and a CHART and save
+        Then the dashboard displays in view mode
+        When I add a "Period" filter
+        Then the Period filter is applied to the dashboard
+
+    Scenario: I add a Organisation Unit filter
+        Given I open existing dashboard
+        Then the dashboard displays in view mode
+        When I add a "Organisation Unit" filter
+        Then the Organisation Unit filter is applied to the dashboard
+
+    Scenario: I add a Facility Type filter
+        Given I open existing dashboard
+        Then the dashboard displays in view mode
+        When I add a "Facility Type" filter
+        Then the Facility Type filter is applied to the dashboard
+
+    Scenario: I can access the dimensions modal from the filter badge
+        Given I open existing dashboard
+        When I add a "Period" filter
+        And I click on the "Period" filter badge
+        Then the filter modal is opened
+
+    Scenario: I delete a dashboard
+        Given I open existing dashboard
+        When I choose to edit dashboard
+        And I choose to delete dashboard
+        When I confirm delete
+        Then different dashboard displays in view mode

--- a/cypress/integration/view/dashboard_filter/create_dashboard.js
+++ b/cypress/integration/view/dashboard_filter/create_dashboard.js
@@ -49,8 +49,8 @@ Given('I open existing dashboard', () => {
 
 Then('the dashboard displays in view mode', () => {
     // check for a map canvas and a highcharts element
-    cy.get(chartSel).should('be.visible')
-    cy.get(mapSel).should('be.visible')
+    cy.get(chartSel, EXTENDED_TIMEOUT).should('be.visible')
+    cy.get(mapSel, EXTENDED_TIMEOUT).should('be.visible')
 })
 
 When('I choose to delete dashboard', () => {

--- a/cypress/integration/view/dashboard_filter/dashboard_filter.js
+++ b/cypress/integration/view/dashboard_filter/dashboard_filter.js
@@ -1,0 +1,84 @@
+import { Then } from 'cypress-cucumber-preprocessor/steps'
+import {
+    filterBadgeSel,
+    dimensionsModalSel,
+} from '../../../elements/dashboardFilter'
+import {
+    gridItemSel,
+    mapLegendButtonSel,
+    mapLegendContentSel,
+    chartSubtitleSel,
+    chartXAxisLabelSel,
+} from '../../../elements/dashboardItem'
+import { innerScrollContainerSel } from '../../../elements/viewDashboard'
+import { EXTENDED_TIMEOUT } from '../../../support/utils'
+
+const PERIOD = 'Last 6 months'
+const OU = 'Sierra Leone'
+const FACILITY_TYPE = 'Clinic'
+
+/*
+Scenario: I add a Period filter
+*/
+
+Then('the Period filter is applied to the dashboard', () => {
+    cy.get(filterBadgeSel).contains(`Period: ${PERIOD}`).should('be.visible')
+
+    // check the CHART
+    cy.get(`${gridItemSel}.VISUALIZATION`)
+        .find(chartSubtitleSel, EXTENDED_TIMEOUT)
+        .scrollIntoView()
+        .contains(PERIOD, EXTENDED_TIMEOUT)
+        .should('be.visible')
+
+    cy.get(innerScrollContainerSel).scrollTo('top')
+    // check the MAP
+    cy.get('.dhis2-map-legend-button', EXTENDED_TIMEOUT).trigger('mouseover')
+    cy.get('.dhis2-map-legend-period', EXTENDED_TIMEOUT)
+        .contains(PERIOD)
+        .should('be.visible')
+})
+
+/*
+Scenario: I add an Organisation Unit filter
+*/
+
+Then('the Organisation Unit filter is applied to the dashboard', () => {
+    cy.get(filterBadgeSel)
+        .contains(`Organisation Unit: ${OU}`)
+        .should('be.visible')
+
+    cy.get(innerScrollContainerSel).scrollTo('bottom')
+    cy.get(`${gridItemSel}.VISUALIZATION`)
+        .find(chartXAxisLabelSel, EXTENDED_TIMEOUT)
+        .scrollIntoView()
+        .contains(OU, EXTENDED_TIMEOUT)
+        .should('be.visible')
+})
+
+/*
+Scenario: I add a Facility Type filter
+*/
+Then('the Facility Type filter is applied to the dashboard', () => {
+    cy.get(filterBadgeSel)
+        .contains(`Facility Type: ${FACILITY_TYPE}`)
+        .should('be.visible')
+
+    cy.get(innerScrollContainerSel).scrollTo('top')
+    cy.get(`${gridItemSel}.VISUALIZATION`)
+        .find(chartSubtitleSel, EXTENDED_TIMEOUT)
+        .scrollIntoView()
+        .contains(FACILITY_TYPE, EXTENDED_TIMEOUT)
+        .should('be.visible')
+
+    cy.get(innerScrollContainerSel).scrollTo('top')
+    cy.get(mapLegendButtonSel, EXTENDED_TIMEOUT).trigger('mouseover')
+    cy.get(mapLegendContentSel, EXTENDED_TIMEOUT)
+        .find('div')
+        .contains(`Facility Type: ${FACILITY_TYPE}`)
+        .should('be.visible')
+})
+
+Then('the filter modal is opened', () => {
+    cy.get(dimensionsModalSel, EXTENDED_TIMEOUT).should('be.visible')
+})

--- a/cypress/integration/view/offline/offline.js
+++ b/cypress/integration/view/offline/offline.js
@@ -175,10 +175,12 @@ Given('I open an uncached dashboard', () => {
 
 When('connectivity is turned off', () => {
     goOffline()
+    cy.wait(500) // eslint-disable-line cypress/no-unnecessary-waiting
 })
 
 When('connectivity is turned on', () => {
     goOnline()
+    cy.wait(500) // eslint-disable-line cypress/no-unnecessary-waiting
 })
 
 Then(

--- a/cypress/integration/view/offline/offline.js
+++ b/cypress/integration/view/offline/offline.js
@@ -175,12 +175,22 @@ Given('I open an uncached dashboard', () => {
 
 When('connectivity is turned off', () => {
     goOffline()
-    cy.wait(500) // eslint-disable-line cypress/no-unnecessary-waiting
+    cy.get('[data-test="headerbar-online-status"]')
+        .contains('Offline')
+        .should('be.visible')
+    cy.get('[data-test="headerbar-online-status"]')
+        .contains('Online')
+        .should('not.exist')
 })
 
 When('connectivity is turned on', () => {
     goOnline()
-    cy.wait(500) // eslint-disable-line cypress/no-unnecessary-waiting
+    cy.get('[data-test="headerbar-online-status"]')
+        .contains('Online')
+        .should('be.visible')
+    cy.get('[data-test="headerbar-online-status"]')
+        .contains('Offline')
+        .should('not.exist')
 })
 
 Then(

--- a/cypress/integration/view/view_dashboard/toggle_show_more_dashboards.js
+++ b/cypress/integration/view/view_dashboard/toggle_show_more_dashboards.js
@@ -30,7 +30,9 @@ Given('I type an invalid dashboard id in the browser url', () => {
 })
 
 Then('a message displays informing that the dashboard is not found', () => {
-    cy.contains('Requested dashboard not found').should('be.visible')
+    cy.contains('Requested dashboard not found', EXTENDED_TIMEOUT).should(
+        'be.visible'
+    )
     cy.get(dashboardTitleSel).should('not.exist')
 })
 Then('the control bar should be at collapsed height', () => {

--- a/cypress/integration/view/view_errors/invalid_dashboard_id.js
+++ b/cypress/integration/view/view_errors/invalid_dashboard_id.js
@@ -7,7 +7,9 @@ Given('I type an invalid dashboard id in the browser url', () => {
     cy.visit('#/invalid', EXTENDED_TIMEOUT)
 })
 Then('a message displays informing that the dashboard is not found', () => {
-    cy.contains('Requested dashboard not found').should('be.visible')
+    cy.contains('Requested dashboard not found', EXTENDED_TIMEOUT).should(
+        'be.visible'
+    )
     cy.get(dashboardTitleSel).should('not.exist')
 })
 

--- a/cypress/integration/view/view_errors/item_chart_fails_to_render.js
+++ b/cypress/integration/view/view_errors/item_chart_fails_to_render.js
@@ -21,7 +21,8 @@ import {
 } from '../../../elements/viewDashboard'
 import { EXTENDED_TIMEOUT } from '../../../support/utils'
 
-const TEST_DASHBOARD_TITLE = '0filter-fail-' + new Date().toUTCString()
+const TEST_DASHBOARD_TITLE =
+    '0filterfail' + new Date().toUTCString().slice(-12, -4)
 
 // Scenario: Item visualization fails when filter applied [DHIS2-11303]
 


### PR DESCRIPTION
Same as https://github.com/dhis2/dashboard-app/pull/1985 (v37)


The tests had been removed due to a bug in a dependency