### PR TITLE
fix: avoid sending props twice when using View as and plugin changes

### DIFF
--- a/src/components/Item/VisualizationItem/Visualization/IframePlugin.js
+++ b/src/components/Item/VisualizationItem/Visualization/IframePlugin.js
@@ -35,6 +35,7 @@ const IframePlugin = ({
 
     // When this mounts, check if the dashboard is recording
     const { isCached, recordingState } = useCacheableSection(dashboardId)
+    const [communicationReceived, setCommunicationReceived] = useState(false)
     const [recordOnNextLoad, setRecordOnNextLoad] = useState(
         recordingState === 'recording'
     )
@@ -86,34 +87,37 @@ const IframePlugin = ({
 
     useEffect(() => {
         if (iframeRef?.current) {
-            const listener = postRobot.on(
-                'getProps',
-                // listen for messages coming only from the iframe rendered by this component
-                { window: iframeRef.current.contentWindow },
-                () => {
-                    if (recordOnNextLoad) {
-                        // Avoid recording unnecessarily,
-                        // e.g. if plugin re-requests props for some reason
-                        setRecordOnNextLoad(false)
+            // if iframe has not sent initial request, set up a listener
+            if (!communicationReceived) {
+                const listener = postRobot.on(
+                    'getProps',
+                    // listen for messages coming only from the iframe rendered by this component
+                    { window: iframeRef.current.contentWindow },
+                    () => {
+                        setCommunicationReceived(true)
+
+                        if (recordOnNextLoad) {
+                            // Avoid recording unnecessarily,
+                            // e.g. if plugin re-requests props for some reason
+                            setRecordOnNextLoad(false)
+                        }
+
+                        return pluginProps
                     }
+                )
 
-                    return pluginProps
-                }
-            )
-
-            return () => listener.cancel()
+                return () => listener.cancel()
+            }
         }
-    }, [recordOnNextLoad, pluginProps])
 
-    useEffect(() => {
-        if (iframeRef.current?.contentWindow) {
+        if (communicationReceived && iframeRef.current?.contentWindow) {
             postRobot.send(
                 iframeRef.current.contentWindow,
                 'newProps',
                 pluginProps
             )
         }
-    }, [pluginProps])
+    }, [communicationReceived, recordOnNextLoad, pluginProps])
 
     useEffect(() => {
         setError(null)


### PR DESCRIPTION
I discovered this problem when testing the "View as" feature in dashboard.

The problem was that props where sent twice to the plugin and I think some of the postRobot timeout errors where a consequence of that.

This is what happened.
When using "View as" and switching app, ie. from DV to Maps and viceversa, the plugin loaded in the iframe needs to change.
This causes the "new" plugin to send the `getProps` message to dashboard, but at the same time `pluginProp` in dashboard `IframePlugin` component changes (the visualization object is adapted for DV/Maps) which causes `newProps` message to be sent from dashboard to the plugin.
The props are then sent twice, which would cause a re-render of the plugin.
I also suspect some of the postRobot console errors are due to `newProps` being sent while the listener in the plugin is not yet available.

This refactor uses the same approach used in the "future" component in app-runtime, currently in the alpha branch:
https://github.com/dhis2/app-runtime/blob/alpha/services/plugin/src/Plugin.tsx