### PR TITLE
fix: adjust z-index so tooltip shows [DHIS2-11647] [v36]

### DIFF
--- a/src/components/ControlBar/ViewControlBar/ShowMoreButton.js
+++ b/src/components/ControlBar/ViewControlBar/ShowMoreButton.js
@@ -35,7 +35,12 @@ const ShowMoreButton = ({ onClick, dashboardBarIsExpanded, disabled }) => {
                     <ChevronDown />
                 </div>
             ) : (
-                <Tooltip content={buttonLabel} placement="bottom">
+                <Tooltip
+                    content={buttonLabel}
+                    placement="top"
+                    openDelay={500}
+                    closeDelay={0}
+                >
                     {({ onMouseOver, onMouseOut, ref }) => (
                         <button
                             className={classes.showMore}

--- a/src/components/ControlBar/ViewControlBar/styles/DashboardsBar.module.css
+++ b/src/components/ControlBar/ViewControlBar/styles/DashboardsBar.module.css
@@ -24,7 +24,7 @@
 
 .expanded .container {
     height: var(--max-rows-height);
-    z-index: 2001;
+    z-index: 1999;
 }
 
 .spacer {

--- a/src/components/Dashboard/ViewDashboard.js
+++ b/src/components/Dashboard/ViewDashboard.js
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
-import { ComponentCover } from '@dhis2/ui'
 import cx from 'classnames'
 import DashboardContainer from './DashboardContainer'
 import ViewTitleBar from '../TitleBar/ViewTitleBar'
@@ -62,9 +61,8 @@ export const ViewDashboard = props => {
             />
             <DashboardContainer covered={controlbarExpanded}>
                 {controlbarExpanded && (
-                    <ComponentCover
+                    <div
                         className={classes.cover}
-                        translucent
                         onClick={() => setControlbarExpanded(false)}
                     />
                 )}

--- a/src/components/Dashboard/styles/ViewDashboard.module.css
+++ b/src/components/Dashboard/styles/ViewDashboard.module.css
@@ -6,6 +6,13 @@
 }
 
 .cover {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 1998;
+    background: rgba(33, 43, 54, 0.4);
     display: none;
 }
 


### PR DESCRIPTION
Backport of https://github.com/dhis2/dashboard-app/pull/1912

Fixes: https://jira.dhis2.org/browse/DHIS2-11647

Because of competing z-indexes on the component cover and tooltip, the tooltip was hidden when the dashboards bar was expanded.

Components should be stacked from bottom to top: cover, dashboards bar, tooltip.
Previously, the z-index of these was: 2000, 2001, 2000 which means the tooltip wasn't visible.
With the new code, the z-index is: 1998, 1999, 2000. (Cannot use ui ComponentCover since z-index is not configurable).