### PR TITLE
chore: allow for both 200 and 201 response from backend in cypress tests

### DIFF
--- a/cypress/integration/edit/edit_dashboard/show_description.js
+++ b/cypress/integration/edit/edit_dashboard/show_description.js
@@ -2,8 +2,8 @@ import { When, Then } from 'cypress-cucumber-preprocessor/steps'
 import { clickViewActionButton } from '../../../elements/viewDashboard.js'
 import { getApiBaseUrl } from '../../../support/utils.js'
 
-const RESP_CODE_201 = 201
 const RESP_CODE_200 = 200
+const RESP_CODE_201 = 201
 const SHOW_DESC_RESP_CODE_FAIL = 409
 
 before(() => {

--- a/cypress/integration/edit/edit_dashboard/show_description.js
+++ b/cypress/integration/edit/edit_dashboard/show_description.js
@@ -4,7 +4,7 @@ import { getApiBaseUrl } from '../../../support/utils.js'
 
 const RESP_CODE_200 = 200
 const RESP_CODE_201 = 201
-const SHOW_DESC_RESP_CODE_FAIL = 409
+const RESP_CODE_FAIL = 409
 
 before(() => {
     //ensure that the description is not currently shown
@@ -45,14 +45,14 @@ When('I click to hide the description', () => {
 // Error scenario
 When('clicking to show description fails', () => {
     cy.intercept('PUT', 'userDataStore/dashboard/showDescription', {
-        statusCode: SHOW_DESC_RESP_CODE_FAIL,
+        statusCode: RESP_CODE_FAIL,
     }).as('showDescriptionFails')
 
     clickViewActionButton('More')
     cy.contains('Show description').click()
     cy.wait('@showDescriptionFails')
         .its('response.statusCode')
-        .should('eq', SHOW_DESC_RESP_CODE_FAIL)
+        .should('eq', RESP_CODE_FAIL)
 })
 
 Then(

--- a/cypress/integration/edit/edit_dashboard/show_description.js
+++ b/cypress/integration/edit/edit_dashboard/show_description.js
@@ -2,7 +2,8 @@ import { When, Then } from 'cypress-cucumber-preprocessor/steps'
 import { clickViewActionButton } from '../../../elements/viewDashboard.js'
 import { getApiBaseUrl } from '../../../support/utils.js'
 
-const SHOW_DESC_RESP_CODE_SUCCESS = 201
+const RESP_CODE_201 = 201
+const RESP_CODE_200 = 200
 const SHOW_DESC_RESP_CODE_FAIL = 409
 
 before(() => {
@@ -15,7 +16,7 @@ before(() => {
         },
         body: 'false',
     }).then((response) =>
-        expect(response.status).to.equal(SHOW_DESC_RESP_CODE_SUCCESS)
+        expect(response.status).to.be.oneOf([RESP_CODE_201, RESP_CODE_200])
     )
 })
 
@@ -29,7 +30,7 @@ When('I click to show description', () => {
 
     cy.wait('@toggleDescription')
         .its('response.statusCode')
-        .should('eq', SHOW_DESC_RESP_CODE_SUCCESS)
+        .should('be.oneOf', [RESP_CODE_200, RESP_CODE_201])
 })
 
 When('I click to hide the description', () => {
@@ -38,7 +39,7 @@ When('I click to hide the description', () => {
 
     cy.wait('@toggleDescription')
         .its('response.statusCode')
-        .should('eq', SHOW_DESC_RESP_CODE_SUCCESS)
+        .should('be.oneOf', [RESP_CODE_200, RESP_CODE_201])
 })
 
 // Error scenario

--- a/cypress/integration/view/view_dashboard/resize_dashboards_bar.js
+++ b/cypress/integration/view/view_dashboard/resize_dashboards_bar.js
@@ -5,6 +5,9 @@ import {
 } from '../../../elements/viewDashboard.js'
 import { EXTENDED_TIMEOUT } from '../../../support/utils.js'
 
+const RESP_CODE_200 = 200
+const RESP_CODE_201 = 201
+
 // Scenario: I change the height of the control bar
 When('I drag to increase the height of the control bar', () => {
     cy.intercept('PUT', '/userDataStore/dashboard/controlBarRows').as('putRows')
@@ -14,7 +17,9 @@ When('I drag to increase the height of the control bar', () => {
         .trigger('mousemove', { clientY: 300 })
         .trigger('mouseup')
 
-    cy.wait('@putRows').its('response.statusCode').should('eq', 201)
+    cy.wait('@putRows')
+        .its('response.statusCode')
+        .should('be.oneOf', [RESP_CODE_200, RESP_CODE_201])
 })
 
 Then('the control bar height should be updated', () => {
@@ -29,7 +34,9 @@ Then('the control bar height should be updated', () => {
         .trigger('mousedown')
         .trigger('mousemove', { clientY: 71 })
         .trigger('mouseup')
-    cy.wait('@putRows').its('response.statusCode').should('eq', 201)
+    cy.wait('@putRows')
+        .its('response.statusCode')
+        .should('be.oneOf', [RESP_CODE_200, RESP_CODE_201])
 })
 
 When('I drag to decrease the height of the control bar', () => {
@@ -40,5 +47,7 @@ When('I drag to decrease the height of the control bar', () => {
         .trigger('mousemove', { clientY: 300 })
         .trigger('mouseup')
 
-    cy.wait('@putRows').its('response.statusCode').should('eq', 201)
+    cy.wait('@putRows')
+        .its('response.statusCode')
+        .should('be.oneOf', [RESP_CODE_200, RESP_CODE_201])
 })

--- a/cypress/integration/view/view_dashboard/toggle_show_more_dashboards.js
+++ b/cypress/integration/view/view_dashboard/toggle_show_more_dashboards.js
@@ -9,6 +9,10 @@ import { getApiBaseUrl, EXTENDED_TIMEOUT } from '../../../support/utils.js'
 const MIN_DASHBOARDS_BAR_HEIGHT = 71
 const MAX_DASHBOARDS_BAR_HEIGHT = 431
 
+const RESP_CODE_200 = 200
+const RESP_CODE_201 = 201
+
+
 beforeEach(() => {
     cy.request({
         method: 'PUT',
@@ -17,7 +21,7 @@ beforeEach(() => {
             'content-type': 'application/json',
         },
         body: '1',
-    }).then((response) => expect(response.status).to.equal(201))
+    }).then((response) => expect(response.status).to.be.oneOf([RESP_CODE_201, RESP_CODE_200])
 })
 
 When('I toggle show more dashboards', () => {

--- a/cypress/integration/view/view_dashboard/toggle_show_more_dashboards.js
+++ b/cypress/integration/view/view_dashboard/toggle_show_more_dashboards.js
@@ -12,7 +12,6 @@ const MAX_DASHBOARDS_BAR_HEIGHT = 431
 const RESP_CODE_200 = 200
 const RESP_CODE_201 = 201
 
-
 beforeEach(() => {
     cy.request({
         method: 'PUT',
@@ -21,7 +20,9 @@ beforeEach(() => {
             'content-type': 'application/json',
         },
         body: '1',
-    }).then((response) => expect(response.status).to.be.oneOf([RESP_CODE_201, RESP_CODE_200])
+    }).then((response) =>
+        expect(response.status).to.be.oneOf([RESP_CODE_201, RESP_CODE_200])
+    )
 })
 
 When('I toggle show more dashboards', () => {

--- a/cypress/integration/view/view_errors/error_while_show_description.js
+++ b/cypress/integration/view/view_errors/error_while_show_description.js
@@ -16,7 +16,9 @@ before(() => {
             'content-type': 'application/json',
         },
         body: 'false',
-    }).then((response) => expect(response.status).to.be.oneOf([RESP_CODE_201, RESP_CODE_200])
+    }).then((response) =>
+        expect(response.status).to.be.oneOf([RESP_CODE_201, RESP_CODE_200])
+    )
 })
 
 When('clicking to show description fails', () => {

--- a/cypress/integration/view/view_errors/error_while_show_description.js
+++ b/cypress/integration/view/view_errors/error_while_show_description.js
@@ -1,6 +1,10 @@
 import { When, Then } from 'cypress-cucumber-preprocessor/steps'
 import { getApiBaseUrl } from '../../../support/utils.js'
 
+const RESP_CODE_200 = 200
+const RESP_CODE_201 = 201
+const RESP_CODE_FAIL = 409
+
 // Error scenario
 
 before(() => {
@@ -12,12 +16,12 @@ before(() => {
             'content-type': 'application/json',
         },
         body: 'false',
-    }).then((response) => expect(response.status).to.equal(201))
+    }).then((response) => expect(response.status).to.be.oneOf([RESP_CODE_201, RESP_CODE_200])
 })
 
 When('clicking to show description fails', () => {
     cy.intercept('PUT', 'userDataStore/dashboard/showDescription', {
-        statusCode: 409,
+        statusCode: RESP_CODE_FAIL,
     }).as('showDescriptionFails')
 
     cy.get('button').contains('More').click()
@@ -25,7 +29,7 @@ When('clicking to show description fails', () => {
 
     cy.wait('@showDescriptionFails')
         .its('response.statusCode')
-        .should('eq', 409)
+        .should('eq', RESP_CODE_FAIL)
 })
 
 Then(


### PR DESCRIPTION
Needed to keep the cypress tests passing.

There is a recurring issue from the backend: Sometimes a create request returns 200, other times 201. To avoid having to update these tests continually, accept both values as valid since it doesn't have any impact on the app