### PR TITLE
fix: bump Analytics and DV plugin to latest (DHIS2-11017) [v36]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-06-10T13:31:39.680Z\n"
-"PO-Revision-Date: 2021-06-10T13:31:39.680Z\n"
+"POT-Creation-Date: 2021-09-16T08:58:12.325Z\n"
+"PO-Revision-Date: 2021-09-16T08:58:12.325Z\n"
 
 msgid "Untitled dashboard"
 msgstr ""
@@ -92,14 +92,8 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-msgid "There was an error loading data for this item"
-msgstr "There was an error loading data for this item"
-
-msgid "Open this item in {{appName}}"
-msgstr "Open this item in {{appName}}"
-
-msgid "Visualizations"
-msgstr "Visualizations"
+msgid "dashboard layout"
+msgstr ""
 
 msgid "one item per page"
 msgstr ""
@@ -199,6 +193,12 @@ msgid "Unable to load the plugin for this item"
 msgstr ""
 
 msgid "No data to display"
+msgstr ""
+
+msgid "There was an error loading data for this item"
+msgstr ""
+
+msgid "Open this item in {{appName}}"
 msgstr ""
 
 msgid "Confirm"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "license": "BSD-3-Clause",
     "dependencies": {
-        "@dhis2/analytics": "^16.0.20",
+        "@dhis2/analytics": "^16.0.23",
         "@dhis2/app-runtime": "^2.8.0",
         "@dhis2/app-runtime-adapter-d2": "^1.0.2",
         "@dhis2/d2-i18n": "^1.1.0",
@@ -15,7 +15,7 @@
         "@dhis2/d2-ui-rich-text": "^7.1.6",
         "@dhis2/d2-ui-sharing-dialog": "^7.1.6",
         "@dhis2/d2-ui-translation-dialog": "^7.1.6",
-        "@dhis2/data-visualizer-plugin": "^36.1.3",
+        "@dhis2/data-visualizer-plugin": "^36.1.7",
         "@dhis2/ui": "^6.5.5",
         "@material-ui/core": "^3.9.2",
         "@material-ui/icons": "^4.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1572,10 +1572,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@dhis2/analytics@^16.0.20":
-  version "16.0.20"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-16.0.20.tgz#5946cf1255d559a14ef296fa5c5a199c67696e17"
-  integrity sha512-n55ESUd+9Vmf36xWuzlbPQD2WODkugsC/6FL1Kd7155qPYNeEqdtZl3KmrAQ4NCJOx5ZY0PaT6M7zPBQ8SBcYQ==
+"@dhis2/analytics@^16.0.23":
+  version "16.0.23"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-16.0.23.tgz#51b3e8a24501c6ee4c2c856510de98fabdca2fec"
+  integrity sha512-xKT6FUzjeQue6i1ycf4IcH1fBzbTFu4fqqnjTyJ6zJVoXEABVeCP/YhzBgc8hEFfiXyQEcqkuAyVir0hHXfIow==
   dependencies:
     "@dhis2/d2-ui-favorites-dialog" "^7.1.5"
     "@dhis2/d2-ui-org-unit-dialog" "^7.1.5"
@@ -1913,12 +1913,12 @@
     react-select "^2.0.0"
     rxjs "^5.5.7"
 
-"@dhis2/data-visualizer-plugin@^36.1.3":
-  version "36.1.3"
-  resolved "https://registry.yarnpkg.com/@dhis2/data-visualizer-plugin/-/data-visualizer-plugin-36.1.3.tgz#961bf277d70fead402eac9f0e570124ca3a91945"
-  integrity sha512-uDgwrNjtjUikVkZGOb+LlIzpQWz3ySuN/tNhQ/RJYTKcfVmfbt1Kk27e8CKYJeTrj702PXuRnZ8M9LyQKCM3wg==
+"@dhis2/data-visualizer-plugin@^36.1.7":
+  version "36.1.7"
+  resolved "https://registry.yarnpkg.com/@dhis2/data-visualizer-plugin/-/data-visualizer-plugin-36.1.7.tgz#a48c1934252700c90838338ced90ed674c400cc0"
+  integrity sha512-R1omSE2z23263GSc/VtaeKDihTCc9Ylu/kExT2LA7BMGW30FzALpBfz+9mqXKI1cQWbzMbILsgnxWwvKDj1WGg==
   dependencies:
-    "@dhis2/analytics" "^16.0.20"
+    "@dhis2/analytics" "^16.0.23"
     "@dhis2/app-runtime" "^2.8.0"
     "@dhis2/d2-i18n" "^1.1.0"
     "@dhis2/ui" "^6.5.5"


### PR DESCRIPTION
Deps bump for [DHIS2-11017](https://jira.dhis2.org/browse/DHIS2-11017), to run [Analytics 16.0.22](https://github.com/dhis2/analytics/pull/1043) (which contains the actual fix) and [DV plugin 36.1.6](https://github.com/dhis2/data-visualizer-app/pull/1885) that uses the new Analytics version as well.