### PR TITLE
fix: remove duplicate field

### DIFF
--- a/src/api/fetchDashboard.js
+++ b/src/api/fetchDashboard.js
@@ -56,7 +56,6 @@ export const editDashboardQuery = {
             'code',
             'description',
             'created',
-            'favorite',
             'favorites',
             'lastUpdated',
             'href', // needed for d2-ui-translations-dialog


### PR DESCRIPTION
Fixes https://jira.dhis2.org/browse/DHIS2-13246

Removes the `favorite` field which is only used as `favorite~rename(starred)` in this app.

No backport needed as the new fields filtering system is merged in 39+.