### PR TITLE
fix: release workflow should also run on patch/* branches

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -7,6 +7,7 @@ on:
         branches:
             - 'master'
             - 'dev'
+            - 'patch/*'
         tags:
             - '*'
 


### PR DESCRIPTION
Pre 2.40 point releases of DHIS2 still rely on the app bundle in the d2-ci/dashboard-app repo, so the deploy-build step in this workflow must also run on patch/* 

patch/* should match for example (according to rules [gh action rules](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet))
patch/2.38.6
patch/2.39.3