### PR TITLE
fix: use new endpoint for dashboard item search (DHIS2-12236)

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -2,5 +2,7 @@
     "baseUrl": "http://localhost:3000",
     "video": true,
     "projectId": "5fk191",
-    "testFiles": "**/*.feature"
+    "testFiles": "**/*.feature",
+    "viewportWidth": 1280,
+    "viewportHeight": 800
 }

--- a/cypress/integration/view/dashboard_filter/create_dashboard.js
+++ b/cypress/integration/view/dashboard_filter/create_dashboard.js
@@ -26,22 +26,27 @@ When('I add a MAP and a CHART and save', () => {
         .find('input')
         .type('Inpatient', { force: true })
 
-    // //chart
+    //chart
     cy.get(
         '[data-test="menu-item-Inpatient: BMI this year by districts"]'
     ).click()
 
+    cy.get('[data-test="dhis2-uicore-layer"]').click('topLeft')
+
+    cy.get('[data-test="item-search"]').click()
+    cy.get('[data-test="item-search"]')
+        .find('input')
+        .type('ipt 2', { force: true })
+
     //map
-    cy.get(
-        '[data-test="menu-item-Inpatient: BMI at facility level this year"]'
-    ).click()
+    cy.get('[data-test="menu-item-ANC: IPT 2 Coverage this year"]').click()
 
     cy.get('[data-test="dhis2-uicore-layer"]').click('topLeft')
 
     //move things so the dashboard is more compact
     cy.get(`${gridItemSel}.MAP`)
         .trigger('mousedown')
-        .trigger('mousemove', { clientX: 600 })
+        .trigger('mousemove', { clientX: 650 })
         .trigger('mouseup')
 
     //save
@@ -54,13 +59,12 @@ Given('I open existing dashboard', () => {
         .click()
 })
 
-// TODO - restore the normal EXTENDED_TIMEOUT when
-// slow loading of this map has been fixes
+// Some map visualization load very slowly:
 // https://dhis2.atlassian.net/browse/DHIS2-14365
 Then('the dashboard displays in view mode', () => {
     // check for a map canvas and a highcharts element
     cy.get(chartSel, EXTENDED_TIMEOUT).should('be.visible')
-    cy.get(mapSel, { timeout: 85000 }).should('be.visible')
+    cy.get(mapSel, EXTENDED_TIMEOUT).should('be.visible')
 })
 
 When('I choose to delete dashboard', () => {

--- a/src/pages/edit/ItemSelector/dashboardsQQuery.js
+++ b/src/pages/edit/ItemSelector/dashboardsQQuery.js
@@ -1,6 +1,0 @@
-export const getDashboardsQQuery = (query = '', maxItems = []) => {
-    return {
-        resource: `dashboards/q/${query}`,
-        params: { count: 11, max: maxItems },
-    }
-}


### PR DESCRIPTION
**Fixes [DHIS2-12236](https://dhis2.atlassian.net/browse/DHIS2-12236)**

---

### Key features

1. use new dashboard item search endpoint

---

### Description

Use the new search endpoint to avoid search issues when `/` is typed as part of the search text.

---

### Screenshots

The request does not return 404 anymore:
<img width="784" alt="Screenshot 2023-01-11 at 14 54 44" src="https://user-images.githubusercontent.com/150978/211826701-25d744cf-9711-4529-aa55-f060374aa895.png">

The dashboard item list is filtered correctly even if just `/` is used as search term:
<img width="766" alt="Screenshot 2023-01-11 at 15 07 27" src="https://user-images.githubusercontent.com/150978/211826793-27fbcec5-a213-43c7-9adf-51c5e1f4e862.png">


[DHIS2-12236]: https://dhis2.atlassian.net/browse/DHIS2-12236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ