### PR TITLE
chore: nightly failing to set up cypress

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -7,6 +7,8 @@ on:
         branches:
             - 'master'
             - 'dev'
+        tags:
+            - '*'
 
 env:
     GIT_AUTHOR_NAME: '@dhis2-bot'
@@ -94,9 +96,6 @@ jobs:
                   path: '**/node_modules'
                   key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
 
-            - name: Install Cypress binary
-              run: yarn cypress install
-
             - name: End-to-End tests
               uses: cypress-io/github-action@v2
               with:
@@ -127,7 +126,7 @@ jobs:
         if: |
             !github.event.push.repository.fork &&
             github.actor != 'dependabot[bot]' &&
-            github.ref == 'refs/heads/master'
+            github.event_name != 'pull_request'
         steps:
             - uses: actions/checkout@v3
               with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,6 +6,7 @@ on:
     schedule:
         - cron: '10 5 * * 1-5'
     workflow_dispatch:
+    pull_request:
 
 concurrency:
     group: ${{ github.workflow}}-${{ github.ref }}
@@ -31,9 +32,6 @@ jobs:
 
             - name: Install
               run: yarn install --frozen-lockfile
-
-            - name: Install Cypress binary
-              run: yarn cypress install
 
             - name: End-to-End tests
               uses: cypress-io/github-action@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,7 +6,6 @@ on:
     schedule:
         - cron: '10 5 * * 1-5'
     workflow_dispatch:
-    pull_request:
 
 concurrency:
     group: ${{ github.workflow}}-${{ github.ref }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,7 @@ name: 'dhis2: nightly'
 on:
     schedule:
         - cron: '10 5 * * 1-5'
+    workflow_dispatch:
 
 concurrency:
     group: ${{ github.workflow}}-${{ github.ref }}
@@ -28,11 +29,8 @@ jobs:
               with:
                   node-version: 18.x
 
-            - uses: actions/cache@v2
-              id: yarn-cache
-              with:
-                  path: '**/node_modules'
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+            - name: Install
+              run: yarn install --frozen-lockfile
 
             - name: Install Cypress binary
               run: yarn cypress install
@@ -45,13 +43,11 @@ jobs:
                   start: ${{ env.SERVER_START_CMD }}
                   wait-on: ${{ env.SERVER_URL }}
                   wait-on-timeout: 300
-                  cache-key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
                   group: 'e2e'
                   tag: ${{ github.event_name }}
               env:
                   CI: true
                   CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-                  COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
                   SERVER_START_CMD: 'yarn cypress:start'
                   SERVER_URL: 'http://localhost:3000'
                   cypress_dhis2_api_stub_mode: 'DISABLED'


### PR DESCRIPTION
1. The verify workflow should run on tags, so that a corresponding branch is created in the d2-ci repository
2. Do not run the release step on PRs, but do allow it for pushes
3. `yarn cypress install` sometimes fails. Turns out it isn't necessary anyway since the cypress-io gh action takes care of installing cypress.