### PR TITLE
chore: disable nightly scheduled test run

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,10 +1,10 @@
 name: 'dhis2: nightly'
 
-# This workflow runs the e2e tests on the default branch against dev at 5:10am M-F
+# This workflow runs the e2e tests on the default branch against dev
 
 on:
     schedule:
-        - cron: '10 5 * * 1-5'
+        - cron: ${{ vars.NIGHTLY_SCHEDULE }}
     workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,8 +3,8 @@ name: 'dhis2: nightly'
 # This workflow runs the e2e tests on the default branch against dev
 
 on:
-    schedule:
-        - cron: '10 4 * * 2'
+    # schedule:
+    # - cron: '10 4 * * 2'
     workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,7 +4,7 @@ name: 'dhis2: nightly'
 
 on:
     schedule:
-        - cron: ${{ vars.NIGHTLY_SCHEDULE }}
+        - cron: '10 4 * * 2'
     workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Disable for July as the tests are failing due to slow instances and nobody is around to look into it.