### PR TITLE
fix: close TranslationDialog after saving a translation

### DIFF
--- a/src/pages/edit/ActionsBar.js
+++ b/src/pages/edit/ActionsBar.js
@@ -165,10 +165,10 @@ const EditBar = ({ dashboard, ...props }) => {
         translationDlgIsOpen ? (
             <TranslationDialog
                 className="translation-dialog"
-                onClose={toggleTranslationDialog}
                 objectToTranslate={dashboard}
                 fieldsToTranslate={fieldsToTranslate}
-                onTranslationSaved={Function.prototype}
+                onClose={toggleTranslationDialog}
+                onTranslationSaved={toggleTranslationDialog}
             />
         ) : null
 


### PR DESCRIPTION
This is the same behaviour as in the apps.
The dialog closing has been recently changed so it needs to be triggered in the app.