### PR TITLE
chore: disable the e2e tests since v37 is no longer supported [v37]

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -104,10 +104,11 @@ jobs:
             - name: Test
               run: yarn test
 
+    # v37 is no longer supported, so do not run e2e tests
     e2e:
         runs-on: ubuntu-latest
         needs: install
-        if: "!contains(github.event.head_commit.message, '[skip ci]')"
+        if: false
 
         strategy:
             matrix:
@@ -156,7 +157,7 @@ jobs:
 
     publish:
         runs-on: ubuntu-latest
-        needs: [build, lint, test, e2e]
+        needs: [build, lint, test]
         if: "!contains(github.event.head_commit.message, '[skip ci]')"
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -104,7 +104,7 @@ jobs:
             - name: Test
               run: yarn test
 
-    # v37 is no longer supported, so do not run e2e tests
+    # v37 is no longer supported, so set the if condition to false to skip this job
     e2e:
         runs-on: ubuntu-latest
         needs: install


### PR DESCRIPTION
Do not run cypress on unsupported versions