### PR TITLE
feat: controlbar expand and drag hover and active states

### DIFF
--- a/src/components/DashboardsBar/ShowMoreButton.js
+++ b/src/components/DashboardsBar/ShowMoreButton.js
@@ -37,7 +37,7 @@ const ShowMoreButton = ({ onClick, dashboardBarIsExpanded, disabled }) => {
                 <Tooltip
                     content={buttonLabel}
                     placement="top"
-                    openDelay={500}
+                    openDelay={800}
                     closeDelay={0}
                 >
                     {({ onMouseOver, onMouseOut, ref }) => (

--- a/src/components/DashboardsBar/styles/DragHandle.module.css
+++ b/src/components/DashboardsBar/styles/DragHandle.module.css
@@ -15,11 +15,11 @@
     height: 3px;
     width: 100%;
     background: var(--colors-white);
-    transition: background 0.2s 0.1s;
 }
 
 .draghandle:hover:after {
     background: var(--colors-blue300);
+    transition: background 0.2s 0.1s;
 }
 
 .draghandle:active:after {

--- a/src/components/DashboardsBar/styles/DragHandle.module.css
+++ b/src/components/DashboardsBar/styles/DragHandle.module.css
@@ -8,6 +8,25 @@
     height: 7px;
 }
 
+.draghandle:after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    height: 3px;
+    width: 100%;
+    background: var(--colors-white);
+    transition: background 0.2s 0.1s;
+}
+
+.draghandle:hover:after {
+    background: var(--colors-blue300);
+}
+
+.draghandle:active:after {
+    background: var(--colors-blue500);
+    transition: none;
+}
+
 @media only screen and (max-width: 480px) {
     .draghandle {
         display: none;

--- a/src/components/DashboardsBar/styles/ShowMoreButton.module.css
+++ b/src/components/DashboardsBar/styles/ShowMoreButton.module.css
@@ -17,6 +17,15 @@
     height: 21px;
 }
 
+.showMore:hover {
+    background: var(--colors-grey200);
+    transition: background 0.2s 0.1s;
+}
+.showMore:active {
+    background: var(--colors-grey300);
+    transition: none;
+}
+
 .showMore:focus {
     outline: none;
 }


### PR DESCRIPTION
This PR improves the user experience of the dashboards, fixing [UX-52](https://jira.dhis2.org/browse/UX-52), controlbar by:
- adding a `hover` and `active` state to the _Show more_ button, highlighting the fact it is 100% width.
- adding a `hover` and `active` state to the _Drag handle_ area.
- prolonging the time before the _show more_ tooltip is shown, preventing ui flickering.

These changes help the user understand which action will be triggered when clicking this action-dense area of the controlbar.


**Before:**

![controlbar-before](https://user-images.githubusercontent.com/33054985/141790176-c8a72531-4f73-4e7d-8877-30a4fc65bae6.gif)


**After:**

![controlbar-after](https://user-images.githubusercontent.com/33054985/141790231-80372769-fc7c-4361-ac61-3676f0764e26.gif)
