### PR TITLE
fix: cypress - add long extended timeout for slow map load in filter test [v38]

### DIFF
--- a/cypress/integration/view/dashboard_filter/create_dashboard.js
+++ b/cypress/integration/view/dashboard_filter/create_dashboard.js
@@ -53,7 +53,7 @@ Given('I open existing dashboard', () => {
 Then('the dashboard displays in view mode', () => {
     // check for a map canvas and a highcharts element
     cy.get(chartSel, EXTENDED_TIMEOUT).should('be.visible')
-    cy.get(mapSel, EXTENDED_TIMEOUT).should('be.visible')
+    cy.get(mapSel, { timeout: 85000 }).should('be.visible')
 })
 
 When('I choose to delete dashboard', () => {

--- a/cypress/integration/view/dashboard_filter/dashboard_filter.js
+++ b/cypress/integration/view/dashboard_filter/dashboard_filter.js
@@ -35,7 +35,7 @@ Then('the Period filter is applied to the dashboard', () => {
 
     cy.get(innerScrollContainerSel).scrollTo('top')
     // check the MAP
-    cy.get('.dhis2-map-legend-button', EXTENDED_TIMEOUT).trigger('mouseover')
+    cy.get('.dhis2-map-legend-button', { timeout: 85000 }).trigger('mouseover')
     cy.get('.dhis2-map-legend-period', EXTENDED_TIMEOUT)
         .contains(PERIOD)
         .should('be.visible')
@@ -74,7 +74,7 @@ Then('the Facility Type filter is applied to the dashboard', () => {
         .should('be.visible')
 
     cy.get(innerScrollContainerSel).scrollTo('top')
-    cy.get(mapLegendButtonSel, EXTENDED_TIMEOUT).trigger('mouseover')
+    cy.get(mapLegendButtonSel, { timeout: 85000 }).trigger('mouseover')
     cy.get(mapLegendContentSel, EXTENDED_TIMEOUT)
         .find('div')
         .contains(`Facility Type: ${FACILITY_TYPE}`)


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-14365 was created to investigate why the map is so slow to load.