### PR TITLE
fix: include program, programStage, trackedEntityType in map request

### DIFF
--- a/cypress/assets/backends/sierraLeone_236.js
+++ b/cypress/assets/backends/sierraLeone_236.js
@@ -12,6 +12,16 @@ export const dashboards = {
             },
         },
     },
+    'Cases Malaria': {
+        id: 'JW7RlN5xafN',
+        route: '#/JW7RlN5xafN',
+        items: {
+            map: {
+                name: 'Malaria: Cases <5y female Pujehun this year events',
+                itemUid: 'HQp9BAUG9v8',
+            },
+        },
+    },
     Delivery: {
         id: 'iMnYyBfSxmM',
         route: '#/iMnYyBfSxmM',
@@ -26,8 +36,7 @@ export const dashboards = {
                 itemUid: 'qXsjttMYuoZ',
             },
             map: {
-                name:
-                    'Delivery: PHU delivery rate (by pop) by chiefdom last year',
+                name: 'Delivery: PHU delivery rate (by pop) by chiefdom last year',
                 itemUid: 'G3EtzSWNP9o',
             },
         },

--- a/cypress/integration/view/view_dashboard.feature
+++ b/cypress/integration/view/view_dashboard.feature
@@ -58,6 +58,12 @@ Feature: Viewing dashboards
         When I toggle show more dashboards
         Then the control bar should be expanded to full height
 
+    @mutating
+    Scenario: Maps with tracked entities show layer names in legend
+        Given I open the Cases Malaria dashboard
+        When I hover over the map legend button
+        Then the legend title shows the tracked entity name
+
 # TODO: flaky test
 # @mutating
 # Scenario: I change the height of the control bar

--- a/cypress/integration/view/view_dashboard/te_map_legend.js
+++ b/cypress/integration/view/view_dashboard/te_map_legend.js
@@ -1,0 +1,34 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+import { dashboards } from '../../../assets/backends/sierraLeone_236'
+import { getDashboardItem, mapSel } from '../../../elements/dashboardItem'
+import {
+    dashboardTitleSel,
+    dashboardChipSel,
+} from '../../../elements/viewDashboard'
+import { EXTENDED_TIMEOUT } from '../../../support/utils'
+
+const mapItemUid = dashboards['Cases Malaria'].items.map.itemUid
+
+Given('I open the Cases Malaria dashboard', () => {
+    const title = 'Cases Malaria'
+    cy.get(dashboardChipSel, EXTENDED_TIMEOUT).contains(title).click()
+
+    cy.location().should(loc => {
+        expect(loc.hash).to.equal(dashboards[title].route)
+    })
+
+    cy.get(dashboardTitleSel).should('be.visible').and('contain', title)
+    cy.get(mapSel, EXTENDED_TIMEOUT).should('exist')
+})
+
+When('I hover over the map legend button', () => {
+    getDashboardItem(mapItemUid)
+        .find('.dhis2-map-legend-button', EXTENDED_TIMEOUT)
+        .trigger('mouseover')
+})
+
+Then('the legend title shows the tracked entity name', () => {
+    cy.get('.dhis2-map-legend-title')
+        .contains('Malaria case registration')
+        .should('be.visible')
+})

--- a/src/api/metadata.js
+++ b/src/api/metadata.js
@@ -83,11 +83,18 @@ export const getListItemFields = () => [
 ]
 
 // Map
-export const getMapFields = () => [
-    `${getIdNameFields({ rename: true }).join(',')}`,
-    'user,longitude,latitude,zoom,basemap',
-    `mapViews[${getFavoriteFields({
+export const getMapFields = () => {
+    const favoriteFields = getFavoriteFields({
         withDimensions: true,
         withOptions: true,
-    })}]`,
-]
+    })
+
+    const teFields =
+        'program[id,displayName~rename(name)],programStage[id,displayName~rename(name)],trackedEntityType[id,displayName~rename(name)]'
+
+    return [
+        `${getIdNameFields({ rename: true }).join(',')}`,
+        'user,longitude,latitude,zoom,basemap',
+        `mapViews[${favoriteFields.concat(teFields)}]`,
+    ]
+}


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-11924

Include program, programStage, and trackedEntityType in the map request. This information is needed for the map legend.

Before: 

![image](https://user-images.githubusercontent.com/6113918/136053584-e3da995c-9ee1-46ea-b62d-dd7801798abe.png)


After

![image](https://user-images.githubusercontent.com/6113918/136053457-3a709287-556f-495f-9733-39c3bce60230.png)

Before:

![image](https://user-images.githubusercontent.com/6113918/136151162-5312b9cf-c4eb-4513-b068-3d955e7393f0.png)

After:
![image](https://user-images.githubusercontent.com/6113918/136151351-ac6ebf53-f1f4-43a1-b297-42f634004a89.png)
