### PR TITLE
fix: use baseUrl from useConfig hook to avoid undefined value

### DIFF
--- a/src/components/Item/VisualizationItem/Visualization/IframePlugin.js
+++ b/src/components/Item/VisualizationItem/Visualization/IframePlugin.js
@@ -1,3 +1,4 @@
+import { useConfig } from '@dhis2/app-runtime'
 import { useD2 } from '@dhis2/app-runtime-adapter-d2'
 import postRobot from '@krakenjs/post-robot'
 import PropTypes from 'prop-types'
@@ -26,6 +27,7 @@ const IframePlugin = ({
     itemType,
 }) => {
     const { d2 } = useD2()
+    const { baseUrl } = useConfig()
 
     const { userSettings } = useUserSettings()
     const iframeRef = useRef()
@@ -133,7 +135,7 @@ const IframePlugin = ({
 
         // 2. check if there is an installed app for the pluginType
         // and use its plugin launch URL
-        const pluginLaunchUrl = getPluginLaunchUrl(pluginType, d2)
+        const pluginLaunchUrl = getPluginLaunchUrl(pluginType, d2, baseUrl)
 
         if (pluginLaunchUrl) {
             return pluginLaunchUrl
@@ -142,7 +144,7 @@ const IframePlugin = ({
         setError('missing-plugin')
 
         return
-    }, [activeType, d2])
+    }, [activeType, d2, baseUrl])
 
     if (error) {
         return error === 'missing-plugin' ? (

--- a/src/components/Item/VisualizationItem/Visualization/plugin.js
+++ b/src/components/Item/VisualizationItem/Visualization/plugin.js
@@ -24,10 +24,9 @@ const itemTypeToScriptPath = {
 const hasIntegratedPlugin = (type) =>
     [CHART, REPORT_TABLE, VISUALIZATION, MAP].includes(type)
 
-export const getPluginLaunchUrl = (type, d2) => {
+export const getPluginLaunchUrl = (type, d2, baseUrl) => {
     // 1. lookup in api/apps for the "manually installed" app, this can be a new version for a core (bundled) app
     // 2. fallback to default hardcoded path for the core (bundled) apps
-    const baseUrl = d2.system.systemInfo.instanceBaseUrl
     const apps = d2.system.installedApps
     const appKey = itemTypeMap[type].appKey
 


### PR DESCRIPTION
The previous approach with d2.system.systemInfo.instanceBaseUrl had issues with localhost and other instances.