### PR TITLE
fix: make landing page scrollable

### DIFF
--- a/src/components/styles/App.css
+++ b/src/components/styles/App.css
@@ -37,6 +37,8 @@ body {
 
 .app-shell-app {
     overflow: hidden !important;
+    display: flex;
+    flex-direction: column;
 }
 
 /* plugin TODO */

--- a/src/pages/start/styles/StartScreen.module.css
+++ b/src/pages/start/styles/StartScreen.module.css
@@ -1,7 +1,8 @@
 .outer {
     display: flex;
     justify-content: center;
-    height: 85%;
+    flex-grow: 1;
+    overflow: auto;
 }
 .inner {
     padding: var(--spacers-dp16) var(--spacers-dp24);
@@ -9,8 +10,7 @@
     box-sizing: border-box;
     color: var(--colors-grey900);
     position: relative;
-    display: flex;
-    align-items: center;
+    padding-top: 15vh;
 }
 .errorContainer {
     display: flex;


### PR DESCRIPTION
Makes the landing page scrollable. To enable a scrollbar the container needs a height, which in turn needs to be dynamic, so the height of the container is set by using flex-grow = 1 to make it fill the rest of the viewport height. To be able to use flex-grow the container's container needs to be flex. The new overflow rule is set on the StartScreen component so that it does not touch other stuff like dashboard print view.

Web:
https://user-images.githubusercontent.com/1010094/140347833-56e46d7d-51ce-41b3-9327-55df48611926.mp4

Mobile:
https://user-images.githubusercontent.com/1010094/140348329-a44247cf-c2c7-4273-b23b-f699549dc769.mp4



