### PR TITLE
chore: include patch packages in cache-key

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -94,7 +94,7 @@ jobs:
               id: yarn-cache
               with:
                   path: '**/node_modules'
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('patches/*.patch') }}
 
             - name: End-to-End tests
               uses: cypress-io/github-action@v2
@@ -104,7 +104,7 @@ jobs:
                   start: ${{ env.SERVER_START_CMD }}
                   wait-on: ${{ env.SERVER_URL }}
                   wait-on-timeout: 300
-                  cache-key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  cache-key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('patches/*.patch') }}
                   group: 'e2e'
                   tag: ${{ github.event_name }}
               env:


### PR DESCRIPTION
Related to https://dhis2.atlassian.net/browse/LIBS-383

Add package patches to the yarn cache key.

If a new patch is added, then this ensures that that the yarn cache gets invalidated and forces yarn install, which will then do the postinstall step that applies the patches.

From user perspective, the e2e-prod tests might fail if it is depending on a patch that didn't get installed.