### PR TITLE
chore: add jest tests that document the getFilteredVisualization function

### DIFF
--- a/cypress/integration/view/dashboard_filter/create_dashboard.js
+++ b/cypress/integration/view/dashboard_filter/create_dashboard.js
@@ -57,7 +57,7 @@ Given('I open existing dashboard', () => {
 Then('the dashboard displays in view mode', () => {
     // check for a map canvas and a highcharts element
     cy.get(chartSel, EXTENDED_TIMEOUT).should('be.visible')
-    cy.get(mapSel, { timeout: 25000 }).should('be.visible')
+    cy.get(mapSel, { timeout: 45000 }).should('be.visible')
 })
 
 When('I choose to delete dashboard', () => {

--- a/cypress/integration/view/dashboard_filter/create_dashboard.js
+++ b/cypress/integration/view/dashboard_filter/create_dashboard.js
@@ -57,7 +57,7 @@ Given('I open existing dashboard', () => {
 Then('the dashboard displays in view mode', () => {
     // check for a map canvas and a highcharts element
     cy.get(chartSel, EXTENDED_TIMEOUT).should('be.visible')
-    cy.get(mapSel, EXTENDED_TIMEOUT).should('be.visible')
+    cy.get(mapSel, { timeout: 25000 }).should('be.visible')
 })
 
 When('I choose to delete dashboard', () => {

--- a/cypress/integration/view/dashboard_filter/create_dashboard.js
+++ b/cypress/integration/view/dashboard_filter/create_dashboard.js
@@ -57,7 +57,7 @@ Given('I open existing dashboard', () => {
 Then('the dashboard displays in view mode', () => {
     // check for a map canvas and a highcharts element
     cy.get(chartSel, EXTENDED_TIMEOUT).should('be.visible')
-    cy.get(mapSel, { timeout: 45000 }).should('be.visible')
+    cy.get(mapSel, { timeout: 85000 }).should('be.visible')
 })
 
 When('I choose to delete dashboard', () => {

--- a/cypress/integration/view/dashboard_filter/create_dashboard.js
+++ b/cypress/integration/view/dashboard_filter/create_dashboard.js
@@ -54,6 +54,9 @@ Given('I open existing dashboard', () => {
         .click()
 })
 
+// TODO - restore the normal EXTENDED_TIMEOUT when
+// slow loading of this map has been fixes
+// https://dhis2.atlassian.net/browse/DHIS2-14365
 Then('the dashboard displays in view mode', () => {
     // check for a map canvas and a highcharts element
     cy.get(chartSel, EXTENDED_TIMEOUT).should('be.visible')

--- a/cypress/integration/view/dashboard_filter/dashboard_filter.js
+++ b/cypress/integration/view/dashboard_filter/dashboard_filter.js
@@ -35,6 +35,9 @@ Then('the Period filter is applied to the dashboard', () => {
 
     cy.get(innerScrollContainerSel).scrollTo('top')
     // check the MAP
+    // TODO - restore the normal EXTENDED_TIMEOUT when
+    // slow loading of this map has been fixes
+    // https://dhis2.atlassian.net/browse/DHIS2-14365
     cy.get('.dhis2-map-legend-button', { timeout: 85000 }).trigger('mouseover')
     cy.get('.dhis2-map-legend-period', EXTENDED_TIMEOUT)
         .contains(PERIOD)
@@ -74,6 +77,9 @@ Then('the Facility Type filter is applied to the dashboard', () => {
         .should('be.visible')
 
     cy.get(innerScrollContainerSel).scrollTo('top')
+    // TODO - restore the normal EXTENDED_TIMEOUT when
+    // slow loading of this map has been fixes
+    // https://dhis2.atlassian.net/browse/DHIS2-14365
     cy.get(mapLegendButtonSel, { timeout: 85000 }).trigger('mouseover')
     cy.get(mapLegendContentSel, EXTENDED_TIMEOUT)
         .find('div')

--- a/cypress/integration/view/dashboard_filter/dashboard_filter.js
+++ b/cypress/integration/view/dashboard_filter/dashboard_filter.js
@@ -35,7 +35,7 @@ Then('the Period filter is applied to the dashboard', () => {
 
     cy.get(innerScrollContainerSel).scrollTo('top')
     // check the MAP
-    cy.get('.dhis2-map-legend-button', EXTENDED_TIMEOUT).trigger('mouseover')
+    cy.get('.dhis2-map-legend-button', { timeout: 85000 }).trigger('mouseover')
     cy.get('.dhis2-map-legend-period', EXTENDED_TIMEOUT)
         .contains(PERIOD)
         .should('be.visible')
@@ -74,7 +74,7 @@ Then('the Facility Type filter is applied to the dashboard', () => {
         .should('be.visible')
 
     cy.get(innerScrollContainerSel).scrollTo('top')
-    cy.get(mapLegendButtonSel, EXTENDED_TIMEOUT).trigger('mouseover')
+    cy.get(mapLegendButtonSel, { timeout: 85000 }).trigger('mouseover')
     cy.get(mapLegendContentSel, EXTENDED_TIMEOUT)
         .find('div')
         .contains(`Facility Type: ${FACILITY_TYPE}`)

--- a/src/components/Item/VisualizationItem/Visualization/__tests__/getFilteredVisualization.spec.js
+++ b/src/components/Item/VisualizationItem/Visualization/__tests__/getFilteredVisualization.spec.js
@@ -1,0 +1,138 @@
+import getFilteredVisualization from '../getFilteredVisualization.js'
+
+describe('getFilteredVisualization', () => {
+    test('modifies existing visualization filter', () => {
+        const filters = {
+            pe: [{ id: 'FILTER_PE' }],
+        }
+
+        const vis = {
+            id: 'myvisualization',
+            rows: [{ dimension: 'ou', items: [{ id: 'SIERRA_LEONE' }] }],
+            filters: [{ dimension: 'pe', items: [{ id: 'THIS_YEAR' }] }],
+            columns: [
+                {
+                    dimension: 'dx',
+                    items: [{ id: 'anc1' }, { id: 'anc2' }],
+                },
+            ],
+        }
+
+        expect(getFilteredVisualization(vis, filters)).toEqual(
+            expect.objectContaining({
+                id: 'myvisualization',
+                rows: [{ dimension: 'ou', items: [{ id: 'SIERRA_LEONE' }] }],
+                filters: [{ dimension: 'pe', items: [{ id: 'FILTER_PE' }] }],
+                columns: [
+                    {
+                        dimension: 'dx',
+                        items: [{ id: 'anc1' }, { id: 'anc2' }],
+                    },
+                ],
+            })
+        )
+    })
+
+    test('modifies existing visualization rows', () => {
+        const filters = {
+            ou: [{ id: 'BO' }],
+        }
+
+        const vis = {
+            rows: [{ dimension: 'ou', items: [{ id: 'SIERRA_LEONE' }] }],
+            filters: [{ dimension: 'pe', items: [{ id: 'THIS_YEAR' }] }],
+            columns: [
+                {
+                    dimension: 'dx',
+                    items: [{ id: 'anc1' }, { id: 'anc2' }],
+                },
+            ],
+        }
+
+        expect(getFilteredVisualization(vis, filters)).toEqual(
+            expect.objectContaining({
+                rows: [{ dimension: 'ou', items: [{ id: 'BO' }] }],
+                filters: [{ dimension: 'pe', items: [{ id: 'THIS_YEAR' }] }],
+                columns: [
+                    {
+                        dimension: 'dx',
+                        items: [{ id: 'anc1' }, { id: 'anc2' }],
+                    },
+                ],
+            })
+        )
+    })
+
+    test('modifies existing visualization columns', () => {
+        const filters = {
+            facility: [{ id: 'CLINIC' }, { id: 'HOSPITAL' }],
+        }
+
+        const vis = {
+            rows: [{ dimension: 'ou', items: [{ id: 'SIERRA_LEONE' }] }],
+            filters: [{ dimension: 'pe', items: [{ id: 'THIS_YEAR' }] }],
+            columns: [
+                {
+                    dimension: 'facility',
+                    items: [
+                        { id: 'CLINIC' },
+                        { id: 'HOSPITAL' },
+                        { id: 'CHC' },
+                        { id: 'CHP' },
+                        { id: 'MCHP' },
+                    ],
+                },
+            ],
+        }
+
+        expect(getFilteredVisualization(vis, filters)).toEqual(
+            expect.objectContaining({
+                filters: [{ dimension: 'pe', items: [{ id: 'THIS_YEAR' }] }],
+                rows: [{ dimension: 'ou', items: [{ id: 'SIERRA_LEONE' }] }],
+                columns: [
+                    {
+                        dimension: 'facility',
+                        items: [{ id: 'CLINIC' }, { id: 'HOSPITAL' }],
+                    },
+                ],
+            })
+        )
+    })
+
+    test('adds new filter to visualization filters', () => {
+        const filters = {
+            pe: [{ id: 'FILTER_PE' }],
+            facility: [{ id: 'CLINIC' }, { id: 'HOSPITAL' }],
+        }
+
+        const vis = {
+            rows: [{ dimension: 'ou', items: [{ id: 'SIERRA_LEONE' }] }],
+            filters: [{ dimension: 'pe', items: [{ id: 'THIS_YEAR' }] }],
+            columns: [
+                {
+                    dimension: 'dx',
+                    items: [{ id: 'anc1' }, { id: 'anc2' }],
+                },
+            ],
+        }
+
+        expect(getFilteredVisualization(vis, filters)).toEqual(
+            expect.objectContaining({
+                rows: [{ dimension: 'ou', items: [{ id: 'SIERRA_LEONE' }] }],
+                filters: [
+                    { dimension: 'pe', items: [{ id: 'FILTER_PE' }] },
+                    {
+                        dimension: 'facility',
+                        items: [{ id: 'CLINIC' }, { id: 'HOSPITAL' }],
+                    },
+                ],
+                columns: [
+                    {
+                        dimension: 'dx',
+                        items: [{ id: 'anc1' }, { id: 'anc2' }],
+                    },
+                ],
+            })
+        )
+    })
+})


### PR DESCRIPTION
Added these tests as documentation of the function. Useful for guiding while implementing the new plugin architecture in maps-app.

Added a temporary extra-long timeout for the map that is really slow.