### PR TITLE
chore: disable the e2e tests since v36 is no longer supported [v36]

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -101,7 +101,7 @@ jobs:
             - name: Test
               run: yarn test
 
-    # v36 is no longer supported, so do not run e2e tests
+    # v36 is no longer supported, so set the if condition to false to skip this job
     e2e:
         runs-on: ubuntu-latest
         needs: install

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -101,10 +101,11 @@ jobs:
             - name: Test
               run: yarn test
 
+    # v36 is no longer supported, so do not run e2e tests
     e2e:
         runs-on: ubuntu-latest
         needs: install
-        if: "!contains(github.event.head_commit.message, '[skip ci]')"
+        if: false
 
         strategy:
             matrix:
@@ -152,7 +153,7 @@ jobs:
 
     publish:
         runs-on: ubuntu-latest
-        needs: [build, lint, test, e2e]
+        needs: [build, lint, test]
         if: "!contains(github.event.head_commit.message, '[skip ci]')"
         steps:
             - uses: actions/checkout@v2


### PR DESCRIPTION
Do not run cypress tests on unsupported versions.