### PR TITLE
chore: pass GITHUB_TOKEN as env param

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -152,6 +152,7 @@ jobs:
                   cypress_dhis2_base_url: ${{ secrets.CYPRESS_DHIS2_BASE_URL }}
                   cypress_dhis2_username: ${{ secrets.CYPRESS_DHIS2_USERNAME }}
                   cypress_dhis2_password: ${{ secrets.CYPRESS_DHIS2_PASSWORD }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     publish:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Pass `GITHUB_TOKEN` to Cypress test GH action, as done here in DV: https://github.com/dhis2/data-visualizer-app/pull/2127