### PR TITLE
feat: move PWA update notification to headerbar, display app debug info [DHIS2-13864]

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "@dhis2/d2-ui-rich-text": "^7.3.3",
         "@dhis2/d2-ui-translation-dialog": "^7.3.3",
         "@dhis2/data-visualizer-plugin": "^39.2.10",
-        "@dhis2/ui": "^8.4.16",
+        "@dhis2/ui": "^8.5.1",
         "classnames": "^2.3.1",
         "d2": "^31.10.0",
         "d2-utilizr": "^0.2.16",
@@ -50,7 +50,7 @@
         "cy:capture": "cypress_dhis2_api_stub_mode=CAPTURE yarn d2-utils-cypress run --appStart 'yarn cypress:start'"
     },
     "devDependencies": {
-        "@dhis2/cli-app-scripts": "^10.0.0",
+        "@dhis2/cli-app-scripts": "^10.1.0",
         "@dhis2/cli-style": "^10.4.1",
         "@dhis2/cli-utils-cypress": "^7.0.1",
         "@dhis2/cypress-commands": "^7.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1573,564 +1573,566 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@dhis2-ui/alert@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/alert/-/alert-8.4.16.tgz#050b793b05211eee291f7a0bd994769414a9b850"
-  integrity sha512-tdcUC0UG1KNbSZhh9ibDOIIjHwaQ7dDl1BL1hmKcsDRbOr3GTsQ20X69aco6OqJqp0UjHSgwm8Y4DenNpaB9Kw==
+"@dhis2-ui/alert@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/alert/-/alert-8.5.1.tgz#709f81d937b854a6fcdf99189e5c735ea3d6480d"
+  integrity sha512-JpdPNNvxbbq2NiNhGj3oSUVDYCtDFf5LFG46pBwynvJ9ssn+mZ9/9eSe0pLRR54+Mj9ZKDv3QGsor9ncwqzmUg==
   dependencies:
-    "@dhis2-ui/portal" "8.4.16"
+    "@dhis2-ui/portal" "8.5.1"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
-    "@dhis2/ui-icons" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
+    "@dhis2/ui-icons" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/box@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/box/-/box-8.4.16.tgz#811ba21bd4238612acc3f326574811fa0661f46a"
-  integrity sha512-Ftxea40kjO4Cuakk9SiU6o7gaZi7P7EgfDz5A951LQ2KafyG+fzIC8chHB3z1bSt8Cxpgkpx/uWfi08GQMGxqw==
+"@dhis2-ui/box@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/box/-/box-8.5.1.tgz#3e1bc311ab13dd32db599c381ccc869eb589dc42"
+  integrity sha512-1F3jSSCsvdFNAqAzYUph6jTJCdXUo5A36XuXVCUgjukZHo0oia0+sMkZkhQwm9HFn3d1bQ+/1GDT8VQ8I7LDYQ==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/button@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/button/-/button-8.4.16.tgz#0ebd734d3b9f0df0cbad2d3ecb4d3e540d2da496"
-  integrity sha512-wwWOn7rNxvyCDM1bP62ZjkaFsPa0WlZ6VNnqbM1HSXoqVySOY/39rinoJ4FKEOGjsaEMHfWODH0u2l4CrhSqqg==
+"@dhis2-ui/button@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/button/-/button-8.5.1.tgz#3c0c720efb22a04cbcc1e80916d09646270bbe52"
+  integrity sha512-dIE6bTwYKJ8aoIF+ip/XNpftMtDdRbvhFEsP7Q0c/yL0ZUhscJnCaPwdgrrVG1mcLestJ5wW4APDiyQYn8+8Og==
   dependencies:
-    "@dhis2-ui/layer" "8.4.16"
-    "@dhis2-ui/loader" "8.4.16"
-    "@dhis2-ui/popper" "8.4.16"
+    "@dhis2-ui/layer" "8.5.1"
+    "@dhis2-ui/loader" "8.5.1"
+    "@dhis2-ui/popper" "8.5.1"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
-    "@dhis2/ui-icons" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
+    "@dhis2/ui-icons" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/card@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/card/-/card-8.4.16.tgz#699c52f60bfb92637a3ceac65bc0ec2570990692"
-  integrity sha512-JXaKxS0XomjZg+pYzSL4CdibeNpCNb9TnDJP2GeerXij9yQ6bEg449kGPvVzvOAy4vR4Dm4d6N0qf5pu5L6o5w==
+"@dhis2-ui/card@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/card/-/card-8.5.1.tgz#2bd58cd133f02f469e622fca5c2ae4ddbf54bf45"
+  integrity sha512-1KHpT/ioYcopcqDjeZB3is/x+ErjKRe5ztLGZ22Sz+l2mf9wEeuM699BfLksNS9JNYq2DuqiAf5Y0EdLAFJ14w==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/center@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/center/-/center-8.4.16.tgz#a8c220606a99710e287edb443095e86bf87fc2fc"
-  integrity sha512-kCKy0RT1jNgIogqnp2MlU29jT+8vkCqQHQP6MKVviIoFUxNeTnImqu15pZrabVedB6BCdprjl+2wEnIieO/N7Q==
+"@dhis2-ui/center@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/center/-/center-8.5.1.tgz#92acc6a56c2e445b50bce88ba6cfeef06f54e95e"
+  integrity sha512-JOnv9VN6WCHpanTfxKAqX7tIFOU9clvMxyh7UMl60FAVSji5z+j4/KEQQ+u4V8ZEdqHcARXNYEnCFRvgW8reDA==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/checkbox@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/checkbox/-/checkbox-8.4.16.tgz#fb21c12aeac5c0d64b0a9eea5db22a62a70cabad"
-  integrity sha512-zowuJi0j/6+Ma1CVzpUWGgX+ARp2jHQOkkQi6KAiXoilGOvQqNyffu6qmQyxwBtbiF5VGcDBTt57rIKjnEp72A==
+"@dhis2-ui/checkbox@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/checkbox/-/checkbox-8.5.1.tgz#b7c79b3e83e5f6124403b783c5f42e0371472f78"
+  integrity sha512-WvEhPmN8BdVJG8hzZuTdB9I/sNMquDWBEk2VT3dt9eUsUByeHH67I4Dl+v0uyfQEkYHZzT5LuNHkUxPzU//PaA==
   dependencies:
-    "@dhis2-ui/field" "8.4.16"
-    "@dhis2-ui/required" "8.4.16"
+    "@dhis2-ui/field" "8.5.1"
+    "@dhis2-ui/required" "8.5.1"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/chip@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/chip/-/chip-8.4.16.tgz#5f9c11fbd608320e19e1cfb8c7332c5e98930f9d"
-  integrity sha512-lmwlMIInO0+gDw66kbyiWVAffGiTwc1wKNKThvgjKuee7J39GQToisOG/2PAgbuqdqO8QVgm4jdcY4KBxaknIA==
+"@dhis2-ui/chip@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/chip/-/chip-8.5.1.tgz#890f434f889637bff3824e034ac8ee4221121f13"
+  integrity sha512-pPHCGJLpDJCEEhGzIL4vwjotA6zU5mYe+m861soKbnWId4/rRe8G9wTMHivEoQGNkGBmCu0V89sD96hOS8RcuQ==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/cover@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/cover/-/cover-8.4.16.tgz#7b26f2754e1ef6a5c9d9a39394641a7a6f72b2a8"
-  integrity sha512-JLAsthqSJjzfLO7k18NgqFx/1HZluKbpiANnT8/ee5a9RjCAkBct6hQIoG4Bf7pOG2kjSTc82z/YHrUZZxR8ZA==
+"@dhis2-ui/cover@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/cover/-/cover-8.5.1.tgz#3386ead70ca50b105c76f30bfb72c3f3ccb8fef9"
+  integrity sha512-pXLecQBzMMm5RZOzz4+jUJ8ftCjuvGl7tP0qO10iFaH4dTACPmJlu5QbJUa1iG7zSYkFO7vCuytO3QZUQWHMkQ==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/css@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/css/-/css-8.4.16.tgz#1cfb7199f53574db24f0b2461e5d74f241103561"
-  integrity sha512-1vgzSsfdKgSaXVDTz7noZ6xPZ0M5uTVmezxUIrLO9/fQsjfadJhstkiWpciKBKrjRgfM88Hw6kySJcXuXLSP/w==
+"@dhis2-ui/css@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/css/-/css-8.5.1.tgz#9f3ab3a202fc2c4029b98d4606633464a45be412"
+  integrity sha512-OEfncfcmwppMDRG0PUiH/ufAulnwmoMf/hAdRDpfv9HCkRuERR4v8uLSGnN7PaS6OI/+Ky2YxFuywALf+23jOw==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/divider@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/divider/-/divider-8.4.16.tgz#7c964a423b9e8cf757685262bedeee9df844f440"
-  integrity sha512-aMd5MJS6ZmwqNs+sHOab8y18/RjJtynt+ouF9XajLlJhV6TwaOApAVspZmFWt9h5pSBUiJOKCq3lekNSCW7vfA==
+"@dhis2-ui/divider@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/divider/-/divider-8.5.1.tgz#9f4aeb07d0b1b45792e27a37208cc8d2ec365f58"
+  integrity sha512-qaBecNjMMBLYjc1PzUL7wzWiRWOuT920t5EEyp4zegktaqW31hqYCpItxZ96uhTmUToSoPdpwHTDg/bn6QI0nA==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/field@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/field/-/field-8.4.16.tgz#4b6980269304f79d15c3dbcd6e4fca9e530869c6"
-  integrity sha512-efIozkexEpYK94Vfd0EOGmwan64MUfQgImUdxz8GEhbIEB9KKJpdyyny/FSUEJjswkTuaL894OZBVe7tgIxgIg==
+"@dhis2-ui/field@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/field/-/field-8.5.1.tgz#4ebfcfa5ecfa8e14342b86985ee6eab317302727"
+  integrity sha512-e8b+Sw+J1q05GF9NMziqZOjXIXp8JE+3PRNrGY2pnhFijOx2qSSTZ+RRV/QzbOWzRHmGSrR30uGo6n/iloHUfA==
   dependencies:
-    "@dhis2-ui/box" "8.4.16"
-    "@dhis2-ui/help" "8.4.16"
-    "@dhis2-ui/label" "8.4.16"
+    "@dhis2-ui/box" "8.5.1"
+    "@dhis2-ui/help" "8.5.1"
+    "@dhis2-ui/label" "8.5.1"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/file-input@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/file-input/-/file-input-8.4.16.tgz#50accbb7b26674a5fbb3f557c6db573a5bdf39eb"
-  integrity sha512-iRLU9D73KAAS24+s+MR1onGX0PuamN/TnK2zK862SNJSh3/f3rXrByZm9iAn6t5PUcEvJaWKM4Wkp6PXELiU+w==
+"@dhis2-ui/file-input@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/file-input/-/file-input-8.5.1.tgz#afb12133793ff6e6612435d746ae2fc846128342"
+  integrity sha512-cWmiPosx25vqaft2nU5CUEDChQyH0JTVjAXkzZnGsulN11FHTWJ9qnNIvuWYGMR6TRl/nz9Cl4Z4GD8kUmXKwQ==
   dependencies:
-    "@dhis2-ui/button" "8.4.16"
-    "@dhis2-ui/field" "8.4.16"
-    "@dhis2-ui/label" "8.4.16"
-    "@dhis2-ui/loader" "8.4.16"
-    "@dhis2-ui/status-icon" "8.4.16"
+    "@dhis2-ui/button" "8.5.1"
+    "@dhis2-ui/field" "8.5.1"
+    "@dhis2-ui/label" "8.5.1"
+    "@dhis2-ui/loader" "8.5.1"
+    "@dhis2-ui/status-icon" "8.5.1"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
-    "@dhis2/ui-icons" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
+    "@dhis2/ui-icons" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/header-bar@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/header-bar/-/header-bar-8.4.16.tgz#289cd62ac56b006501ca18cc244f27279e3f0297"
-  integrity sha512-3xYtNhzIixMkokcWrvukuJNNiIW7ohtdVq/fhTZ/C4GmJfqBKbo25JpVF6sOT+XTJpS/zM1PBEFuyQxBp+bmIg==
+"@dhis2-ui/header-bar@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/header-bar/-/header-bar-8.5.1.tgz#9262eb5bbe8b3e5a147a40e234ac19cc02834a12"
+  integrity sha512-GlnyjAe/UQPgnN643XaNOmAf/719JAF3IQkV/mdTVJ95ONhdc7VoHLK9xHcPPEI7eufnzO287v2U+NGJYAvIRw==
   dependencies:
-    "@dhis2-ui/box" "8.4.16"
-    "@dhis2-ui/card" "8.4.16"
-    "@dhis2-ui/center" "8.4.16"
-    "@dhis2-ui/divider" "8.4.16"
-    "@dhis2-ui/input" "8.4.16"
-    "@dhis2-ui/layer" "8.4.16"
-    "@dhis2-ui/loader" "8.4.16"
-    "@dhis2-ui/logo" "8.4.16"
-    "@dhis2-ui/menu" "8.4.16"
-    "@dhis2-ui/user-avatar" "8.4.16"
+    "@dhis2-ui/box" "8.5.1"
+    "@dhis2-ui/button" "8.5.1"
+    "@dhis2-ui/card" "8.5.1"
+    "@dhis2-ui/center" "8.5.1"
+    "@dhis2-ui/divider" "8.5.1"
+    "@dhis2-ui/input" "8.5.1"
+    "@dhis2-ui/layer" "8.5.1"
+    "@dhis2-ui/loader" "8.5.1"
+    "@dhis2-ui/logo" "8.5.1"
+    "@dhis2-ui/menu" "8.5.1"
+    "@dhis2-ui/modal" "8.5.1"
+    "@dhis2-ui/user-avatar" "8.5.1"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
-    "@dhis2/ui-icons" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
+    "@dhis2/ui-icons" "8.5.1"
     classnames "^2.3.1"
     moment "^2.29.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/help@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/help/-/help-8.4.16.tgz#d7116a85d341c9d687904c1e52181fcad0614f10"
-  integrity sha512-5nHyZXpVe7+6SFwSM3lEqXbRcsZtNwOQzrcNDV/cgM7IzQ0txG7yEFnBXPGNa+LYrIKqBO5UZl4nVa0oAaIxcw==
+"@dhis2-ui/help@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/help/-/help-8.5.1.tgz#3ec922d963b8a7c8e7d36dc38b7ef0274ea02349"
+  integrity sha512-u6QZG3jU7hcqmxTmcx6w21NqK/OGRa2YY/ucYZwehUSxTVc8uYNXkhLApdyliyGYzOqUjtLSFWiC4e2WFpcV7w==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/input@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/input/-/input-8.4.16.tgz#7d5fa0c3b0d9a32b87f13106b8f73d54a2915b5c"
-  integrity sha512-p1SIF2GLOBuvDVthVHvRij/uvcn2fO+F/lnYC2uRdUWZ2sNTNX1LNgcRqTKYsQvAcwmvyuQezUiYTAry4Nzdug==
+"@dhis2-ui/input@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/input/-/input-8.5.1.tgz#fe4e8631f63bdff7d55fc999c8109b98e3a08fc4"
+  integrity sha512-Gkcm2RWfY50r+K3TqW9p8w00ee4UIi28CIUSiu9vdDOzuJoF/dQjddhVDRC31+5Nwlw4++9l2ozAWrjkOg/S/g==
   dependencies:
-    "@dhis2-ui/box" "8.4.16"
-    "@dhis2-ui/field" "8.4.16"
-    "@dhis2-ui/input" "8.4.16"
-    "@dhis2-ui/loader" "8.4.16"
-    "@dhis2-ui/status-icon" "8.4.16"
+    "@dhis2-ui/box" "8.5.1"
+    "@dhis2-ui/field" "8.5.1"
+    "@dhis2-ui/input" "8.5.1"
+    "@dhis2-ui/loader" "8.5.1"
+    "@dhis2-ui/status-icon" "8.5.1"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
-    "@dhis2/ui-icons" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
+    "@dhis2/ui-icons" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/intersection-detector@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/intersection-detector/-/intersection-detector-8.4.16.tgz#62f517e2b141028aeee08ae39858375d4b5d8835"
-  integrity sha512-KawZH1Zpd5KrN3WdXmlXqZIkGSAeXvbJCkDCkmUtD8It+eKRMwjDD0CUEK0GEzZXrnvzuE1LB9U+eZSaixBF0w==
+"@dhis2-ui/intersection-detector@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/intersection-detector/-/intersection-detector-8.5.1.tgz#9eefbe6ef2d2eb9005e3b2d55dcd30b538ecce0d"
+  integrity sha512-RC9QjsaJOOBmSzfzggJ+1lC9cVKmqVML6YH3SO11afg+NJjyVLCxS5Df23DGmHiT+SVSJ2WdoKLwN0TL718CkA==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/label@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/label/-/label-8.4.16.tgz#90e232186c5792bc3bc50da497c0a9958fd1f87d"
-  integrity sha512-Z3fPF5KWlFBr1imwjceliBKt86n/qHonCloijDts5EyP0g4kUsmFoWxV2tsykZ2SOWWTpezNphJujsQI2J65Cg==
+"@dhis2-ui/label@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/label/-/label-8.5.1.tgz#e3b5c51a308563185c618e7ef217bc3ffd63ac79"
+  integrity sha512-Hppnk0XG2Saoktu2RanFUokhzz7SLoAa6WkgGRm+f/eroFcVDo45b6YKtOep6oopzOyiYJK5s+i6tDci0lVuGQ==
   dependencies:
-    "@dhis2-ui/required" "8.4.16"
+    "@dhis2-ui/required" "8.5.1"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/layer@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/layer/-/layer-8.4.16.tgz#a8db3f8455d931180ccde7792110cf3010f9f159"
-  integrity sha512-yoPrhiBptTTbJJxyhFXSPqstLPLgS7pyZDl9v97UmgSNJhNmBrSn6QBH9gmJWF722jOzZpZiEFz6FewnDtORtA==
+"@dhis2-ui/layer@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/layer/-/layer-8.5.1.tgz#1170ae9ac08947a72721cf0eeaef387f76955043"
+  integrity sha512-Q1EKoNl/OBbuJNT+7zFyPKOYwjoUsB2UVfG9wiiX8QeFkCyEF5+HUg/QswcgTTc7OX8ylWcpN75kFPgh3lSnyQ==
   dependencies:
-    "@dhis2-ui/portal" "8.4.16"
+    "@dhis2-ui/portal" "8.5.1"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/legend@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/legend/-/legend-8.4.16.tgz#e7b87692ae964513732e3166a81cab7bcbfcc6dc"
-  integrity sha512-+H1dftu0ODOoDq7ZpMIYxiFQ400eekG7KfBt3YgSbcycd0dTjh12JYHRIR+cmIoyR71ULSe7VlbyaysCGpiSjg==
+"@dhis2-ui/legend@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/legend/-/legend-8.5.1.tgz#fc56cb466d2959de05180589ad4ac566183483c8"
+  integrity sha512-Wz65JXFcKRL0dA1MGYXly/hdfhg1UgCt/CgVkT3MR+9OqMiF7j9lA23tTJfroHRw5sbT1IMUWElILNOKwUATkw==
   dependencies:
-    "@dhis2-ui/required" "8.4.16"
+    "@dhis2-ui/required" "8.5.1"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/loader@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/loader/-/loader-8.4.16.tgz#0bd4bccc40e419dfad94464e0ccefc186605664d"
-  integrity sha512-rkrDxuViDAwkpGCGTZbvp/fUAWyUx4CYJfYLR+yR50F5Ogso/jiKpHoIbKbjljTIWQqkKmTTNzTDgY+YAA0dBg==
+"@dhis2-ui/loader@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/loader/-/loader-8.5.1.tgz#1751ef6e2eea7ed232c12d6c2e33f4d7143d5250"
+  integrity sha512-Yh5a6ueUvobJm1m2BPQYX2dV5ke0FjHj438FhLXX2yGt5m9jjnGvaJ3kuWXvA1DTvZU5OsyhaY9Z/7mt2sMB2A==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/logo@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/logo/-/logo-8.4.16.tgz#8b017a74fe1e02a94a050dcf034dcaae580d03b5"
-  integrity sha512-PXi2P1wVXHwSvb4b+1bGuskEJSrcHOurC9AGSOM/xOMw/24mGHp1PL5dEBIKrFD2zywmwS7uGBxYVRQjiQrAJQ==
+"@dhis2-ui/logo@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/logo/-/logo-8.5.1.tgz#fb972a502339e488867749049f3e6a7439dafbea"
+  integrity sha512-g3mRnLmBkn4S/pzhTHF43NfA3BDgr85lLaa93UBOzxYGWv/f96hAoeUgA0eiVd5Yv7F3jAk85YSjIrJv1I0siQ==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/menu@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/menu/-/menu-8.4.16.tgz#05e3c1b25fcabf77b6dfca3b8e6e50394c5ac22f"
-  integrity sha512-hdx7BGeHJyFceLvlXIItP7lTl4qsd6zqPQCnz3OnST6PmmXaeJ34bvKmWOdzM1Zo+b1rptAGOt8EDF7guV3pkw==
+"@dhis2-ui/menu@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/menu/-/menu-8.5.1.tgz#7a970703b4366d6460323d43645e626637ecb609"
+  integrity sha512-IKGx9aqI7xpDdp9C6EOT8nIomNKuAhTjtxp8Zo2o89+1tBSu8fk6riwXosvcLlI9t2FLTQ4Xf1X9fNBTp2vWvA==
   dependencies:
-    "@dhis2-ui/card" "8.4.16"
-    "@dhis2-ui/divider" "8.4.16"
-    "@dhis2-ui/layer" "8.4.16"
-    "@dhis2-ui/popper" "8.4.16"
-    "@dhis2-ui/portal" "8.4.16"
+    "@dhis2-ui/card" "8.5.1"
+    "@dhis2-ui/divider" "8.5.1"
+    "@dhis2-ui/layer" "8.5.1"
+    "@dhis2-ui/popper" "8.5.1"
+    "@dhis2-ui/portal" "8.5.1"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
-    "@dhis2/ui-icons" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
+    "@dhis2/ui-icons" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/modal@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/modal/-/modal-8.4.16.tgz#f4cace9ab5c76b86ddd341728baf8ae73d6298ad"
-  integrity sha512-Un6NX5T/Y4F0G9sSFakcWoep6ywf0PU3RVWjkrlHDluC8I/TvCipsmeRJ12YaewTZuTQXBNNbZNO7grEjBPY/A==
+"@dhis2-ui/modal@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/modal/-/modal-8.5.1.tgz#1e406c6eb00466d1bc723a2332fcfb6d57bbb440"
+  integrity sha512-iu14YtjgjH7AT8sQ4hmaKlCjCcxYb5SR3f8wZ8xV1lW4PX3kPiZmGz43uO0aF8XboNTwln/OBejPQefoAo3ZzA==
   dependencies:
-    "@dhis2-ui/card" "8.4.16"
-    "@dhis2-ui/center" "8.4.16"
-    "@dhis2-ui/layer" "8.4.16"
-    "@dhis2-ui/portal" "8.4.16"
+    "@dhis2-ui/card" "8.5.1"
+    "@dhis2-ui/center" "8.5.1"
+    "@dhis2-ui/layer" "8.5.1"
+    "@dhis2-ui/portal" "8.5.1"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
-    "@dhis2/ui-icons" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
+    "@dhis2/ui-icons" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/node@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/node/-/node-8.4.16.tgz#096bc77b37d1af0c252fa62f1c7fc3e37224a318"
-  integrity sha512-Tbgdniz9J0tGqDP1x30ROcYN3ANENZKsBkHVj8Pbdi0h+VFdB66t1C5VhWQInYKfnveX3W/uyxUt9Ws9UreSLw==
+"@dhis2-ui/node@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/node/-/node-8.5.1.tgz#672f48fa194713aaadca45c84657cc312565029d"
+  integrity sha512-5JMR1tF3n3k8IVe04kqN06N4qopS33rQuFfeuLCQQL3uoCT3TUSY5QvFttjEPx6cgYj7aZdr/4ejhC6zLZAa1A==
   dependencies:
-    "@dhis2-ui/loader" "8.4.16"
+    "@dhis2-ui/loader" "8.5.1"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/notice-box@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/notice-box/-/notice-box-8.4.16.tgz#423dc1ec56d8029b1f151175cc44823be739c0c3"
-  integrity sha512-MnliWaFehRCBa3l1PUjRnrAHUDq+ptCn8dHtePZUCYflUGkyq1N7GbMjzUSlmCMJz7eHva82+8PjpiegIGWWng==
+"@dhis2-ui/notice-box@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/notice-box/-/notice-box-8.5.1.tgz#2f1de9cf0529ce57e1a56e4c66516e84512896c2"
+  integrity sha512-f2jbxd+yujMh+/mk1yRgHljgRAUbnYPg8zQEvhhC18/jWQdyj/1IvJ7njv8Rh8rXJ6Vnu3HVJw6wjTNw4Ra8ow==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
-    "@dhis2/ui-icons" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
+    "@dhis2/ui-icons" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/organisation-unit-tree@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/organisation-unit-tree/-/organisation-unit-tree-8.4.16.tgz#a9e1d1efd80375476b99097539b8381eb14955bd"
-  integrity sha512-lT+a+ZPLaaquBkKzDaAkOlV1p+r32nsCCLPXRUX3+KMe/oBmJg085qByyRo0frdq7bulXB/HF8BzwGhZiUU+DA==
+"@dhis2-ui/organisation-unit-tree@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/organisation-unit-tree/-/organisation-unit-tree-8.5.1.tgz#ad29506ddbc03f012cea270258f4271ed6192a35"
+  integrity sha512-OdcOPLD8I5oqXwQfN/lshW6G3koQTejaPQZuXUYDfvOEQgW/xI5O31MzqtshC2SpXT5Q4ymxXsltHOr0OoFw1g==
   dependencies:
-    "@dhis2-ui/checkbox" "8.4.16"
-    "@dhis2-ui/loader" "8.4.16"
-    "@dhis2-ui/node" "8.4.16"
+    "@dhis2-ui/checkbox" "8.5.1"
+    "@dhis2-ui/loader" "8.5.1"
+    "@dhis2-ui/node" "8.5.1"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/pagination@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/pagination/-/pagination-8.4.16.tgz#646572e74bfe09f9b818ad3570d242ff6cc81eeb"
-  integrity sha512-A+0w+oIOfdw+gEXhCL1ryrZ4NL+W1WzPLLaQxzEN82evJOz4AbeItbokOzDsp3Hc/SaakIrfUiHmEHRkOdmAqA==
+"@dhis2-ui/pagination@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/pagination/-/pagination-8.5.1.tgz#9cd8e350412f3751a17ba55e999f05fb96f215d3"
+  integrity sha512-poQzJ0zZmbR/q4ufW6wa1cmiK/xAhkpKgQ5YswSW+xnltJA1FsRAUPq0ODsTbqNh7g+SbfOl6uWtFzn30grKzg==
   dependencies:
-    "@dhis2-ui/button" "8.4.16"
-    "@dhis2-ui/select" "8.4.16"
+    "@dhis2-ui/button" "8.5.1"
+    "@dhis2-ui/select" "8.5.1"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
-    "@dhis2/ui-icons" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
+    "@dhis2/ui-icons" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/popover@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/popover/-/popover-8.4.16.tgz#9f4234f87db3f8b1bb1a62416403714f30cd60b0"
-  integrity sha512-f1rl4u1NL/Le8K3AKjlayRScICy2j3x469AQDErMC4c4AUJ64kgTaS4Ho9xdmp/I6060ZWWXEciUPbCQfh/Lfw==
+"@dhis2-ui/popover@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/popover/-/popover-8.5.1.tgz#586e98da29c23f3e707b62c7c7a79eec0ef9719b"
+  integrity sha512-vDy4bdjtcP+bto2pmBMABkgUc4kBo1UFWHXZ3Z6b0cDmVwXPKVMrA7WB8bTt1sGtCVsVFJnL08/uDUn4g5EEHA==
   dependencies:
-    "@dhis2-ui/layer" "8.4.16"
-    "@dhis2-ui/popper" "8.4.16"
+    "@dhis2-ui/layer" "8.5.1"
+    "@dhis2-ui/popper" "8.5.1"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/popper@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/popper/-/popper-8.4.16.tgz#0bcf2b52e465d2032d4db1818b20690c174008f3"
-  integrity sha512-ZRG/jNo4FclZ5ji2DIpj/Ot++JMJo89xWb87wOZODP2W0Geafpn9SrQPcEHmpkNgq4OejSx3B7I86anX4iwqiw==
+"@dhis2-ui/popper@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/popper/-/popper-8.5.1.tgz#7ab7fe89578d44482519efdb6fa534a2d8505e07"
+  integrity sha512-xkWEg5Tz/2ENzIRcNdPwX8gYV1HpY0DgpeOZPyOBMCEVjxpSIS9sDw7vjSuCIMVBex+Xm141iS2+EA38OQ0EeQ==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
     "@popperjs/core" "^2.10.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
     react-popper "^2.2.5"
     resize-observer-polyfill "^1.5.1"
 
-"@dhis2-ui/portal@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/portal/-/portal-8.4.16.tgz#57a42ae8e1a04170b01a16f3eccdbee2fb933364"
-  integrity sha512-fduc3TAWrnCMzNLZAAuw7OxyKanlcXTi1RoCj1M9ZnamVULoTmRvoSPRUNOFILVYti4sgfroI0aJcLY0zYFiNw==
+"@dhis2-ui/portal@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/portal/-/portal-8.5.1.tgz#93702cf79c850a505a581da7474b292ec3bdc4ed"
+  integrity sha512-U6b/NPMBhpiWw65PMdcDFKgWuiigLSn9/7h3TQSPTXhBBMx/uU/fLQVeq4ISxqKiLmTqvGxfokMGT5w1ykvYqw==
   dependencies:
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/radio@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/radio/-/radio-8.4.16.tgz#1741bc283856726a85b81e4f9463aaf7b77caba1"
-  integrity sha512-/nFmHBL+XjE5+Mh1YlbwTY5jt4wDCufBpnyUodb4yHcYoXgXZ9B82xGUIzRZmXtjZ/yhO9JgiKxkBAFzxl4XEA==
+"@dhis2-ui/radio@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/radio/-/radio-8.5.1.tgz#b13f1929f9232a8512e1f10eb36a3a848a667279"
+  integrity sha512-CUk0FYvxBED32/x1GwKJCQ++QGNkin+E6AoyXbLdf1YJNkQFKQ1WkqxxMkcp3mhI7Zkbpg+NMENIwP7DhCNuKA==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/required@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/required/-/required-8.4.16.tgz#fa98ae597b105d0f908db5bb6e7d261c4d2fc837"
-  integrity sha512-nqI3dXc00no6j5cQq/2qFeE8WkngNKlwzeIAk26QHyWFJv5vvRfvCOGSRvkQSEONBFGsNQnj5ooH4KjVJbOAiA==
+"@dhis2-ui/required@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/required/-/required-8.5.1.tgz#0e76733167bfd7810ed6ff25c071f0f35037698b"
+  integrity sha512-iT4Ft2PrUIbDQzxjkGVMc72h0XITmYNW/VQjgNWJACyPWrwf+7hKe0pPZMRO9mZVQx8yOXDr0z/jFylHjrvbtQ==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/segmented-control@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/segmented-control/-/segmented-control-8.4.16.tgz#b558ac375f9f9a4995e8a7ad4e144c10e4fd4c10"
-  integrity sha512-d9+L++OrbyPymzvwLnb2Wmal8xuq1rVekqFjfVAMFuX/GhZksxHy5XX8eHXzOcUwH1HH+3ZpQtc0/FSe1QhXCA==
+"@dhis2-ui/segmented-control@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/segmented-control/-/segmented-control-8.5.1.tgz#366e83a6310a5603baf103f60eed1ca82f21fed3"
+  integrity sha512-mhpVrmLo7d8zqVdDHFjZZR9Fj8cjuu3IIsvaJEMgzCbvmlbysYmFvygdhBiwJFIH2DJWl6L05VqmUbGA4DIb1Q==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/select@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/select/-/select-8.4.16.tgz#27af50b08869fe103044e5fe19a75767778bcf68"
-  integrity sha512-+Q+OlQLL/SnDpwCO0TDouIqyaTQtER8MyjuTeXPzsIAy1sPtoh722ojFVRL80TPL5mMUKrftk+gwxfEbizkVGg==
+"@dhis2-ui/select@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/select/-/select-8.5.1.tgz#22074cc9abc5f502da1666d62c91e69c77593d22"
+  integrity sha512-mE/yArumnVC5PzalKXQHkYqpHcfIagsdFxTr3zY/+KqKLPRSQK0qiF4Y0LSHZVC1sCh+NuKHWHqSv5xa24Q5fQ==
   dependencies:
-    "@dhis2-ui/box" "8.4.16"
-    "@dhis2-ui/button" "8.4.16"
-    "@dhis2-ui/card" "8.4.16"
-    "@dhis2-ui/checkbox" "8.4.16"
-    "@dhis2-ui/chip" "8.4.16"
-    "@dhis2-ui/field" "8.4.16"
-    "@dhis2-ui/input" "8.4.16"
-    "@dhis2-ui/layer" "8.4.16"
-    "@dhis2-ui/loader" "8.4.16"
-    "@dhis2-ui/popper" "8.4.16"
-    "@dhis2-ui/status-icon" "8.4.16"
+    "@dhis2-ui/box" "8.5.1"
+    "@dhis2-ui/button" "8.5.1"
+    "@dhis2-ui/card" "8.5.1"
+    "@dhis2-ui/checkbox" "8.5.1"
+    "@dhis2-ui/chip" "8.5.1"
+    "@dhis2-ui/field" "8.5.1"
+    "@dhis2-ui/input" "8.5.1"
+    "@dhis2-ui/layer" "8.5.1"
+    "@dhis2-ui/loader" "8.5.1"
+    "@dhis2-ui/popper" "8.5.1"
+    "@dhis2-ui/status-icon" "8.5.1"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
-    "@dhis2/ui-icons" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
+    "@dhis2/ui-icons" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/selector-bar@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/selector-bar/-/selector-bar-8.4.16.tgz#e62f36e30b4bbde799a247c272928e218103286a"
-  integrity sha512-nBzJRkQydCWKh5QB5uf8H84gHbO15FQKnCZ4ePjDkEHGENgvP/AdhXOn3er0y+WkL3Zd03t1q6pi1vMjOZd2DA==
+"@dhis2-ui/selector-bar@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/selector-bar/-/selector-bar-8.5.1.tgz#4dee31f183d30dd1d6417f8147002016b48de8ef"
+  integrity sha512-f/srC+LA8x9Wi0xkTmbHy0pK67HqrOz88eJ58QslVw+EiSB1t4gjHKvT4RUDm41YA5+3hNI7/J3O8EsyDvCllQ==
   dependencies:
-    "@dhis2-ui/button" "8.4.16"
-    "@dhis2-ui/card" "8.4.16"
-    "@dhis2-ui/layer" "8.4.16"
-    "@dhis2-ui/popper" "8.4.16"
-    "@dhis2/ui-constants" "8.4.16"
-    "@dhis2/ui-icons" "8.4.16"
+    "@dhis2-ui/button" "8.5.1"
+    "@dhis2-ui/card" "8.5.1"
+    "@dhis2-ui/layer" "8.5.1"
+    "@dhis2-ui/popper" "8.5.1"
+    "@dhis2/ui-constants" "8.5.1"
+    "@dhis2/ui-icons" "8.5.1"
     "@testing-library/react" "^12.1.2"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/sharing-dialog@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/sharing-dialog/-/sharing-dialog-8.4.16.tgz#dcbc8555cad185fe77c9e9c43418bb7cb6d63bec"
-  integrity sha512-wr0ZoydYeATqEMpDUpaUrYSGHNOVH/I2JJqyTs6Si3iuHkPZxBkWISomJWd7i0hdnvfKDpFDQ1i6srNsKZ2SSA==
+"@dhis2-ui/sharing-dialog@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/sharing-dialog/-/sharing-dialog-8.5.1.tgz#e5a716bd2ab1cbdd113c4627c690f27237a3a6ca"
+  integrity sha512-EPVtd5HBCHCwQQlGh8WAkz91A4Wqh1d++YjSt4Ps4FmDha21Sd1CUDkOUP27xjoK/J/DH+6UFnSyp5UA3ZvGtQ==
   dependencies:
-    "@dhis2-ui/box" "8.4.16"
-    "@dhis2-ui/button" "8.4.16"
-    "@dhis2-ui/card" "8.4.16"
-    "@dhis2-ui/divider" "8.4.16"
-    "@dhis2-ui/input" "8.4.16"
-    "@dhis2-ui/layer" "8.4.16"
-    "@dhis2-ui/menu" "8.4.16"
-    "@dhis2-ui/modal" "8.4.16"
-    "@dhis2-ui/notice-box" "8.4.16"
-    "@dhis2-ui/popper" "8.4.16"
-    "@dhis2-ui/select" "8.4.16"
-    "@dhis2-ui/tab" "8.4.16"
-    "@dhis2-ui/tooltip" "8.4.16"
-    "@dhis2-ui/user-avatar" "8.4.16"
+    "@dhis2-ui/box" "8.5.1"
+    "@dhis2-ui/button" "8.5.1"
+    "@dhis2-ui/card" "8.5.1"
+    "@dhis2-ui/divider" "8.5.1"
+    "@dhis2-ui/input" "8.5.1"
+    "@dhis2-ui/layer" "8.5.1"
+    "@dhis2-ui/menu" "8.5.1"
+    "@dhis2-ui/modal" "8.5.1"
+    "@dhis2-ui/notice-box" "8.5.1"
+    "@dhis2-ui/popper" "8.5.1"
+    "@dhis2-ui/select" "8.5.1"
+    "@dhis2-ui/tab" "8.5.1"
+    "@dhis2-ui/tooltip" "8.5.1"
+    "@dhis2-ui/user-avatar" "8.5.1"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
-    "@dhis2/ui-icons" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
+    "@dhis2/ui-icons" "8.5.1"
     "@react-hook/size" "^2.1.2"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/status-icon@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/status-icon/-/status-icon-8.4.16.tgz#d5646d95880db5508b360653f3252475aba2c016"
-  integrity sha512-dC8DRVS9lF8z4RHq+DsToA2i6N9kgRXz6b/KNtP0UA1pk4dPJ2j06mPjqAyeKuc2KBNL9HuxnBnf6dEWSoPsdg==
+"@dhis2-ui/status-icon@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/status-icon/-/status-icon-8.5.1.tgz#a5896e4de5b4e34188d8e15dbc2fdba7630efec5"
+  integrity sha512-1XRPEqETs/RvBbqDl1ZAyURn1F8Sr8NLNRrPCOQuH2XQw7KtPI+WnEf5bcgyL3ptWl5XY41Otqn0+5ilI1mbQA==
   dependencies:
-    "@dhis2-ui/loader" "8.4.16"
+    "@dhis2-ui/loader" "8.5.1"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
-    "@dhis2/ui-icons" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
+    "@dhis2/ui-icons" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/switch@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/switch/-/switch-8.4.16.tgz#8669d15362f75295fda144a400b83c194386e18a"
-  integrity sha512-0hil61WzWX5jkllpQ5eVCVa9WTobbRopVU51cQeUG7Qmo9hx/wHQr/Cq6MW6WT0fs/6QyfNaSAzRmduxWY316Q==
+"@dhis2-ui/switch@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/switch/-/switch-8.5.1.tgz#9c113778837acb1d60a286c7202acd0a86ddae56"
+  integrity sha512-/bzBPSiXo3CNbRh/q9mL+VaEEI0/MDGm+JREXBY0g23P8FR73rpYsKBcDnvZSZvrguZw1owcif54i79ChyC3pQ==
   dependencies:
-    "@dhis2-ui/field" "8.4.16"
-    "@dhis2-ui/required" "8.4.16"
+    "@dhis2-ui/field" "8.5.1"
+    "@dhis2-ui/required" "8.5.1"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/tab@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/tab/-/tab-8.4.16.tgz#03866b89fa4f248098947dcaff5c8375f678cf13"
-  integrity sha512-qTPIlz42H0nb163NOTtrgojFtkglVj0CJ04KGQZ1Csr9HfdPmFp/P1x8o+JiPq+TRcRbNveN/486/FzF7AmHzw==
+"@dhis2-ui/tab@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/tab/-/tab-8.5.1.tgz#a99b0f0410cac8eee8786271fb31c6207bde2358"
+  integrity sha512-XQgXKGAbKBz75P+mruaI9kSjEPR7qzPNN8oX0AdcRhF9jzV9w3Q2+0ednAHh24xvLuydEQV3LKjHWR2jOcStkQ==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
-    "@dhis2/ui-icons" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
+    "@dhis2/ui-icons" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/table@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/table/-/table-8.4.16.tgz#3c414ce228cb1f3cf446854b0dd81d34ef528c65"
-  integrity sha512-yE7v0wywu0d1alAItOhx/TsTCxmJ2TtF7RAMxePA2V5JU9fFaa0Hd4sy1REIezl3JCmuMUZ3kEX+t8RMV7VloQ==
+"@dhis2-ui/table@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/table/-/table-8.5.1.tgz#925d9f9b92be6d2bd8381e11cdb432ebbdc94713"
+  integrity sha512-q5RIW5UEviMOdPXuTdQEI9ooRXmcNW2D27JFjUkF7qR3g6IKzyks/XwMz0PJeg20q8wNqBptl7WZNH3OkW+VAA==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
-    "@dhis2/ui-icons" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
+    "@dhis2/ui-icons" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/tag@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/tag/-/tag-8.4.16.tgz#065b171f3202100cca6977a4e58a6d33d69f916b"
-  integrity sha512-MC7OWmIqZBLsofKDTKAIjz5hXa1+lPyPw38vUU6A/ThcwwYQutnFU0b8gwM0OOe4ztgcqQgTkEkkJM86hQ7MWg==
+"@dhis2-ui/tag@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/tag/-/tag-8.5.1.tgz#5c745857181a260f4ac868bd93897304ed6f851d"
+  integrity sha512-4eZXFdE/rhwWj1YpsbSyR8cDgeBL7aMGMQ2heM4UK+9YgP4YEweGtJlkKT0KDCbBYDloYZFv0rjiSKI7CxbmLg==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/text-area@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/text-area/-/text-area-8.4.16.tgz#778009b843dec860318364af066933d49cd10943"
-  integrity sha512-as8C6GSLBXlcA5NPRnkINhEpKysMeRSVr7Ia9Rc4rwdYvT0m4H5S9ksAI3RpkxtN3nZeD3ggng7L0KU8eGEaww==
+"@dhis2-ui/text-area@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/text-area/-/text-area-8.5.1.tgz#df0b227acec568cc5be64d90251552ae35d3cb04"
+  integrity sha512-sWIjiL3oRi/H/jm7SiFYsLUksjkUIZUluJoFrtdDzfLOjKjvLFJCju8PuAa7COdONIZaL8tLzv8Jy0uRXlB6KQ==
   dependencies:
-    "@dhis2-ui/box" "8.4.16"
-    "@dhis2-ui/field" "8.4.16"
-    "@dhis2-ui/loader" "8.4.16"
-    "@dhis2-ui/status-icon" "8.4.16"
+    "@dhis2-ui/box" "8.5.1"
+    "@dhis2-ui/field" "8.5.1"
+    "@dhis2-ui/loader" "8.5.1"
+    "@dhis2-ui/status-icon" "8.5.1"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
-    "@dhis2/ui-icons" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
+    "@dhis2/ui-icons" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/tooltip@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/tooltip/-/tooltip-8.4.16.tgz#a2ad58c79b004fc622e5fddf94241261b3d365b4"
-  integrity sha512-g63fYa/7Cbuqa0X1xW2CqhxGFrP4prN+PojvPf3/JNXX/LcM/PqIPezJN/GofjuDNq5hfAogjhV4TcWg4RuByQ==
+"@dhis2-ui/tooltip@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/tooltip/-/tooltip-8.5.1.tgz#d75c4be3d8510a3bac743f0f972e56f098d2ccc3"
+  integrity sha512-vnDs352AVxfJE+IFaPvvhsEVe+m6Y0pS0ajvHz4/hUg86DWSSev//P6RAM7q5XPULDeNu0UsFH6B7uVkzEH/ig==
   dependencies:
-    "@dhis2-ui/popper" "8.4.16"
-    "@dhis2-ui/portal" "8.4.16"
+    "@dhis2-ui/popper" "8.5.1"
+    "@dhis2-ui/portal" "8.5.1"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/transfer@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/transfer/-/transfer-8.4.16.tgz#6575d71ebd9c41bc512c55c48a16b157129fc799"
-  integrity sha512-x3a773QZnFALWKNrcQoUqtRRxTQxGBkZ3nInxrI5SG5MxIOdpyOOB4AsPUr2TdKPFcDyp7IbieLlnhH3togMcg==
+"@dhis2-ui/transfer@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/transfer/-/transfer-8.5.1.tgz#0ecc1caeebe04cc25f172f7323abfc34ebfb9d6a"
+  integrity sha512-Zu6EUzkOzWlvwPJl3nEkirje+I16kFDPVaL9F1/d3WE0VYtf5gRPme+Fvz/8pldXjbOF/IA0w/Uu/HrJrbJm9w==
   dependencies:
-    "@dhis2-ui/button" "8.4.16"
-    "@dhis2-ui/field" "8.4.16"
-    "@dhis2-ui/input" "8.4.16"
-    "@dhis2-ui/intersection-detector" "8.4.16"
-    "@dhis2-ui/loader" "8.4.16"
+    "@dhis2-ui/button" "8.5.1"
+    "@dhis2-ui/field" "8.5.1"
+    "@dhis2-ui/input" "8.5.1"
+    "@dhis2-ui/intersection-detector" "8.5.1"
+    "@dhis2-ui/loader" "8.5.1"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/user-avatar@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/user-avatar/-/user-avatar-8.4.16.tgz#9cb783aa637a9cfcdc1a56b840cfa955afc8ad22"
-  integrity sha512-Wex7cb3zdXYgqtblNfHzdB8PU2xD02ItRLgLlXj/EPKRjM+F/g4Zh35HbGHgBCgfH3xtjfw+hVLbpb+TyL4RHQ==
+"@dhis2-ui/user-avatar@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/user-avatar/-/user-avatar-8.5.1.tgz#eaae5a6d2eb6a543fbf0ec4e2071064f84835196"
+  integrity sha512-nzUVyiUNXwCWORC8bNs7EMYxql9fej7dafxQMDIBa7+3uO/N19llXH2ejTlwVp2xY0ZeOV+PsAwQeTAV7vlb3Q==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.4.16"
+    "@dhis2/ui-constants" "8.5.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
@@ -2149,12 +2151,12 @@
     react-beautiful-dnd "^10.1.1"
     resize-observer-polyfill "^1.5.1"
 
-"@dhis2/app-adapter@10.0.0":
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-adapter/-/app-adapter-10.0.0.tgz#5e89add391373c0f84d717aa759f17081fec7ebf"
-  integrity sha512-qz74GPSkzaXbBNK09Brykwt8f4kPPPj+jOMjWBBF5hb03xomN6GAp+kjx3EOnpmQs2x1KHc0xgmU1cBuQK5wRw==
+"@dhis2/app-adapter@10.1.0":
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-adapter/-/app-adapter-10.1.0.tgz#c1bd4340fe277c705fc450c5197318f3934029c2"
+  integrity sha512-FzfDvX9K8pdF6T9SiFLD7Tml0DCmHijCnK7BwDfjLBImjhTWz9qNzmUL7YGvoq+rP6Wu9vF93tGRUROOLYj+Pw==
   dependencies:
-    "@dhis2/pwa" "10.0.0"
+    "@dhis2/pwa" "10.1.0"
     moment "^2.24.0"
 
 "@dhis2/app-runtime-adapter-d2@^1.1.0":
@@ -2164,50 +2166,50 @@
   dependencies:
     prop-types "^15.7.2"
 
-"@dhis2/app-runtime@^3.2.3", "@dhis2/app-runtime@^3.4.4":
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-runtime/-/app-runtime-3.4.4.tgz#87202b82babe6e4b3f29f784e02a3b295960359c"
-  integrity sha512-GTj0H6TLVcw6zo0Vf9aDuPJbsjFfbNWN/SSC9/GF2a0foXdKVSCoc4H5+gW/RhBgYvaSZYwQBA6L+qBaQj7c0Q==
+"@dhis2/app-runtime@^3.4.4", "@dhis2/app-runtime@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-runtime/-/app-runtime-3.5.0.tgz#e4416e12b76749965eed333b6f95b2c52a42a2ce"
+  integrity sha512-WnaosdNSyaJ2q5TU5RUnsg+rQX03oayuo/37BnJbGZI1DeGEUT/7K3gd1wSTSPFM+zN6rm+rkbIXs/C3WgRRAQ==
   dependencies:
-    "@dhis2/app-service-alerts" "3.4.4"
-    "@dhis2/app-service-config" "3.4.4"
-    "@dhis2/app-service-data" "3.4.4"
-    "@dhis2/app-service-offline" "3.4.4"
+    "@dhis2/app-service-alerts" "3.5.0"
+    "@dhis2/app-service-config" "3.5.0"
+    "@dhis2/app-service-data" "3.5.0"
+    "@dhis2/app-service-offline" "3.5.0"
 
-"@dhis2/app-service-alerts@3.4.4":
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-service-alerts/-/app-service-alerts-3.4.4.tgz#ccd8848f416e976a01ea11bbbd6e1ae873136777"
-  integrity sha512-o2DHlZIHxJQ4XwJ9uIr0UpMTi3ZK0W6u+FkSnPGwrvF+MCFsxA0+pjN7PfBo4acCQHPBwTZzcyq0WYiEAJM7OA==
+"@dhis2/app-service-alerts@3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-service-alerts/-/app-service-alerts-3.5.0.tgz#b21cb636e43371e7d3842c50a9f6f025be6fc71a"
+  integrity sha512-VYFrD4ltY4yTCLsbA/qFd/nO3xIs2lwZfSQ/NRvRhVecN1xq2vfqBS2tK5sompB7r1GaAlr1QInBeDJN9yvj7w==
 
-"@dhis2/app-service-config@3.4.4":
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-service-config/-/app-service-config-3.4.4.tgz#b5773138183bf339055957bdd1d24b54fecc404e"
-  integrity sha512-QCUfptfmwh3Xs16rr7DDTgMBuQIcJpt2CZEc6XROPYMgBBvN3sncA9Rzb7Jf+xblZwUWi0xuZ7PKs49FFS+5kQ==
+"@dhis2/app-service-config@3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-service-config/-/app-service-config-3.5.0.tgz#fc91a855fff818353bc298eaca9e52bd94ffc576"
+  integrity sha512-I4qh/8Tpi3UpLtenW7UPNWvykmlOSNlHWfNt8S6ZsinLn7hyXt14h20N+MvWD7m95JWnAjBhqZyy1PzhssULmA==
 
-"@dhis2/app-service-data@3.4.4":
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-service-data/-/app-service-data-3.4.4.tgz#028236463b82f998ff7bd44e811153f6c1408507"
-  integrity sha512-mJyaSRikY5noXHdpSm3pTPM/ga+6Jp7XgG62J0mSXsVbwYSOJSLQqcponXsTNwaX3IuQHLir83dXe06YjZq70Q==
+"@dhis2/app-service-data@3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-service-data/-/app-service-data-3.5.0.tgz#986e592d58f7fec7698edf3cd1dc0982756f32d4"
+  integrity sha512-LAoJtVQZhf7KltQ93exBNcbYygqN87Eqm50C6J737yPM5thyiZD6Rs4Zvte25gQy8IoFGZDmyJC1Dm5aFHjE+Q==
   dependencies:
     react-query "^3.13.11"
 
-"@dhis2/app-service-offline@3.4.4":
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-service-offline/-/app-service-offline-3.4.4.tgz#49d460b22c8eb8357aeef05aee8ed6f8a5c3a953"
-  integrity sha512-wBlaMh7rdlr9RQ02q5vADtk9ixFtfI5ywXmxCPiXPBRftahMqwUpGpD88KPIUpoSPRI0V2LYGv0XQm33+gmKnw==
+"@dhis2/app-service-offline@3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-service-offline/-/app-service-offline-3.5.0.tgz#af3677fd10a54415db6ab4740eb4940023b2db29"
+  integrity sha512-phvl4gnjMXgl3cxios7upShs0q5GV3+2ZRyeXGXD57tIMypyhLwHKqEoVpFbinMp4zvX25vJFMm6ub6HsnRcSQ==
   dependencies:
     lodash "^4.17.21"
 
-"@dhis2/app-shell@10.0.0":
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-shell/-/app-shell-10.0.0.tgz#ab18d169afed9efc681668aba592f17deb0ecf00"
-  integrity sha512-ehMDa+uq6ubH95/kEETW4GaED27EGnwHc52jiODNjbN8bNCEtgLDyuFKyqkt0mUygOa5Uwa+oAlmvrOj0fe2Ug==
+"@dhis2/app-shell@10.1.0":
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-shell/-/app-shell-10.1.0.tgz#a11ef39d654a070158ca1ea38675709ca5315a87"
+  integrity sha512-Y1cst4+3sn0fn5O97wsZ3/4zMXNE6jEhQ0ageho5sVHyFiUzfDEtggcdkD8ANVcJXNW9HIs+DLkcc/C0YZEZFg==
   dependencies:
-    "@dhis2/app-adapter" "10.0.0"
-    "@dhis2/app-runtime" "^3.2.3"
+    "@dhis2/app-adapter" "10.1.0"
+    "@dhis2/app-runtime" "^3.5.0"
     "@dhis2/d2-i18n" "^1.1.0"
-    "@dhis2/pwa" "10.0.0"
-    "@dhis2/ui" "^8.0.0"
+    "@dhis2/pwa" "10.1.0"
+    "@dhis2/ui" "^8.5.0"
     classnames "^2.2.6"
     moment "^2.29.1"
     prop-types "^15.7.2"
@@ -2219,10 +2221,10 @@
     typeface-roboto "^0.0.75"
     typescript "^3.6.3"
 
-"@dhis2/cli-app-scripts@^10.0.0":
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/cli-app-scripts/-/cli-app-scripts-10.0.0.tgz#7f813d8c809410e4f47d54fdc2d033e40326fc5a"
-  integrity sha512-BLNwREoXkb6huUWgnMNThYrSqPuM6Ik0qA7KMyhnQPRPRv+nkWMe130R4jmRenHAA5ub0aQgDpkNImoGv0l7NQ==
+"@dhis2/cli-app-scripts@^10.1.0":
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/cli-app-scripts/-/cli-app-scripts-10.1.0.tgz#9d0ce3dcdc3910942a41ad8940a6f958c02caf74"
+  integrity sha512-bKXTTFdvz+C0Sz55Aklsi9Zf1yPfO0YJfKOWXoV+Mhs+o2rM7zMhMuWJQA+j9iFfAqQNyzKJw0pQpLGHA/Wxqg==
   dependencies:
     "@babel/core" "^7.6.2"
     "@babel/plugin-proposal-class-properties" "^7.8.3"
@@ -2231,7 +2233,7 @@
     "@babel/preset-env" "^7.14.7"
     "@babel/preset-react" "^7.0.0"
     "@babel/preset-typescript" "^7.6.0"
-    "@dhis2/app-shell" "10.0.0"
+    "@dhis2/app-shell" "10.1.0"
     "@dhis2/cli-helpers-engine" "^3.2.0"
     "@jest/core" "^27.0.6"
     "@yarnpkg/lockfile" "^1.1.0"
@@ -2442,10 +2444,10 @@
   resolved "https://registry.yarnpkg.com/@dhis2/prop-types/-/prop-types-3.1.2.tgz#65b8ad2da8cd2f72bc8b951049a6c9d1b97af3e9"
   integrity sha512-eM0jjLOWvtXWqSFp5YC4DHFpkP8Y1D2eUwGV7MBWjni+o27oesVan+oT7WHeOeLdlAd4acRJrnaaAyB4Ck1wGQ==
 
-"@dhis2/pwa@10.0.0":
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/pwa/-/pwa-10.0.0.tgz#35dd1eba09d4e14016cab3f6dbf7b49a169c89ef"
-  integrity sha512-d4Rynv54mFNaOgigamgUqHWbcqg5n9Bn7JSncX0O8BvEE66db/JjkXo2ZKnnj3qimHEB3U4iR+IzfABSB2X7CQ==
+"@dhis2/pwa@10.1.0":
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/pwa/-/pwa-10.1.0.tgz#764c1f8fe7c4a8a00168769646626e97d0b37500"
+  integrity sha512-C3/Pi9RPfRfa9INeIL+WNbaYpTCDLTQdqZWafi4NBgD/Pq/jvobyTuevZrEeMyzR/uDGrzDjt2d6Cllp00QHEg==
   dependencies:
     idb "^6.0.0"
     workbox-core "^6.1.5"
@@ -2453,90 +2455,90 @@
     workbox-routing "^6.1.5"
     workbox-strategies "^6.1.5"
 
-"@dhis2/ui-constants@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-constants/-/ui-constants-8.4.16.tgz#75fc311f3b0b958c8950e4fb6a7ff343ff144341"
-  integrity sha512-fM/XXCMOwshseD1KVzG6t82eNWeHS32jqtZczNSFyC7XOBpAMGTuiICwTytkoLvvT780O7b8YRTiedIhBI6IMw==
+"@dhis2/ui-constants@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-constants/-/ui-constants-8.5.1.tgz#d6f676689428629787291280e8021b259e4ce174"
+  integrity sha512-A+oFT4EJnsR3OXL3qWuZctj9XQLmBC5FurIXFOhDnFnSjhU8nCm0yUCY5mjpTPzAYLJbxqzxkpnloMOGdS84kQ==
   dependencies:
     prop-types "^15.7.2"
 
-"@dhis2/ui-forms@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-forms/-/ui-forms-8.4.16.tgz#64b939663b76137937dbd28622d739b4cd21a207"
-  integrity sha512-4ZJWNuBku9nveAWLp8Y5HlfDbF6bVcjUXy74xeq4gNClUzc2g4b7SR4VGL4IiSbUtcgxya/k7GD40H4PmRvqvw==
+"@dhis2/ui-forms@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-forms/-/ui-forms-8.5.1.tgz#9593bbe564b41d0aa7013ac6d3f96a574b383a75"
+  integrity sha512-UqLI1/BoGnbxVT6ghsX0XWzVgQLEaBkA6/VzDdsTzBuE4ZuhI7t8ycN0UzW3lBZlIe66x9oGAZQ8RzbLPZc8Mg==
   dependencies:
-    "@dhis2-ui/button" "8.4.16"
-    "@dhis2-ui/checkbox" "8.4.16"
-    "@dhis2-ui/field" "8.4.16"
-    "@dhis2-ui/file-input" "8.4.16"
-    "@dhis2-ui/input" "8.4.16"
-    "@dhis2-ui/radio" "8.4.16"
-    "@dhis2-ui/select" "8.4.16"
-    "@dhis2-ui/switch" "8.4.16"
-    "@dhis2-ui/text-area" "8.4.16"
+    "@dhis2-ui/button" "8.5.1"
+    "@dhis2-ui/checkbox" "8.5.1"
+    "@dhis2-ui/field" "8.5.1"
+    "@dhis2-ui/file-input" "8.5.1"
+    "@dhis2-ui/input" "8.5.1"
+    "@dhis2-ui/radio" "8.5.1"
+    "@dhis2-ui/select" "8.5.1"
+    "@dhis2-ui/switch" "8.5.1"
+    "@dhis2-ui/text-area" "8.5.1"
     "@dhis2/prop-types" "^3.1.2"
     classnames "^2.3.1"
     final-form "^4.20.2"
     prop-types "^15.7.2"
     react-final-form "^6.5.3"
 
-"@dhis2/ui-icons@8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-icons/-/ui-icons-8.4.16.tgz#f77ab5eff684e4794c1d53d343700bbff85ab522"
-  integrity sha512-oq3vXRUxcoOtghZU0QoA5bK6HSIOJ1H26Xse6bmxJiQD16tCxD5SS7WCzkyHLDaWouzef/+pRd81ZnvJ8PMEVA==
+"@dhis2/ui-icons@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-icons/-/ui-icons-8.5.1.tgz#09017289ee11a81c83635d38db648b8180908a99"
+  integrity sha512-RTjN03OsCv1HdWkfarVB3gEIXrIzpwzJ6lQQ/LE3PqniJ++5Sl8f6b8yy54go5C+EhuL5/3boeAH10kH7D1KYA==
 
-"@dhis2/ui@^8.0.0", "@dhis2/ui@^8.4.11", "@dhis2/ui@^8.4.16":
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-8.4.16.tgz#effb8969e8b279af15e7870a985c36191aae1912"
-  integrity sha512-PuSnVMYLZQsBAebV0nMV99QZDZYi++q4AAvfAOLKPjAN0VQqzc9zOjO4RxCzPqP4QgzI3udgR2hWoQ0ZhxDR7w==
+"@dhis2/ui@^8.4.11", "@dhis2/ui@^8.5.0", "@dhis2/ui@^8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-8.5.1.tgz#d3a34b008ec7f53875f65b4da75ae58f51354c6e"
+  integrity sha512-xG+JXI10y7J1kwuj9t2mvs9Wuvbb7Nau2deEufqfgIqfL1l2FO3fbMSZ7RZurtKHLgPtyDTUL8qTerfu1heUwQ==
   dependencies:
-    "@dhis2-ui/alert" "8.4.16"
-    "@dhis2-ui/box" "8.4.16"
-    "@dhis2-ui/button" "8.4.16"
-    "@dhis2-ui/card" "8.4.16"
-    "@dhis2-ui/center" "8.4.16"
-    "@dhis2-ui/checkbox" "8.4.16"
-    "@dhis2-ui/chip" "8.4.16"
-    "@dhis2-ui/cover" "8.4.16"
-    "@dhis2-ui/css" "8.4.16"
-    "@dhis2-ui/divider" "8.4.16"
-    "@dhis2-ui/field" "8.4.16"
-    "@dhis2-ui/file-input" "8.4.16"
-    "@dhis2-ui/header-bar" "8.4.16"
-    "@dhis2-ui/help" "8.4.16"
-    "@dhis2-ui/input" "8.4.16"
-    "@dhis2-ui/intersection-detector" "8.4.16"
-    "@dhis2-ui/label" "8.4.16"
-    "@dhis2-ui/layer" "8.4.16"
-    "@dhis2-ui/legend" "8.4.16"
-    "@dhis2-ui/loader" "8.4.16"
-    "@dhis2-ui/logo" "8.4.16"
-    "@dhis2-ui/menu" "8.4.16"
-    "@dhis2-ui/modal" "8.4.16"
-    "@dhis2-ui/node" "8.4.16"
-    "@dhis2-ui/notice-box" "8.4.16"
-    "@dhis2-ui/organisation-unit-tree" "8.4.16"
-    "@dhis2-ui/pagination" "8.4.16"
-    "@dhis2-ui/popover" "8.4.16"
-    "@dhis2-ui/popper" "8.4.16"
-    "@dhis2-ui/portal" "8.4.16"
-    "@dhis2-ui/radio" "8.4.16"
-    "@dhis2-ui/required" "8.4.16"
-    "@dhis2-ui/segmented-control" "8.4.16"
-    "@dhis2-ui/select" "8.4.16"
-    "@dhis2-ui/selector-bar" "8.4.16"
-    "@dhis2-ui/sharing-dialog" "8.4.16"
-    "@dhis2-ui/switch" "8.4.16"
-    "@dhis2-ui/tab" "8.4.16"
-    "@dhis2-ui/table" "8.4.16"
-    "@dhis2-ui/tag" "8.4.16"
-    "@dhis2-ui/text-area" "8.4.16"
-    "@dhis2-ui/tooltip" "8.4.16"
-    "@dhis2-ui/transfer" "8.4.16"
-    "@dhis2-ui/user-avatar" "8.4.16"
-    "@dhis2/ui-constants" "8.4.16"
-    "@dhis2/ui-forms" "8.4.16"
-    "@dhis2/ui-icons" "8.4.16"
+    "@dhis2-ui/alert" "8.5.1"
+    "@dhis2-ui/box" "8.5.1"
+    "@dhis2-ui/button" "8.5.1"
+    "@dhis2-ui/card" "8.5.1"
+    "@dhis2-ui/center" "8.5.1"
+    "@dhis2-ui/checkbox" "8.5.1"
+    "@dhis2-ui/chip" "8.5.1"
+    "@dhis2-ui/cover" "8.5.1"
+    "@dhis2-ui/css" "8.5.1"
+    "@dhis2-ui/divider" "8.5.1"
+    "@dhis2-ui/field" "8.5.1"
+    "@dhis2-ui/file-input" "8.5.1"
+    "@dhis2-ui/header-bar" "8.5.1"
+    "@dhis2-ui/help" "8.5.1"
+    "@dhis2-ui/input" "8.5.1"
+    "@dhis2-ui/intersection-detector" "8.5.1"
+    "@dhis2-ui/label" "8.5.1"
+    "@dhis2-ui/layer" "8.5.1"
+    "@dhis2-ui/legend" "8.5.1"
+    "@dhis2-ui/loader" "8.5.1"
+    "@dhis2-ui/logo" "8.5.1"
+    "@dhis2-ui/menu" "8.5.1"
+    "@dhis2-ui/modal" "8.5.1"
+    "@dhis2-ui/node" "8.5.1"
+    "@dhis2-ui/notice-box" "8.5.1"
+    "@dhis2-ui/organisation-unit-tree" "8.5.1"
+    "@dhis2-ui/pagination" "8.5.1"
+    "@dhis2-ui/popover" "8.5.1"
+    "@dhis2-ui/popper" "8.5.1"
+    "@dhis2-ui/portal" "8.5.1"
+    "@dhis2-ui/radio" "8.5.1"
+    "@dhis2-ui/required" "8.5.1"
+    "@dhis2-ui/segmented-control" "8.5.1"
+    "@dhis2-ui/select" "8.5.1"
+    "@dhis2-ui/selector-bar" "8.5.1"
+    "@dhis2-ui/sharing-dialog" "8.5.1"
+    "@dhis2-ui/switch" "8.5.1"
+    "@dhis2-ui/tab" "8.5.1"
+    "@dhis2-ui/table" "8.5.1"
+    "@dhis2-ui/tag" "8.5.1"
+    "@dhis2-ui/text-area" "8.5.1"
+    "@dhis2-ui/tooltip" "8.5.1"
+    "@dhis2-ui/transfer" "8.5.1"
+    "@dhis2-ui/user-avatar" "8.5.1"
+    "@dhis2/ui-constants" "8.5.1"
+    "@dhis2/ui-forms" "8.5.1"
+    "@dhis2/ui-icons" "8.5.1"
     prop-types "^15.7.2"
 
 "@emotion/babel-utils@^0.6.4":


### PR DESCRIPTION
Closes [DHIS2-13864](https://dhis2.atlassian.net/browse/DHIS2-13864) by upgrading @dhis2/cli-app-scripts and @dhis2/ui (headerbar)

This adds app debug info the the profile menu and also moves app update notifications "out of the way" by putting them in the profile menu as well.  The app will also automatically reload and update to the latest version when refreshed (and also hard-refreshed) if only one tab is open.

<img width="349" alt="Screen Shot 2022-09-26 at 13 17 32" src="https://user-images.githubusercontent.com/947888/194571295-24a9fc42-65e0-456f-b760-7a42667d77c8.png">
