### PR TITLE
fix: list LL items after Maps and before ER/EV

### DIFF
--- a/src/pages/edit/ItemSelector/selectableItems.js
+++ b/src/pages/edit/ItemSelector/selectableItems.js
@@ -41,9 +41,9 @@ export const singleItems = [
 export const categorizedItems = [
     VISUALIZATION,
     MAP,
+    EVENT_VISUALIZATION,
     EVENT_REPORT,
     EVENT_CHART,
-    EVENT_VISUALIZATION,
     REPORTS,
     RESOURCES,
     APP,


### PR DESCRIPTION
Reorder dashboard items result list to show LL items after DV and Maps and before ER, EV and the other types.

## Screenshot
<img width="755" alt="Screenshot 2023-03-17 at 17 21 09" src="https://user-images.githubusercontent.com/150978/225962192-1d2232bd-7ca5-43a3-a32f-98e2760f306c.png">

