### PR TITLE
fix: only show Exit print preview button in print preview [DHIS2-11778] [v36]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-09-16T08:58:12.325Z\n"
-"PO-Revision-Date: 2021-09-16T08:58:12.325Z\n"
+"POT-Creation-Date: 2022-01-10T14:24:29.926Z\n"
+"PO-Revision-Date: 2022-01-10T14:24:29.926Z\n"
 
 msgid "Untitled dashboard"
 msgstr ""
@@ -37,7 +37,7 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-msgid "Exit Print preview"
+msgid "Exit print preview"
 msgstr ""
 
 msgid "Print preview"
@@ -84,9 +84,6 @@ msgid ""
 msgstr ""
 
 msgid "Not supported"
-msgstr ""
-
-msgid "Exit print preview"
 msgstr ""
 
 msgid "Print"

--- a/src/components/ControlBar/EditBar.js
+++ b/src/components/ControlBar/EditBar.js
@@ -163,30 +163,40 @@ const EditBar = props => {
 
     const renderActionButtons = () => (
         <ButtonStrip>
-            <Button primary onClick={onSave} dataTest="save-dashboard-button">
-                {i18n.t('Save changes')}
-            </Button>
+            {!props.isPrintPreviewView && (
+                <Button
+                    primary
+                    onClick={onSave}
+                    dataTest="save-dashboard-button"
+                >
+                    {i18n.t('Save changes')}
+                </Button>
+            )}
             <Button onClick={onPrintPreview}>
                 {props.isPrintPreviewView
-                    ? i18n.t('Exit Print preview')
+                    ? i18n.t('Exit print preview')
                     : i18n.t('Print preview')}
             </Button>
-            <Button onClick={toggleFilterSettingsDialog}>
-                {i18n.t('Filter settings')}
-            </Button>
-            {props.dashboardId && (
+            {!props.isPrintPreviewView && (
+                <Button onClick={toggleFilterSettingsDialog}>
+                    {i18n.t('Filter settings')}
+                </Button>
+            )}
+            {!props.isPrintPreviewView && props.dashboardId && (
                 <Button onClick={toggleTranslationDialog}>
                     {i18n.t('Translate')}
                 </Button>
             )}
-            {props.dashboardId && props.deleteAccess && (
-                <Button
-                    onClick={onConfirmDelete}
-                    dataTest="delete-dashboard-button"
-                >
-                    {i18n.t('Delete')}
-                </Button>
-            )}
+            {!props.isPrintPreviewView &&
+                props.dashboardId &&
+                props.deleteAccess && (
+                    <Button
+                        onClick={onConfirmDelete}
+                        dataTest="delete-dashboard-button"
+                    >
+                        {i18n.t('Delete')}
+                    </Button>
+                )}
         </ButtonStrip>
     )
 
@@ -203,9 +213,11 @@ const EditBar = props => {
             <div className={classes.editBar} data-test="edit-control-bar">
                 <div className={classes.controls}>
                     {props.updateAccess ? renderActionButtons() : null}
-                    <Button secondary onClick={onDiscard}>
-                        {discardBtnText}
-                    </Button>
+                    {!props.isPrintPreviewView && (
+                        <Button secondary onClick={onDiscard}>
+                            {discardBtnText}
+                        </Button>
+                    )}
                 </div>
             </div>
             {filterSettingsDialog()}

--- a/src/components/ControlBar/__tests__/EditBar.spec.js
+++ b/src/components/ControlBar/__tests__/EditBar.spec.js
@@ -144,6 +144,31 @@ test('renders Translate, Delete, and Discard buttons when delete access', async 
     expect(container).toMatchSnapshot()
 })
 
+test('renders only Exit print preview button in print preview', async () => {
+    const store = {
+        editDashboard: {
+            id: 'rainbowDash',
+            name: 'Rainbow Dash',
+            access: {
+                update: true,
+                delete: true,
+            },
+            printPreviewView: true,
+        },
+    }
+    const promise = Promise.resolve()
+    apiFetchDashboard.mockResolvedValue(promise)
+
+    const { container } = render(
+        <Provider store={mockStore(store)}>
+            <EditBar />
+        </Provider>
+    )
+
+    await act(() => promise)
+    expect(container).toMatchSnapshot()
+})
+
 test('shows the confirm delete dialog when delete button clicked', async () => {
     const store = {
         editDashboard: {

--- a/src/components/ControlBar/__tests__/__snapshots__/EditBar.spec.js.snap
+++ b/src/components/ControlBar/__tests__/__snapshots__/EditBar.spec.js.snap
@@ -146,6 +146,48 @@ exports[`renders Translate, Delete, and Discard buttons when delete access 1`] =
 </div>
 `;
 
+exports[`renders only Exit print preview button in print preview 1`] = `
+<div>
+  <div
+    class="editBar"
+    data-test="edit-control-bar"
+  >
+    <div
+      class="controls"
+    >
+      <div
+        class="jsx-71743532 start"
+        data-test="dhis2-uicore-buttonstrip"
+      >
+        <div
+          class="jsx-71743532 box"
+        />
+        <div
+          class="jsx-71743532 box"
+        >
+          <button
+            class="jsx-2371629422 "
+            data-test="dhis2-uicore-button"
+            type="button"
+          >
+            Exit print preview
+          </button>
+        </div>
+        <div
+          class="jsx-71743532 box"
+        />
+        <div
+          class="jsx-71743532 box"
+        />
+        <div
+          class="jsx-71743532 box"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders only the Go to Dashboards button when no update access 1`] = `
 <div>
   <div


### PR DESCRIPTION
Backport of https://github.com/dhis2/dashboard-app/pull/1974

To prevent the user from accidentally losing their changes while in print preview mode, remove all action buttons other than "Exit print preview". 

The files changed view looks like major changes were made, but the only change is the addition of the !props.isPrintPreviewView for all the buttons.
