### PR TITLE
fix: ou group filter crashes in custom widgets [v39]

### DIFF
--- a/src/components/Item/AppItem/Item.js
+++ b/src/components/Item/AppItem/Item.js
@@ -3,27 +3,13 @@ import { Divider, colors, spacers, IconQuestion24 } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { connect } from 'react-redux'
-import { FILTER_ORG_UNIT } from '../../../actions/itemFilters.js'
 import { EDIT, isEditMode } from '../../../modules/dashboardModes.js'
 import {
     sGetItemFiltersRoot,
     DEFAULT_STATE_ITEM_FILTERS,
 } from '../../../reducers/itemFilters.js'
 import ItemHeader from '../ItemHeader/ItemHeader.js'
-
-const getIframeSrc = (appDetails, item, itemFilters) => {
-    let iframeSrc = `${appDetails.launchUrl}?dashboardItemId=${item.id}`
-
-    if (itemFilters[FILTER_ORG_UNIT] && itemFilters[FILTER_ORG_UNIT].length) {
-        const ouIds = itemFilters[FILTER_ORG_UNIT].map(
-            (ouFilter) => ouFilter.path.split('/').slice(-1)[0]
-        )
-
-        iframeSrc += `&userOrgUnit=${ouIds.join(',')}`
-    }
-
-    return iframeSrc
-}
+import { getIframeSrc } from './getIframeSrc.js'
 
 const AppItem = ({ dashboardMode, item, itemFilters }) => {
     const { d2 } = useD2()

--- a/src/components/Item/AppItem/__tests__/getIframeSrc.spec.js
+++ b/src/components/Item/AppItem/__tests__/getIframeSrc.spec.js
@@ -2,15 +2,14 @@ import { getIframeSrc } from '../getIframeSrc.js'
 
 const appDetails = { launchUrl: 'debug/dev' }
 const dashboardItem = { id: 'rainbowdashitem' }
+const expectedSrc = `${appDetails.launchUrl}?dashboardItemId=${dashboardItem.id}`
 
 describe('getIframeSrc', () => {
     it('no ou filter', () => {
         const ouFilter = []
 
         const src = getIframeSrc(appDetails, dashboardItem, { ou: ouFilter })
-        expect(src).toEqual(
-            `${appDetails.launchUrl}?dashboardItemId=${dashboardItem.id}`
-        )
+        expect(src).toEqual(expectedSrc)
     })
 
     it('should return the correct iframe src', () => {
@@ -27,12 +26,9 @@ describe('getIframeSrc', () => {
             },
         ]
 
-        const appDetails = { launchUrl: 'debug/dev' }
-        const dashboardItem = { id: 'rainbowdashitem' }
-
         const src = getIframeSrc(appDetails, dashboardItem, { ou: ouFilter })
         expect(src).toEqual(
-            `${appDetails.launchUrl}?dashboardItemId=${dashboardItem.id}&userOrgUnit=fdc6uOvgoji,lc3eMKXaEfw`
+            `${expectedSrc}&userOrgUnit=fdc6uOvgoji,lc3eMKXaEfw`
         )
     })
 
@@ -49,12 +45,9 @@ describe('getIframeSrc', () => {
             },
         ]
 
-        const appDetails = { launchUrl: 'debug/dev' }
-        const dashboardItem = { id: 'rainbowdashitem' }
-
         const src = getIframeSrc(appDetails, dashboardItem, { ou: ouFilter })
         expect(src).toEqual(
-            `${appDetails.launchUrl}?dashboardItemId=${dashboardItem.id}&userOrgUnit=OU_GROUP-b0EsAxm8Nge,lc3eMKXaEfw`
+            `${expectedSrc}&userOrgUnit=OU_GROUP-b0EsAxm8Nge,lc3eMKXaEfw`
         )
     })
 
@@ -71,12 +64,9 @@ describe('getIframeSrc', () => {
             },
         ]
 
-        const appDetails = { launchUrl: 'debug/dev' }
-        const dashboardItem = { id: 'rainbowdashitem' }
-
         const src = getIframeSrc(appDetails, dashboardItem, { ou: ouFilter })
         expect(src).toEqual(
-            `${appDetails.launchUrl}?dashboardItemId=${dashboardItem.id}&userOrgUnit=LEVEL-m9lBJogzE95,fdc6uOvgoji`
+            `${expectedSrc}&userOrgUnit=LEVEL-m9lBJogzE95,fdc6uOvgoji`
         )
     })
 
@@ -88,13 +78,8 @@ describe('getIframeSrc', () => {
             },
         ]
 
-        const appDetails = { launchUrl: 'debug/dev' }
-        const dashboardItem = { id: 'rainbowdashitem' }
-
         const src = getIframeSrc(appDetails, dashboardItem, { ou: ouFilter })
-        expect(src).toEqual(
-            `${appDetails.launchUrl}?dashboardItemId=${dashboardItem.id}&userOrgUnit=USER_ORGUNIT`
-        )
+        expect(src).toEqual(`${expectedSrc}&userOrgUnit=USER_ORGUNIT`)
     })
 
     it('all user org units in filter', () => {
@@ -113,12 +98,9 @@ describe('getIframeSrc', () => {
             },
         ]
 
-        const appDetails = { launchUrl: 'debug/dev' }
-        const dashboardItem = { id: 'rainbowdashitem' }
-
         const src = getIframeSrc(appDetails, dashboardItem, { ou: ouFilter })
         expect(src).toEqual(
-            `${appDetails.launchUrl}?dashboardItemId=${dashboardItem.id}&userOrgUnit=USER_ORGUNIT_CHILDREN,USER_ORGUNIT_GRANDCHILDREN,USER_ORGUNIT`
+            `${expectedSrc}&userOrgUnit=USER_ORGUNIT_CHILDREN,USER_ORGUNIT_GRANDCHILDREN,USER_ORGUNIT`
         )
     })
 })

--- a/src/components/Item/AppItem/__tests__/getIframeSrc.spec.js
+++ b/src/components/Item/AppItem/__tests__/getIframeSrc.spec.js
@@ -1,0 +1,124 @@
+import { getIframeSrc } from '../getIframeSrc.js'
+
+const appDetails = { launchUrl: 'debug/dev' }
+const dashboardItem = { id: 'rainbowdashitem' }
+
+describe('getIframeSrc', () => {
+    it('no ou filter', () => {
+        const ouFilter = []
+
+        const src = getIframeSrc(appDetails, dashboardItem, { ou: ouFilter })
+        expect(src).toEqual(
+            `${appDetails.launchUrl}?dashboardItemId=${dashboardItem.id}`
+        )
+    })
+
+    it('should return the correct iframe src', () => {
+        const ouFilter = [
+            {
+                id: 'fdc6uOvgoji',
+                path: '/ImspTQPwCqd/fdc6uOvgoji',
+                name: 'Bombali',
+            },
+            {
+                id: 'lc3eMKXaEfw',
+                path: '/ImspTQPwCqd/lc3eMKXaEfw',
+                name: 'Bonthe',
+            },
+        ]
+
+        const appDetails = { launchUrl: 'debug/dev' }
+        const dashboardItem = { id: 'rainbowdashitem' }
+
+        const src = getIframeSrc(appDetails, dashboardItem, { ou: ouFilter })
+        expect(src).toEqual(
+            `${appDetails.launchUrl}?dashboardItemId=${dashboardItem.id}&userOrgUnit=fdc6uOvgoji,lc3eMKXaEfw`
+        )
+    })
+
+    it('org unit group in filter', () => {
+        const ouFilter = [
+            {
+                id: 'OU_GROUP-b0EsAxm8Nge',
+                name: 'Western Area',
+            },
+            {
+                id: 'lc3eMKXaEfw',
+                path: '/ImspTQPwCqd/lc3eMKXaEfw',
+                name: 'Bonthe',
+            },
+        ]
+
+        const appDetails = { launchUrl: 'debug/dev' }
+        const dashboardItem = { id: 'rainbowdashitem' }
+
+        const src = getIframeSrc(appDetails, dashboardItem, { ou: ouFilter })
+        expect(src).toEqual(
+            `${appDetails.launchUrl}?dashboardItemId=${dashboardItem.id}&userOrgUnit=OU_GROUP-b0EsAxm8Nge,lc3eMKXaEfw`
+        )
+    })
+
+    it('org unit level in filter', () => {
+        const ouFilter = [
+            {
+                id: 'LEVEL-m9lBJogzE95',
+                name: 'Facility',
+            },
+            {
+                id: 'fdc6uOvgoji',
+                path: '/ImspTQPwCqd/fdc6uOvgoji',
+                name: 'Bombali',
+            },
+        ]
+
+        const appDetails = { launchUrl: 'debug/dev' }
+        const dashboardItem = { id: 'rainbowdashitem' }
+
+        const src = getIframeSrc(appDetails, dashboardItem, { ou: ouFilter })
+        expect(src).toEqual(
+            `${appDetails.launchUrl}?dashboardItemId=${dashboardItem.id}&userOrgUnit=LEVEL-m9lBJogzE95,fdc6uOvgoji`
+        )
+    })
+
+    it('user org unit in filter', () => {
+        const ouFilter = [
+            {
+                id: 'USER_ORGUNIT',
+                displayName: 'User organisation unit',
+            },
+        ]
+
+        const appDetails = { launchUrl: 'debug/dev' }
+        const dashboardItem = { id: 'rainbowdashitem' }
+
+        const src = getIframeSrc(appDetails, dashboardItem, { ou: ouFilter })
+        expect(src).toEqual(
+            `${appDetails.launchUrl}?dashboardItemId=${dashboardItem.id}&userOrgUnit=USER_ORGUNIT`
+        )
+    })
+
+    it('all user org units in filter', () => {
+        const ouFilter = [
+            {
+                id: 'USER_ORGUNIT_CHILDREN',
+                displayName: 'User sub-units',
+            },
+            {
+                id: 'USER_ORGUNIT_GRANDCHILDREN',
+                displayName: 'User sub-x2-units',
+            },
+            {
+                id: 'USER_ORGUNIT',
+                displayName: 'User organisation unit',
+            },
+        ]
+
+        const appDetails = { launchUrl: 'debug/dev' }
+        const dashboardItem = { id: 'rainbowdashitem' }
+
+        const src = getIframeSrc(appDetails, dashboardItem, { ou: ouFilter })
+        expect(src).toEqual(
+            `${appDetails.launchUrl}?dashboardItemId=${dashboardItem.id}&userOrgUnit=USER_ORGUNIT_CHILDREN,USER_ORGUNIT_GRANDCHILDREN,USER_ORGUNIT`
+        )
+    })
+})

--- a/src/components/Item/AppItem/getIframeSrc.js
+++ b/src/components/Item/AppItem/getIframeSrc.js
@@ -1,0 +1,17 @@
+import { FILTER_ORG_UNIT } from '../../../actions/itemFilters.js'
+
+export const getIframeSrc = (appDetails, item, itemFilters) => {
+    let iframeSrc = `${appDetails.launchUrl}?dashboardItemId=${item.id}`
+
+    console.log('jj itemfilters', itemFilters)
+
+    if (itemFilters[FILTER_ORG_UNIT] && itemFilters[FILTER_ORG_UNIT].length) {
+        const ouIds = itemFilters[FILTER_ORG_UNIT].map(({ id, path }) =>
+            path ? path.split('/').slice(-1)[0] : id
+        )
+
+        iframeSrc += `&userOrgUnit=${ouIds.join(',')}`
+    }
+
+    return iframeSrc
+}

--- a/src/components/Item/AppItem/getIframeSrc.js
+++ b/src/components/Item/AppItem/getIframeSrc.js
@@ -3,8 +3,6 @@ import { FILTER_ORG_UNIT } from '../../../actions/itemFilters.js'
 export const getIframeSrc = (appDetails, item, itemFilters) => {
     let iframeSrc = `${appDetails.launchUrl}?dashboardItemId=${item.id}`
 
-    console.log('jj itemfilters', itemFilters)
-
     if (itemFilters[FILTER_ORG_UNIT] && itemFilters[FILTER_ORG_UNIT].length) {
         const ouIds = itemFilters[FILTER_ORG_UNIT].map(({ id, path }) =>
             path ? path.split('/').slice(-1)[0] : id


### PR DESCRIPTION
 backport of https://github.com/dhis2/dashboard-app/pull/2691

Fixes [DHIS2-14544](https://dhis2.atlassian.net/browse/DHIS2-14544)

If path exists, then parse it, otherwise use id (which will be the case for groups, levels and USER_ORGUNITS)

[DHIS2-14544]: https://dhis2.atlassian.net/browse/DHIS2-14544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ