### PR TITLE
fix: fix props handling when switching Map <-> DV plugins

### DIFF
--- a/src/components/Item/VisualizationItem/Visualization/IframePlugin.js
+++ b/src/components/Item/VisualizationItem/Visualization/IframePlugin.js
@@ -39,7 +39,6 @@ const IframePlugin = ({
         recordingState === 'recording'
     )
 
-    const communicationReceivedRef = useRef(false)
     const prevPluginRef = useRef()
 
     const onError = () => setError('plugin')
@@ -113,41 +112,28 @@ const IframePlugin = ({
     }, [isCached])
 
     useEffect(() => {
-        console.log('in useEffect', iframeSrc, prevPluginRef.current) //communicationReceivedRef.current)
         if (iframeRef?.current) {
             // if iframe has not sent initial request, set up a listener
             if (iframeSrc !== prevPluginRef.current) {
-                //communicationReceivedRef.current) {
                 prevPluginRef.current = iframeSrc
 
-                console.log('setup getProps listener')
                 const listener = postRobot.on(
                     'getProps',
                     // listen for messages coming only from the iframe rendered by this component
                     { window: iframeRef.current.contentWindow },
                     () => {
-                        //       setCommunicationReceived(true)
-                        //communicationReceivedRef.current = true
-                        console.log('getProps: communication received')
-
                         if (recordOnNextLoad) {
                             // Avoid recording unnecessarily,
                             // e.g. if plugin re-requests props for some reason
                             setRecordOnNextLoad(false)
                         }
 
-                        console.log('getProps: return props:', pluginProps)
                         return pluginProps
                     }
                 )
 
-                return () => {
-                    console.log('teardown')
-                    //communicationReceivedRef.current = false
-                    listener.cancel()
-                }
+                return () => listener.cancel()
             } else {
-                console.log('send newProps', pluginProps)
                 postRobot.send(
                     iframeRef.current.contentWindow,
                     'newProps',
@@ -180,7 +166,6 @@ const IframePlugin = ({
         )
     }
 
-    console.log('before return')
     return (
         <div className={classes.wrapper}>
             {iframeSrc ? (


### PR DESCRIPTION
### Key features

1. fix problem when switching between Map and DV using "View as"

---

### Description

When using "View as" and switching between Map and chart/table or viceversa, the plugin loaded in the iframe needs to change.
This transition didn't work because the message listener in dashboard was not in place when the plugin requested `getProps`, resulting in the Map/chart/table not showing.
Switching between chart and table worked because in that case the plugin does not change and the `newProps` message is used instead of `getProps`.

The `getProps` listener is still removed in the cleanup function returned by the useEffect, but it's recreated if the iframe src change (plugin change).

After the first `getProps` message is received there shouldn't be other `getProps` messages incoming, but `newProps` is used for passing new/modified props instead.

---

### Screenshots

Before:
https://user-images.githubusercontent.com/150978/227541666-4c0ec880-0eed-4b8f-bce0-3656bddb5284.mov

After:
https://user-images.githubusercontent.com/150978/227542408-996b818a-c1ba-473e-b007-5d2f60c762f5.mov


