### PR TITLE
feat: support outlier table plugin (DHIS2-16751)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2023-06-22T08:57:46.931Z\n"
-"PO-Revision-Date: 2023-06-22T08:57:46.931Z\n"
+"POT-Creation-Date: 2024-02-26T14:42:02.563Z\n"
+"PO-Revision-Date: 2024-02-26T14:42:02.563Z\n"
 
 msgid "Untitled dashboard"
 msgstr "Untitled dashboard"
@@ -89,14 +89,20 @@ msgstr "View fullscreen"
 msgid "This map can't be displayed as a chart"
 msgstr "This map can't be displayed as a chart"
 
+msgid "This map can't be displayed as a pivot table"
+msgstr "This map can't be displayed as a pivot table"
+
+msgid "This visualization can't be displayed as a pivot table"
+msgstr "This visualization can't be displayed as a pivot table"
+
+msgid "This visualization can't be displayed as a map"
+msgstr "This visualization can't be displayed as a map"
+
 msgid "View as Chart"
 msgstr "View as Chart"
 
-msgid "This map can't be displayed as a table"
-msgstr "This map can't be displayed as a table"
-
-msgid "View as Table"
-msgstr "View as Table"
+msgid "View as Pivot table"
+msgstr "View as Pivot table"
 
 msgid "View as Map"
 msgstr "View as Map"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "license": "BSD-3-Clause",
     "dependencies": {
-        "@dhis2/analytics": "999.9.9-outlier-table.alpha.3",
+        "@dhis2/analytics": "999.9.9-outlier-table.alpha.4",
         "@dhis2/app-runtime": "^3.10.2",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/d2-i18n": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/d2-i18n": "^1.1.3",
         "@dhis2/d2-ui-rich-text": "^7.4.3",
-        "@dhis2/ui": "^8.14.0",
+        "@dhis2/ui": "^9.2.0",
         "@krakenjs/post-robot": "^11.0.0",
         "classnames": "^2.3.2",
         "d2": "^31.10.0",
@@ -61,5 +61,8 @@
         "moduleNameMapper": {
             "^.+\\.(css|sass|scss)$": "identity-obj-proxy"
         }
+    },
+    "resolutions": {
+        "@dhis2/ui": "^9.2.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "license": "BSD-3-Clause",
     "dependencies": {
-        "@dhis2/analytics": "^26.4.0",
+        "@dhis2/analytics": "999.9.9-outlier-table.alpha.3",
         "@dhis2/app-runtime": "^3.10.2",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/d2-i18n": "^1.1.3",

--- a/src/components/Item/VisualizationItem/ItemContextMenu/ViewAsMenuItems.js
+++ b/src/components/Item/VisualizationItem/ItemContextMenu/ViewAsMenuItems.js
@@ -1,3 +1,4 @@
+import { VIS_TYPE_OUTLIER_TABLE } from '@dhis2/analytics'
 import i18n from '@dhis2/d2-i18n'
 import { IconVisualizationColumn16, IconTable16, IconWorld16 } from '@dhis2/ui'
 import PropTypes from 'prop-types'
@@ -31,17 +32,33 @@ const ViewAsMenuItems = ({
 
     const onViewMap = () => onActiveTypeChanged(MAP)
 
-    const notSupported = type === MAP && !getThematicMapViews(visualization)
+    const notSupported =
+        (type === MAP && !getThematicMapViews(visualization)) ||
+        (type === CHART && visualization.type === VIS_TYPE_OUTLIER_TABLE)
+
+    const getNotSupportedMessage = (viewAs) => {
+        if (type === MAP && !getThematicMapViews(visualization)) {
+            return viewAs === 'chart'
+                ? i18n.t("This map can't be displayed as a chart")
+                : i18n.t("This map can't be displayed as a pivot table")
+        }
+
+        if (type === CHART && visualization.type === VIS_TYPE_OUTLIER_TABLE) {
+            return viewAs === 'table'
+                ? i18n.t(
+                      "This visualization can't be displayed as a pivot table"
+                  )
+                : i18n.t("This visualization can't be displayed as a map")
+        }
+
+        return null
+    }
 
     return (
         <>
             {![CHART, EVENT_CHART].includes(activeType) && (
                 <MenuItem
-                    tooltip={
-                        notSupported
-                            ? i18n.t("This map can't be displayed as a chart")
-                            : null
-                    }
+                    tooltip={getNotSupportedMessage('chart')}
                     label={i18n.t('View as Chart')}
                     onClick={onViewChart}
                     disabled={notSupported}
@@ -52,12 +69,8 @@ const ViewAsMenuItems = ({
                 activeType
             ) && (
                 <MenuItem
-                    tooltip={
-                        notSupported
-                            ? i18n.t("This map can't be displayed as a table")
-                            : null
-                    }
-                    label={i18n.t('View as Table')}
+                    tooltip={getNotSupportedMessage('table')}
+                    label={i18n.t('View as Pivot table')}
                     onClick={onViewTable}
                     disabled={notSupported}
                     icon={<IconTable16 />}
@@ -65,8 +78,10 @@ const ViewAsMenuItems = ({
             )}
             {hasMapView(type) && activeType !== MAP && (
                 <MenuItem
+                    tooltip={getNotSupportedMessage('map')}
                     label={i18n.t('View as Map')}
                     onClick={onViewMap}
+                    disabled={notSupported}
                     icon={<IconWorld16 />}
                 />
             )}

--- a/src/components/Item/VisualizationItem/ItemContextMenu/__tests__/ItemContextMenu.offline.spec.js
+++ b/src/components/Item/VisualizationItem/ItemContextMenu/__tests__/ItemContextMenu.offline.spec.js
@@ -59,7 +59,7 @@ test('renders just the button when menu closed', () => {
     expect(getByRole('button')).toBeTruthy()
     expect(queryByText('View as Map')).toBeNull()
     expect(queryByText('View as Chart')).toBeNull()
-    expect(queryByText('View as Table')).toBeNull()
+    expect(queryByText('View as Pivot table')).toBeNull()
     expect(queryByTestId('divider')).toBeNull()
     expect(queryByText('Open in Data Visualizer app')).toBeNull()
     expect(queryByText('Show details and interpretations')).toBeNull()
@@ -113,7 +113,7 @@ test('renders popover menu for BAR chart', async () => {
     await waitFor(() => {
         expect(queryByText('View as Map')).toBeTruthy()
         expect(queryByText('View as Chart')).toBeNull()
-        expect(queryByText('View as Table')).toBeTruthy()
+        expect(queryByText('View as Pivot table')).toBeTruthy()
         expect(queryByTestId('divider')).toBeTruthy()
         expect(queryByText('Open in Data Visualizer app')).toBeTruthy()
         expect(queryByText('Show details and interpretations')).toBeTruthy()
@@ -140,7 +140,7 @@ test('renders popover menu for SINGLE_VALUE chart', async () => {
     await waitFor(() => {
         expect(queryByText('View as Map')).toBeNull()
         expect(queryByText('View as Chart')).toBeNull()
-        expect(queryByText('View as Table')).toBeNull()
+        expect(queryByText('View as Pivot table')).toBeNull()
         expect(queryByTestId('divider')).toBeNull()
         expect(queryByText('Open in Data Visualizer app')).toBeTruthy()
         expect(queryByText('Show details and interpretations')).toBeTruthy()
@@ -167,7 +167,7 @@ test('renders popover menu for YEAR_OVER_YEAR_LINE chart', async () => {
     await waitFor(() => {
         expect(queryByText('View as Map')).toBeNull()
         expect(queryByText('View as Chart')).toBeNull()
-        expect(queryByText('View as Table')).toBeNull()
+        expect(queryByText('View as Pivot table')).toBeNull()
         expect(queryByTestId('divider')).toBeNull()
         expect(queryByText('Open in Data Visualizer app')).toBeTruthy()
         expect(queryByText('Show details and interpretations')).toBeTruthy()
@@ -194,7 +194,7 @@ test('renders popover menu for GAUGE chart', async () => {
     await waitFor(() => {
         expect(queryByText('View as Map')).toBeNull()
         expect(queryByText('View as Chart')).toBeNull()
-        expect(queryByText('View as Table')).toBeNull()
+        expect(queryByText('View as Pivot table')).toBeNull()
         expect(queryByTestId('divider')).toBeNull()
         expect(queryByText('Open in Data Visualizer app')).toBeTruthy()
         expect(queryByText('Show details and interpretations')).toBeTruthy()
@@ -221,7 +221,7 @@ test('renders popover menu for PIE chart', async () => {
     await waitFor(() => {
         expect(queryByText('View as Map')).toBeNull()
         expect(queryByText('View as Chart')).toBeNull()
-        expect(queryByText('View as Table')).toBeNull()
+        expect(queryByText('View as Pivot table')).toBeNull()
         expect(queryByTestId('divider')).toBeNull()
         expect(queryByText('Open in Data Visualizer app')).toBeTruthy()
         expect(queryByText('Show details and interpretations')).toBeTruthy()
@@ -252,7 +252,7 @@ test('renders popover menu for PIVOT_TABLE', async () => {
     await waitFor(() => {
         expect(queryByText('View as Map')).toBeTruthy()
         expect(queryByText('View as Chart')).toBeTruthy()
-        expect(queryByText('View as Table')).toBeNull()
+        expect(queryByText('View as Pivot table')).toBeNull()
         expect(queryByTestId('divider')).toBeTruthy()
         expect(queryByText('Open in Data Visualizer app')).toBeTruthy()
         expect(queryByText('Show details and interpretations')).toBeTruthy()
@@ -281,7 +281,7 @@ test('renders popover menu for MAP', async () => {
     await waitFor(() => {
         expect(queryByText('View as Map')).toBeNull()
         expect(queryByText('View as Chart')).toBeTruthy()
-        expect(queryByText('View as Table')).toBeTruthy()
+        expect(queryByText('View as Pivot table')).toBeTruthy()
         expect(queryByTestId('divider')).toBeTruthy()
         expect(queryByText('Open in Maps app')).toBeTruthy()
         expect(queryByText('Show details and interpretations')).toBeTruthy()
@@ -379,7 +379,7 @@ test('renders only View in App when item load failed', async () => {
     await waitFor(() => {
         expect(queryByText('View as Map')).toBeNull()
         expect(queryByText('View as Chart')).toBeNull()
-        expect(queryByText('View as Table')).toBeNull()
+        expect(queryByText('View as Pivot table')).toBeNull()
         expect(queryByTestId('divider')).toBeNull()
         expect(queryByText('Open in Maps app')).toBeTruthy()
         expect(queryByText('Show details and interpretations')).toBeNull()
@@ -467,7 +467,7 @@ test('renders correct options for BAR in small screen', async () => {
     await waitFor(() => {
         expect(queryByText('View as Map')).toBeTruthy()
         expect(queryByText('View as Chart')).toBeNull()
-        expect(queryByText('View as Table')).toBeTruthy()
+        expect(queryByText('View as Pivot table')).toBeTruthy()
         expect(queryByTestId('divider')).toBeTruthy()
         expect(queryByText('Open in Data Visualizer app')).toBeNull()
         expect(queryByText('Show details and interpretations')).toBeTruthy()
@@ -498,7 +498,7 @@ test('renders correct options for PIE in small screen', async () => {
     await waitFor(() => {
         expect(queryByText('View as Map')).toBeNull()
         expect(queryByText('View as Chart')).toBeNull()
-        expect(queryByText('View as Table')).toBeNull()
+        expect(queryByText('View as Pivot table')).toBeNull()
         expect(queryByTestId('divider')).toBeNull()
         expect(queryByText('Open in Data Visualizer app')).toBeNull()
         expect(queryByText('Show details and interpretations')).toBeTruthy()

--- a/src/components/Item/VisualizationItem/ItemContextMenu/__tests__/ItemContextMenu.spec.js
+++ b/src/components/Item/VisualizationItem/ItemContextMenu/__tests__/ItemContextMenu.spec.js
@@ -59,7 +59,7 @@ test('renders just the button when menu closed', () => {
     expect(getByRole('button')).toBeTruthy()
     expect(queryByText('View as Map')).toBeNull()
     expect(queryByText('View as Chart')).toBeNull()
-    expect(queryByText('View as Table')).toBeNull()
+    expect(queryByText('View as Pivot table')).toBeNull()
     expect(queryByTestId('divider')).toBeNull()
     expect(queryByText('Open in Data Visualizer app')).toBeNull()
     expect(queryByText('Show details and interpretations')).toBeNull()
@@ -113,7 +113,7 @@ test('renders popover menu for BAR chart', async () => {
     await waitFor(() => {
         expect(queryByText('View as Map')).toBeTruthy()
         expect(queryByText('View as Chart')).toBeNull()
-        expect(queryByText('View as Table')).toBeTruthy()
+        expect(queryByText('View as Pivot table')).toBeTruthy()
         expect(queryByTestId('divider')).toBeTruthy()
         expect(queryByText('Open in Data Visualizer app')).toBeTruthy()
         expect(queryByText('Show details and interpretations')).toBeTruthy()
@@ -140,7 +140,7 @@ test('renders popover menu for SINGLE_VALUE chart', async () => {
     await waitFor(() => {
         expect(queryByText('View as Map')).toBeNull()
         expect(queryByText('View as Chart')).toBeNull()
-        expect(queryByText('View as Table')).toBeNull()
+        expect(queryByText('View as Pivot table')).toBeNull()
         expect(queryByTestId('divider')).toBeNull()
         expect(queryByText('Open in Data Visualizer app')).toBeTruthy()
         expect(queryByText('Show details and interpretations')).toBeTruthy()
@@ -167,7 +167,7 @@ test('renders popover menu for YEAR_OVER_YEAR_LINE chart', async () => {
     await waitFor(() => {
         expect(queryByText('View as Map')).toBeNull()
         expect(queryByText('View as Chart')).toBeNull()
-        expect(queryByText('View as Table')).toBeNull()
+        expect(queryByText('View as Pivot table')).toBeNull()
         expect(queryByTestId('divider')).toBeNull()
         expect(queryByText('Open in Data Visualizer app')).toBeTruthy()
         expect(queryByText('Show details and interpretations')).toBeTruthy()
@@ -194,7 +194,7 @@ test('renders popover menu for GAUGE chart', async () => {
     await waitFor(() => {
         expect(queryByText('View as Map')).toBeNull()
         expect(queryByText('View as Chart')).toBeNull()
-        expect(queryByText('View as Table')).toBeNull()
+        expect(queryByText('View as Pivot table')).toBeNull()
         expect(queryByTestId('divider')).toBeNull()
         expect(queryByText('Open in Data Visualizer app')).toBeTruthy()
         expect(queryByText('Show details and interpretations')).toBeTruthy()
@@ -221,7 +221,7 @@ test('renders popover menu for PIE chart', async () => {
     await waitFor(() => {
         expect(queryByText('View as Map')).toBeNull()
         expect(queryByText('View as Chart')).toBeNull()
-        expect(queryByText('View as Table')).toBeNull()
+        expect(queryByText('View as Pivot table')).toBeNull()
         expect(queryByTestId('divider')).toBeNull()
         expect(queryByText('Open in Data Visualizer app')).toBeTruthy()
         expect(queryByText('Show details and interpretations')).toBeTruthy()
@@ -252,7 +252,7 @@ test('renders popover menu for PIVOT_TABLE', async () => {
     await waitFor(() => {
         expect(queryByText('View as Map')).toBeTruthy()
         expect(queryByText('View as Chart')).toBeTruthy()
-        expect(queryByText('View as Table')).toBeNull()
+        expect(queryByText('View as Pivot table')).toBeNull()
         expect(queryByTestId('divider')).toBeTruthy()
         expect(queryByText('Open in Data Visualizer app')).toBeTruthy()
         expect(queryByText('Show details and interpretations')).toBeTruthy()
@@ -281,7 +281,7 @@ test('renders popover menu for MAP', async () => {
     await waitFor(() => {
         expect(queryByText('View as Map')).toBeNull()
         expect(queryByText('View as Chart')).toBeTruthy()
-        expect(queryByText('View as Table')).toBeTruthy()
+        expect(queryByText('View as Pivot table')).toBeTruthy()
         expect(queryByTestId('divider')).toBeTruthy()
         expect(queryByText('Open in Maps app')).toBeTruthy()
         expect(queryByText('Show details and interpretations')).toBeTruthy()
@@ -379,7 +379,7 @@ test('renders only View in App when item load failed', async () => {
     await waitFor(() => {
         expect(queryByText('View as Map')).toBeNull()
         expect(queryByText('View as Chart')).toBeNull()
-        expect(queryByText('View as Table')).toBeNull()
+        expect(queryByText('View as Pivot table')).toBeNull()
         expect(queryByTestId('divider')).toBeNull()
         expect(queryByText('Open in Maps app')).toBeTruthy()
         expect(queryByText('Show details and interpretations')).toBeNull()
@@ -467,7 +467,7 @@ test('renders correct options for BAR in small screen', async () => {
     await waitFor(() => {
         expect(queryByText('View as Map')).toBeTruthy()
         expect(queryByText('View as Chart')).toBeNull()
-        expect(queryByText('View as Table')).toBeTruthy()
+        expect(queryByText('View as Pivot table')).toBeTruthy()
         expect(queryByTestId('divider')).toBeTruthy()
         expect(queryByText('Open in Data Visualizer app')).toBeNull()
         expect(queryByText('Show details and interpretations')).toBeTruthy()
@@ -498,7 +498,7 @@ test('renders correct options for PIE in small screen', async () => {
     await waitFor(() => {
         expect(queryByText('View as Map')).toBeNull()
         expect(queryByText('View as Chart')).toBeNull()
-        expect(queryByText('View as Table')).toBeNull()
+        expect(queryByText('View as Pivot table')).toBeNull()
         expect(queryByTestId('divider')).toBeNull()
         expect(queryByText('Open in Data Visualizer app')).toBeNull()
         expect(queryByText('Show details and interpretations')).toBeTruthy()

--- a/src/components/Item/VisualizationItem/ItemContextMenu/__tests__/ViewAsMenuItems.spec.js
+++ b/src/components/Item/VisualizationItem/ItemContextMenu/__tests__/ViewAsMenuItems.spec.js
@@ -36,6 +36,9 @@ test('renders menu for active type MAP and type CHART', async () => {
     const props = Object.assign({}, defaultProps, {
         type: CHART,
         activeType: MAP,
+        visualization: {
+            type: 'COLUMN',
+        },
     })
 
     const { container } = render(<ViewAsMenuItems {...props} />)
@@ -49,6 +52,9 @@ test('renders disabled menu items when offline', () => {
     const props = Object.assign({}, defaultProps, {
         type: CHART,
         activeType: MAP,
+        visualization: {
+            type: 'COLUMN',
+        },
     })
 
     const { container } = render(<ViewAsMenuItems {...props} />)
@@ -105,7 +111,7 @@ test('renders menu for active type REPORT_TABLE and type CHART', async () => {
     const props = Object.assign({}, defaultProps, {
         type: CHART,
         activeType: REPORT_TABLE,
-        visualization: {},
+        visualization: { type: 'COLUMN' },
     })
 
     const { container } = render(<ViewAsMenuItems {...props} />)
@@ -118,7 +124,7 @@ test('renders menu for active type CHART and type REPORT_TABLE', async () => {
     const props = Object.assign({}, defaultProps, {
         type: REPORT_TABLE,
         activeType: CHART,
-        visualization: {},
+        visualization: { type: 'PIVOT_TABLE' },
     })
 
     const { container } = render(<ViewAsMenuItems {...props} />)

--- a/src/components/Item/VisualizationItem/ItemContextMenu/__tests__/__snapshots__/ViewAsMenuItems.spec.js.snap
+++ b/src/components/Item/VisualizationItem/ItemContextMenu/__tests__/__snapshots__/ViewAsMenuItems.spec.js.snap
@@ -3,14 +3,14 @@
 exports[`renders disabled menu items when offline 1`] = `
 <div>
   <li
-    class="jsx-2002348738 disabled dense"
+    class="jsx-1930534478 disabled dense"
     data-test="dhis2-uicore-menuitem"
   >
     <a
-      class="jsx-2002348738"
+      class="jsx-1930534478"
     >
       <span
-        class="jsx-2002348738 icon"
+        class="jsx-1930534478 icon"
       >
         <svg
           height="16"
@@ -32,7 +32,7 @@ exports[`renders disabled menu items when offline 1`] = `
         </svg>
       </span>
       <span
-        class="jsx-2002348738 label"
+        class="jsx-1930534478 label"
       >
         <span
           class="jsx-3661110597 tooltip notAllowed"
@@ -43,14 +43,14 @@ exports[`renders disabled menu items when offline 1`] = `
     </a>
   </li>
   <li
-    class="jsx-2002348738 disabled dense"
+    class="jsx-1930534478 disabled dense"
     data-test="dhis2-uicore-menuitem"
   >
     <a
-      class="jsx-2002348738"
+      class="jsx-1930534478"
     >
       <span
-        class="jsx-2002348738 icon"
+        class="jsx-1930534478 icon"
       >
         <svg
           height="16"
@@ -65,12 +65,12 @@ exports[`renders disabled menu items when offline 1`] = `
         </svg>
       </span>
       <span
-        class="jsx-2002348738 label"
+        class="jsx-1930534478 label"
       >
         <span
           class="jsx-3661110597 tooltip notAllowed"
         >
-          View as Table
+          View as Pivot table
         </span>
       </span>
     </a>
@@ -81,14 +81,14 @@ exports[`renders disabled menu items when offline 1`] = `
 exports[`renders menu for active type CHART and type MAP 1`] = `
 <div>
   <li
-    class="jsx-2002348738 dense"
+    class="jsx-1930534478 dense"
     data-test="dhis2-uicore-menuitem"
   >
     <a
-      class="jsx-2002348738"
+      class="jsx-1930534478"
     >
       <span
-        class="jsx-2002348738 icon"
+        class="jsx-1930534478 icon"
       >
         <svg
           height="16"
@@ -103,25 +103,25 @@ exports[`renders menu for active type CHART and type MAP 1`] = `
         </svg>
       </span>
       <span
-        class="jsx-2002348738 label"
+        class="jsx-1930534478 label"
       >
         <span
           class="jsx-3661110597 tooltip"
         >
-          View as Table
+          View as Pivot table
         </span>
       </span>
     </a>
   </li>
   <li
-    class="jsx-2002348738 dense"
+    class="jsx-1930534478 dense"
     data-test="dhis2-uicore-menuitem"
   >
     <a
-      class="jsx-2002348738"
+      class="jsx-1930534478"
     >
       <span
-        class="jsx-2002348738 icon"
+        class="jsx-1930534478 icon"
       >
         <svg
           height="16"
@@ -136,7 +136,7 @@ exports[`renders menu for active type CHART and type MAP 1`] = `
         </svg>
       </span>
       <span
-        class="jsx-2002348738 label"
+        class="jsx-1930534478 label"
       >
         <span
           class="jsx-3661110597 tooltip"
@@ -152,14 +152,14 @@ exports[`renders menu for active type CHART and type MAP 1`] = `
 exports[`renders menu for active type CHART and type REPORT_TABLE 1`] = `
 <div>
   <li
-    class="jsx-2002348738 dense"
+    class="jsx-1930534478 dense"
     data-test="dhis2-uicore-menuitem"
   >
     <a
-      class="jsx-2002348738"
+      class="jsx-1930534478"
     >
       <span
-        class="jsx-2002348738 icon"
+        class="jsx-1930534478 icon"
       >
         <svg
           height="16"
@@ -174,25 +174,25 @@ exports[`renders menu for active type CHART and type REPORT_TABLE 1`] = `
         </svg>
       </span>
       <span
-        class="jsx-2002348738 label"
+        class="jsx-1930534478 label"
       >
         <span
           class="jsx-3661110597 tooltip"
         >
-          View as Table
+          View as Pivot table
         </span>
       </span>
     </a>
   </li>
   <li
-    class="jsx-2002348738 dense"
+    class="jsx-1930534478 dense"
     data-test="dhis2-uicore-menuitem"
   >
     <a
-      class="jsx-2002348738"
+      class="jsx-1930534478"
     >
       <span
-        class="jsx-2002348738 icon"
+        class="jsx-1930534478 icon"
       >
         <svg
           height="16"
@@ -207,7 +207,7 @@ exports[`renders menu for active type CHART and type REPORT_TABLE 1`] = `
         </svg>
       </span>
       <span
-        class="jsx-2002348738 label"
+        class="jsx-1930534478 label"
       >
         <span
           class="jsx-3661110597 tooltip"
@@ -223,14 +223,14 @@ exports[`renders menu for active type CHART and type REPORT_TABLE 1`] = `
 exports[`renders menu for active type EVENT_CHART and type EVENT_REPORT 1`] = `
 <div>
   <li
-    class="jsx-2002348738 dense"
+    class="jsx-1930534478 dense"
     data-test="dhis2-uicore-menuitem"
   >
     <a
-      class="jsx-2002348738"
+      class="jsx-1930534478"
     >
       <span
-        class="jsx-2002348738 icon"
+        class="jsx-1930534478 icon"
       >
         <svg
           height="16"
@@ -245,12 +245,12 @@ exports[`renders menu for active type EVENT_CHART and type EVENT_REPORT 1`] = `
         </svg>
       </span>
       <span
-        class="jsx-2002348738 label"
+        class="jsx-1930534478 label"
       >
         <span
           class="jsx-3661110597 tooltip"
         >
-          View as Table
+          View as Pivot table
         </span>
       </span>
     </a>
@@ -261,14 +261,14 @@ exports[`renders menu for active type EVENT_CHART and type EVENT_REPORT 1`] = `
 exports[`renders menu for active type EVENT_REPORT and type EVENT_CHART 1`] = `
 <div>
   <li
-    class="jsx-2002348738 dense"
+    class="jsx-1930534478 dense"
     data-test="dhis2-uicore-menuitem"
   >
     <a
-      class="jsx-2002348738"
+      class="jsx-1930534478"
     >
       <span
-        class="jsx-2002348738 icon"
+        class="jsx-1930534478 icon"
       >
         <svg
           height="16"
@@ -290,7 +290,7 @@ exports[`renders menu for active type EVENT_REPORT and type EVENT_CHART 1`] = `
         </svg>
       </span>
       <span
-        class="jsx-2002348738 label"
+        class="jsx-1930534478 label"
       >
         <span
           class="jsx-3661110597 tooltip"
@@ -306,14 +306,14 @@ exports[`renders menu for active type EVENT_REPORT and type EVENT_CHART 1`] = `
 exports[`renders menu for active type MAP and type CHART 1`] = `
 <div>
   <li
-    class="jsx-2002348738 dense"
+    class="jsx-1930534478 dense"
     data-test="dhis2-uicore-menuitem"
   >
     <a
-      class="jsx-2002348738"
+      class="jsx-1930534478"
     >
       <span
-        class="jsx-2002348738 icon"
+        class="jsx-1930534478 icon"
       >
         <svg
           height="16"
@@ -335,7 +335,7 @@ exports[`renders menu for active type MAP and type CHART 1`] = `
         </svg>
       </span>
       <span
-        class="jsx-2002348738 label"
+        class="jsx-1930534478 label"
       >
         <span
           class="jsx-3661110597 tooltip"
@@ -346,14 +346,14 @@ exports[`renders menu for active type MAP and type CHART 1`] = `
     </a>
   </li>
   <li
-    class="jsx-2002348738 dense"
+    class="jsx-1930534478 dense"
     data-test="dhis2-uicore-menuitem"
   >
     <a
-      class="jsx-2002348738"
+      class="jsx-1930534478"
     >
       <span
-        class="jsx-2002348738 icon"
+        class="jsx-1930534478 icon"
       >
         <svg
           height="16"
@@ -368,12 +368,12 @@ exports[`renders menu for active type MAP and type CHART 1`] = `
         </svg>
       </span>
       <span
-        class="jsx-2002348738 label"
+        class="jsx-1930534478 label"
       >
         <span
           class="jsx-3661110597 tooltip"
         >
-          View as Table
+          View as Pivot table
         </span>
       </span>
     </a>
@@ -384,14 +384,14 @@ exports[`renders menu for active type MAP and type CHART 1`] = `
 exports[`renders menu for active type MAP and type MAP without Thematic layer 1`] = `
 <div>
   <li
-    class="jsx-2002348738 disabled dense"
+    class="jsx-1930534478 disabled dense"
     data-test="dhis2-uicore-menuitem"
   >
     <a
-      class="jsx-2002348738"
+      class="jsx-1930534478"
     >
       <span
-        class="jsx-2002348738 icon"
+        class="jsx-1930534478 icon"
       >
         <svg
           height="16"
@@ -413,7 +413,7 @@ exports[`renders menu for active type MAP and type MAP without Thematic layer 1`
         </svg>
       </span>
       <span
-        class="jsx-2002348738 label"
+        class="jsx-1930534478 label"
       >
         <span
           class="jsx-3661110597 tooltip notAllowed"
@@ -424,14 +424,14 @@ exports[`renders menu for active type MAP and type MAP without Thematic layer 1`
     </a>
   </li>
   <li
-    class="jsx-2002348738 disabled dense"
+    class="jsx-1930534478 disabled dense"
     data-test="dhis2-uicore-menuitem"
   >
     <a
-      class="jsx-2002348738"
+      class="jsx-1930534478"
     >
       <span
-        class="jsx-2002348738 icon"
+        class="jsx-1930534478 icon"
       >
         <svg
           height="16"
@@ -446,12 +446,12 @@ exports[`renders menu for active type MAP and type MAP without Thematic layer 1`
         </svg>
       </span>
       <span
-        class="jsx-2002348738 label"
+        class="jsx-1930534478 label"
       >
         <span
           class="jsx-3661110597 tooltip notAllowed"
         >
-          View as Table
+          View as Pivot table
         </span>
       </span>
     </a>
@@ -462,14 +462,14 @@ exports[`renders menu for active type MAP and type MAP without Thematic layer 1`
 exports[`renders menu for active type MAP and type MAP without Thematic layer when offline 1`] = `
 <div>
   <li
-    class="jsx-2002348738 disabled dense"
+    class="jsx-1930534478 disabled dense"
     data-test="dhis2-uicore-menuitem"
   >
     <a
-      class="jsx-2002348738"
+      class="jsx-1930534478"
     >
       <span
-        class="jsx-2002348738 icon"
+        class="jsx-1930534478 icon"
       >
         <svg
           height="16"
@@ -491,7 +491,7 @@ exports[`renders menu for active type MAP and type MAP without Thematic layer wh
         </svg>
       </span>
       <span
-        class="jsx-2002348738 label"
+        class="jsx-1930534478 label"
       >
         <span
           class="jsx-3661110597 tooltip notAllowed"
@@ -502,14 +502,14 @@ exports[`renders menu for active type MAP and type MAP without Thematic layer wh
     </a>
   </li>
   <li
-    class="jsx-2002348738 disabled dense"
+    class="jsx-1930534478 disabled dense"
     data-test="dhis2-uicore-menuitem"
   >
     <a
-      class="jsx-2002348738"
+      class="jsx-1930534478"
     >
       <span
-        class="jsx-2002348738 icon"
+        class="jsx-1930534478 icon"
       >
         <svg
           height="16"
@@ -524,12 +524,12 @@ exports[`renders menu for active type MAP and type MAP without Thematic layer wh
         </svg>
       </span>
       <span
-        class="jsx-2002348738 label"
+        class="jsx-1930534478 label"
       >
         <span
           class="jsx-3661110597 tooltip notAllowed"
         >
-          View as Table
+          View as Pivot table
         </span>
       </span>
     </a>
@@ -540,14 +540,14 @@ exports[`renders menu for active type MAP and type MAP without Thematic layer wh
 exports[`renders menu for active type REPORT_TABLE and type CHART 1`] = `
 <div>
   <li
-    class="jsx-2002348738 dense"
+    class="jsx-1930534478 dense"
     data-test="dhis2-uicore-menuitem"
   >
     <a
-      class="jsx-2002348738"
+      class="jsx-1930534478"
     >
       <span
-        class="jsx-2002348738 icon"
+        class="jsx-1930534478 icon"
       >
         <svg
           height="16"
@@ -569,7 +569,7 @@ exports[`renders menu for active type REPORT_TABLE and type CHART 1`] = `
         </svg>
       </span>
       <span
-        class="jsx-2002348738 label"
+        class="jsx-1930534478 label"
       >
         <span
           class="jsx-3661110597 tooltip"
@@ -580,14 +580,14 @@ exports[`renders menu for active type REPORT_TABLE and type CHART 1`] = `
     </a>
   </li>
   <li
-    class="jsx-2002348738 dense"
+    class="jsx-1930534478 dense"
     data-test="dhis2-uicore-menuitem"
   >
     <a
-      class="jsx-2002348738"
+      class="jsx-1930534478"
     >
       <span
-        class="jsx-2002348738 icon"
+        class="jsx-1930534478 icon"
       >
         <svg
           height="16"
@@ -602,7 +602,7 @@ exports[`renders menu for active type REPORT_TABLE and type CHART 1`] = `
         </svg>
       </span>
       <span
-        class="jsx-2002348738 label"
+        class="jsx-1930534478 label"
       >
         <span
           class="jsx-3661110597 tooltip"

--- a/src/pages/edit/ItemSelector/__tests__/__snapshots__/ContentMenuItem.spec.js.snap
+++ b/src/pages/edit/ItemSelector/__tests__/__snapshots__/ContentMenuItem.spec.js.snap
@@ -3,14 +3,14 @@
 exports[`ContentMenuItem has a LaunchLink when url is provided 1`] = `
 <div>
   <li
-    class="jsx-2002348738 "
+    class="jsx-1930534478 "
     data-test="menu-item-Rainbow Dash"
   >
     <a
-      class="jsx-2002348738"
+      class="jsx-1930534478"
     >
       <span
-        class="jsx-2002348738 icon"
+        class="jsx-1930534478 icon"
       >
         <svg
           color="#6C7787"
@@ -26,7 +26,7 @@ exports[`ContentMenuItem has a LaunchLink when url is provided 1`] = `
         </svg>
       </span>
       <span
-        class="jsx-2002348738 label"
+        class="jsx-1930534478 label"
       >
         <div
           class="menuItem"
@@ -72,14 +72,14 @@ exports[`ContentMenuItem has a LaunchLink when url is provided 1`] = `
 exports[`does not have LaunchLink if no url provided 1`] = `
 <div>
   <li
-    class="jsx-2002348738 "
+    class="jsx-1930534478 "
     data-test="menu-item-Fancy chart"
   >
     <a
-      class="jsx-2002348738"
+      class="jsx-1930534478"
     >
       <span
-        class="jsx-2002348738 icon"
+        class="jsx-1930534478 icon"
       >
         <svg
           color="#6C7787"
@@ -95,7 +95,7 @@ exports[`does not have LaunchLink if no url provided 1`] = `
         </svg>
       </span>
       <span
-        class="jsx-2002348738 label"
+        class="jsx-1930534478 label"
       >
         <div
           class="menuItem"

--- a/src/pages/edit/ItemSelector/__tests__/__snapshots__/SinglesMenuGroup.spec.js.snap
+++ b/src/pages/edit/ItemSelector/__tests__/__snapshots__/SinglesMenuGroup.spec.js.snap
@@ -3,14 +3,14 @@
 exports[`renders SingleMenuGroup 1`] = `
 <div>
   <li
-    class="jsx-2002348738 item disabled dense"
+    class="jsx-1930534478 item disabled dense"
     data-test="dhis2-uicore-menuitem"
   >
     <a
-      class="jsx-2002348738"
+      class="jsx-1930534478"
     >
       <span
-        class="jsx-2002348738 label"
+        class="jsx-1930534478 label"
       >
         <span
           style="color: rgb(64, 75, 90); font-weight: 600;"
@@ -21,14 +21,14 @@ exports[`renders SingleMenuGroup 1`] = `
     </a>
   </li>
   <li
-    class="jsx-2002348738 "
+    class="jsx-1930534478 "
     data-test="menu-item-Rainbow Dash"
   >
     <a
-      class="jsx-2002348738"
+      class="jsx-1930534478"
     >
       <span
-        class="jsx-2002348738 icon"
+        class="jsx-1930534478 icon"
       >
         <svg
           color="#6C7787"
@@ -44,7 +44,7 @@ exports[`renders SingleMenuGroup 1`] = `
         </svg>
       </span>
       <span
-        class="jsx-2002348738 label"
+        class="jsx-1930534478 label"
       >
         <div
           class="menuItem"
@@ -66,14 +66,14 @@ exports[`renders SingleMenuGroup 1`] = `
     </a>
   </li>
   <li
-    class="jsx-2002348738 "
+    class="jsx-1930534478 "
     data-test="menu-item-Twilight"
   >
     <a
-      class="jsx-2002348738"
+      class="jsx-1930534478"
     >
       <span
-        class="jsx-2002348738 icon"
+        class="jsx-1930534478 icon"
       >
         <svg
           color="#6C7787"
@@ -89,7 +89,7 @@ exports[`renders SingleMenuGroup 1`] = `
         </svg>
       </span>
       <span
-        class="jsx-2002348738 label"
+        class="jsx-1930534478 label"
       >
         <div
           class="menuItem"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2245,10 +2245,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@999.9.9-outlier-table.alpha.3":
-  version "999.9.9-outlier-table.alpha.3"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-999.9.9-outlier-table.alpha.3.tgz#04dfc98a57b917b1ffa007d2ee3a172c566ccb6f"
-  integrity sha512-Ln956fy7UojRKlQ/HXdaTUFV/zQwgpvppqA8VJAtk4N9HTWCskbtKwOGj6PN4UQABxkQKeRXBhtAXrT+iq3FHw==
+"@dhis2/analytics@999.9.9-outlier-table.alpha.4":
+  version "999.9.9-outlier-table.alpha.4"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-999.9.9-outlier-table.alpha.4.tgz#a5ca4dc5cc8d1e819d9462c69a1d12149b9351c7"
+  integrity sha512-JtvJxqRQSEDoo2+Jq+bo0NIb2gq0hqCQfCpnTpET08uwkYFAwu6YKma2Z0rmK3A9IM0wwqSJNx3a7Cje7Px9BQ==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^7.4.1"
     "@dhis2/multi-calendar-dates" "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2245,10 +2245,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^26.4.0":
-  version "26.4.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-26.4.0.tgz#adbdac2896457fdcaf913f66ee5afe012eab5ea5"
-  integrity sha512-j5t6hOykYEW6jTmcwDUP/bmXJS3+t2h92GzzOKhNnhsc3iPNjB1xVGQxfKmPhO3sCLvMR1N0mG1EP7/AEefUew==
+"@dhis2/analytics@999.9.9-outlier-table.alpha.3":
+  version "999.9.9-outlier-table.alpha.3"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-999.9.9-outlier-table.alpha.3.tgz#04dfc98a57b917b1ffa007d2ee3a172c566ccb6f"
+  integrity sha512-Ln956fy7UojRKlQ/HXdaTUFV/zQwgpvppqA8VJAtk4N9HTWCskbtKwOGj6PN4UQABxkQKeRXBhtAXrT+iq3FHw==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^7.4.1"
     "@dhis2/multi-calendar-dates" "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1665,583 +1665,583 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@dhis2-ui/alert@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/alert/-/alert-8.14.0.tgz#38ea79acf0606355eace4dfe1fd1356ed2d58e67"
-  integrity sha512-PjPa+XascXLC/fynFeMEPfbOCktuBofPbCZPIRHvoWBR3qParT92/uRE2Ao5Wdlz2aPN4RF+4n8VAauhYCqWCw==
+"@dhis2-ui/alert@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/alert/-/alert-9.2.0.tgz#3b30e90a88a96c617219c60ad8bc16a5969e85d1"
+  integrity sha512-9uh6vIKlj9vm9wOr/7UvSvxrEgl0p99+FdfFtvCeiOywR2+CCPvd9fRsL/vWKcCraopOriCmTm5PzBUWPuatvg==
   dependencies:
-    "@dhis2-ui/portal" "8.14.0"
+    "@dhis2-ui/portal" "9.2.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
-    "@dhis2/ui-icons" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
+    "@dhis2/ui-icons" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/box@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/box/-/box-8.14.0.tgz#b95f6885c30962c9389ef6e9a4b1c3c9d4a317da"
-  integrity sha512-/Nvv4hIcie1ESj3TatsZuv/nRcTFodsOdZVjxbJu6cnO5sh+Dx9L9bSyA7KlBIKP4kN0ivzi1exw7OmidLBmJA==
+"@dhis2-ui/box@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/box/-/box-9.2.0.tgz#0f8fd79059d724c075180ea442c860ebff88c802"
+  integrity sha512-ERNEd8lDAQIGDmTYknWClPGbmWuOpFAnE8XurB6wrkydn0M2+wsIa00q2on6RgY2YaAjVtYZEXr9CfjBtwh04w==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/button@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/button/-/button-8.14.0.tgz#bcd21a45ac76d282d86a4a3e40c0133f2e6fd089"
-  integrity sha512-46ELNzA1eV14dxblYNTXN4dKRNGdnXx/+xP4lvqGrw/11SgMNMeqtf6JBxNCFKoZj3zKlcFUG2RD/FOANC/tNg==
+"@dhis2-ui/button@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/button/-/button-9.2.0.tgz#8d465f471ca629e1cb0ded01fc68143eb4960c1c"
+  integrity sha512-YBdIpaOqEgpI0JhHm8XBlpFGDF7O6eiFQ4Noxu131KEyDOf7a+AkIyECVZw6Jsj3n2zrbyzBDw6IndSFSlBqRQ==
   dependencies:
-    "@dhis2-ui/layer" "8.14.0"
-    "@dhis2-ui/loader" "8.14.0"
-    "@dhis2-ui/popper" "8.14.0"
+    "@dhis2-ui/layer" "9.2.0"
+    "@dhis2-ui/loader" "9.2.0"
+    "@dhis2-ui/popper" "9.2.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
-    "@dhis2/ui-icons" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
+    "@dhis2/ui-icons" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/calendar@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/calendar/-/calendar-8.14.0.tgz#829335a22e41e3823e534853bbec73775a254d72"
-  integrity sha512-jEI/m7FHpjAHrqo4G3Vf4DeBTdu3yvLenWpoSwV9nioioLr2n6h0eTLNqpuR784xmEQ9YbWat1SMl0enekgHmw==
+"@dhis2-ui/calendar@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/calendar/-/calendar-9.2.0.tgz#c3fbcdc622a13dd112de163719cfdcd0f960cfe2"
+  integrity sha512-6xxkCx66tjfGffGoPnDB6pe9Pvx+UybAGCqof7/0xfHP2vnfdss716imM02HfJRZwp5dNUrXqBO9uuQ1qkp/HA==
   dependencies:
-    "@dhis2-ui/button" "8.14.0"
-    "@dhis2-ui/card" "8.14.0"
-    "@dhis2-ui/input" "8.14.0"
-    "@dhis2-ui/layer" "8.14.0"
-    "@dhis2-ui/popper" "8.14.0"
+    "@dhis2-ui/button" "9.2.0"
+    "@dhis2-ui/card" "9.2.0"
+    "@dhis2-ui/input" "9.2.0"
+    "@dhis2-ui/layer" "9.2.0"
+    "@dhis2-ui/popper" "9.2.0"
     "@dhis2/multi-calendar-dates" "1.0.2"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
-    "@dhis2/ui-icons" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
+    "@dhis2/ui-icons" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/card@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/card/-/card-8.14.0.tgz#1284f93c643ba22164192ea9d70c66967b6ee3fe"
-  integrity sha512-PDjYFTBWu4cf43xENylluIvMpC+G913fYsUmPgpq8ToWxrsUK8ObXzOMUAivKQTvavi9CB0UhqwlkqSVLMdYXQ==
+"@dhis2-ui/card@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/card/-/card-9.2.0.tgz#1a2d8f2f9becfd9fd43e7e315fda511418698fd1"
+  integrity sha512-++eLieBc4WsNXD1iQEQaqijnQ7hpKu0HH9cjkwTa46jjI9SoJGdYInvCzZPafB1XuCZ42f08kTcdND2qZWbssQ==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/center@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/center/-/center-8.14.0.tgz#6b74acb9730a3200748ef32b6878e402f9172ee0"
-  integrity sha512-bdL/lh5YUld5RRRJ+CW5APs5NI9kKZ63HCbN7cJ0iKzldjAP6DXLoXxFc8WVURy4i/lXTzAkLLPJDIqN1V0OOA==
+"@dhis2-ui/center@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/center/-/center-9.2.0.tgz#f7fbcbd00696d718286f269a64a5bad327160449"
+  integrity sha512-IBwLld/SQEtT5acjBr3nJnpkXNzypxm9f+QfdGYRq2ZSQmkIv9IUjIvlC25CU72Ksq+N0nWvA8AYp2Qx/l04fg==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/checkbox@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/checkbox/-/checkbox-8.14.0.tgz#4e747df029782460ac6c74ca4ce5c369f335ca42"
-  integrity sha512-sZ7FWDEE29nJFjMcmE0RB6D/fT9KKgpRZ5vtUzFTVdGXDSzun0MiOqTLEK9yqitPi18tex2Gu+mcu/ohx/bO9g==
+"@dhis2-ui/checkbox@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/checkbox/-/checkbox-9.2.0.tgz#7f27c645bb9d31df4898c9c96cfdabf9ddd01ab3"
+  integrity sha512-EIGbkdnCLOyW3s7Mh31LdPgghHPaTAt0MJe5ieF/1NycUCfx99NGoR7wXlAlI6wNvjkuTYnYBknERGHUEzY9rA==
   dependencies:
-    "@dhis2-ui/field" "8.14.0"
-    "@dhis2-ui/required" "8.14.0"
+    "@dhis2-ui/field" "9.2.0"
+    "@dhis2-ui/required" "9.2.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/chip@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/chip/-/chip-8.14.0.tgz#5fe751772fae2453335d7dbec188ce7e8e93a7d7"
-  integrity sha512-vKgvKL0n2IvCFswODOxcEEocy62IYviHxzSt5zX+5k4AcZjWIgX+yJy4ixyR2nu8rtgJDSR4c5k++dnLiWWqMQ==
+"@dhis2-ui/chip@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/chip/-/chip-9.2.0.tgz#45b5e55e6d11318bb6917f1bcdee9bf9b67bd620"
+  integrity sha512-PesbKz0MrXegDAFcGHq34Ast0kM/mJrmExiLua262egYYaRiQXDYeaNuS2TT+qPsPsDva2Pp7kqjdrFRDL2Few==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/cover@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/cover/-/cover-8.14.0.tgz#4e7aabdc8a7bb8dee6221b53edfbd7e8faf3bee1"
-  integrity sha512-gHbqciNccPWlfdIyKleXloTZ1CCmMLmJr8sB9F2PP/u/dqdGUMMwQvhWtzadqqRYHey5Get8oEbkBkXngiAJ/A==
+"@dhis2-ui/cover@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/cover/-/cover-9.2.0.tgz#0288dad0ba9caf8c0b77c86868fc4bae3388f6c7"
+  integrity sha512-ZxcOOuyy/dB4pgjdVzBlgwtVue0HEct2XOiuIKM66F5G0DPBqz6UtLDD+8VRofQwTKcTYQh9kPZPmx/9q65Zcg==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/css@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/css/-/css-8.14.0.tgz#68902ea5cadbf5879ba64b0156c4b3436787493c"
-  integrity sha512-Y/ZZJ2v7HpG6weBOFoNp2HzqNn/HTfuNkMjhjmuqbF/4ZyoDv/Fs6cNhMQSkI4Nt0aRBUAfF4x1IWf+s2jT5YQ==
+"@dhis2-ui/css@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/css/-/css-9.2.0.tgz#ad881b90371c7506690ee2a2b2151c09f793e368"
+  integrity sha512-dBe9S75+Nj1c9SNRkxU0VWTVwFZJ+vLFKxD1UYaPdbJ2DHD6AD4UJ1YtXgvBvgiJ0wbT1vesh3tKfEUXbnTmkw==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/divider@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/divider/-/divider-8.14.0.tgz#aab56542073bce43452f0ec09b2f0452da88ff33"
-  integrity sha512-RsjYuDd6XZwpchjp/J4Yo+qt3F5OJvQNX5nB11iVTJPUMr/wztPJZUQwBOTNt44gNFOLktgJEl60okRhP4P1lg==
+"@dhis2-ui/divider@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/divider/-/divider-9.2.0.tgz#2f9ea2f3a1f89853963bcffdeef27e5ebc390021"
+  integrity sha512-z87v4XKIO1IXhWmHYhCQgR7MTiuU+zLMg9Py2OIDxMchVXrdyGSeKCpL9UgOzl/jtHxwoMdnVDzy8sLLzITgsw==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/field@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/field/-/field-8.14.0.tgz#3ae79b901d1fda86fa0d623730cc5130685097b5"
-  integrity sha512-1pnWNy8T7B1zNx1BNyTNefu5fddFaF59FdmcA0jCGoNHbTnq488pTnwOxFzIew3Mme0sg7XYD7E+BkZ5fZhEAg==
+"@dhis2-ui/field@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/field/-/field-9.2.0.tgz#d16b443ff168e352b6f5168d2179975377902dd1"
+  integrity sha512-pZr1LkzOm4TOPdPAen9e3RHQE8Y1uCbdFhP1oc5vg44etmudX7stJuEXP6/DrPm6sHCJRojf90laqPai1vfrHg==
   dependencies:
-    "@dhis2-ui/box" "8.14.0"
-    "@dhis2-ui/help" "8.14.0"
-    "@dhis2-ui/label" "8.14.0"
+    "@dhis2-ui/box" "9.2.0"
+    "@dhis2-ui/help" "9.2.0"
+    "@dhis2-ui/label" "9.2.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/file-input@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/file-input/-/file-input-8.14.0.tgz#b9de9b24a7beab582d5a35cce6ac06ce842db7fc"
-  integrity sha512-LSPoODLf84Dl+hcFzgfSlP1JfBPSngiobHSOhMCZZiK6qPintuE4bY36BfZXvWJZUmSOQZvTGvrmAPLJ4YqTSg==
+"@dhis2-ui/file-input@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/file-input/-/file-input-9.2.0.tgz#d48e9d290aea798640b251d915b9a8f51abcf363"
+  integrity sha512-x+lKilo6aQN320fIAPZMAq13PxKuTb/jhZb7m7pMS0HKsPqfT5rWm1VfmBlN/02BkKsmhsvo/tTe9vxpAic71A==
   dependencies:
-    "@dhis2-ui/button" "8.14.0"
-    "@dhis2-ui/field" "8.14.0"
-    "@dhis2-ui/label" "8.14.0"
-    "@dhis2-ui/loader" "8.14.0"
-    "@dhis2-ui/status-icon" "8.14.0"
+    "@dhis2-ui/button" "9.2.0"
+    "@dhis2-ui/field" "9.2.0"
+    "@dhis2-ui/label" "9.2.0"
+    "@dhis2-ui/loader" "9.2.0"
+    "@dhis2-ui/status-icon" "9.2.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
-    "@dhis2/ui-icons" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
+    "@dhis2/ui-icons" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/header-bar@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/header-bar/-/header-bar-8.14.0.tgz#90a104c89b76d87a602f1aa964b5379ea3043dbe"
-  integrity sha512-UeL5VSlxpMcvSg2eNVW1qJC/QwEaXqI4M89VaMNEVPSmGDEqdOdzvb2ENxgiee52dGR+y/KFKddLOqbKe+KfnA==
+"@dhis2-ui/header-bar@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/header-bar/-/header-bar-9.2.0.tgz#83efe93821318decca3bd1a28d30fd3089435b6d"
+  integrity sha512-7iNKOllQNeYfa9nJjXVqiohcuKEk+RMhuu/7BY8g2oPmwbvS0uc49KiL53cFfAWBST/v5fU1XOpWS/N7PmJr2g==
   dependencies:
-    "@dhis2-ui/box" "8.14.0"
-    "@dhis2-ui/button" "8.14.0"
-    "@dhis2-ui/card" "8.14.0"
-    "@dhis2-ui/center" "8.14.0"
-    "@dhis2-ui/divider" "8.14.0"
-    "@dhis2-ui/input" "8.14.0"
-    "@dhis2-ui/layer" "8.14.0"
-    "@dhis2-ui/loader" "8.14.0"
-    "@dhis2-ui/logo" "8.14.0"
-    "@dhis2-ui/menu" "8.14.0"
-    "@dhis2-ui/modal" "8.14.0"
-    "@dhis2-ui/user-avatar" "8.14.0"
+    "@dhis2-ui/box" "9.2.0"
+    "@dhis2-ui/button" "9.2.0"
+    "@dhis2-ui/card" "9.2.0"
+    "@dhis2-ui/center" "9.2.0"
+    "@dhis2-ui/divider" "9.2.0"
+    "@dhis2-ui/input" "9.2.0"
+    "@dhis2-ui/layer" "9.2.0"
+    "@dhis2-ui/loader" "9.2.0"
+    "@dhis2-ui/logo" "9.2.0"
+    "@dhis2-ui/menu" "9.2.0"
+    "@dhis2-ui/modal" "9.2.0"
+    "@dhis2-ui/user-avatar" "9.2.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
-    "@dhis2/ui-icons" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
+    "@dhis2/ui-icons" "9.2.0"
     classnames "^2.3.1"
     moment "^2.29.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/help@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/help/-/help-8.14.0.tgz#8e77cc7521a2222d640a528b3e1c6cb3669b1af2"
-  integrity sha512-z5OoPNH3VvIm5xjxAaHb3eBsuo7CSgYGBUOiBgiwmXpost482Eh+5FNtKScqSxiae1/7LkndYm7nar52bRxz9g==
+"@dhis2-ui/help@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/help/-/help-9.2.0.tgz#76556c0d581fb0f7611fe5c5bb0d9adf35ad0c8e"
+  integrity sha512-qD3oNEwEb+pT7jsD4ciHtu16KrxMySPWoqco5nJwoGbcZFLw/caEfkBo2IroImD0MxtI0mKt5emD7V2yXRWm7A==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/input@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/input/-/input-8.14.0.tgz#f1fa8a94e32f91f41e66f3ac1f299eafdc1a1a3a"
-  integrity sha512-tdCARoqRAN5eE4LHv6XmzwR4Rl+eRUSQZgX4ARkCUMP4Bkxpl2S+Q9pnnvZJvHzcQkQx9lXDiJF/WPzaaOx+sQ==
+"@dhis2-ui/input@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/input/-/input-9.2.0.tgz#bdf7c72e11b818ed86e1e6335cd373ae037f4ef3"
+  integrity sha512-0bzF/8pZSMqe5ZN2v0t0/rMTvKWd9kl5MDOy9fRXpX6yoFgfH+j+iIU06eVyqJl3DMqCdInfapJvpJR7MHvd+g==
   dependencies:
-    "@dhis2-ui/box" "8.14.0"
-    "@dhis2-ui/field" "8.14.0"
-    "@dhis2-ui/input" "8.14.0"
-    "@dhis2-ui/loader" "8.14.0"
-    "@dhis2-ui/status-icon" "8.14.0"
+    "@dhis2-ui/box" "9.2.0"
+    "@dhis2-ui/field" "9.2.0"
+    "@dhis2-ui/input" "9.2.0"
+    "@dhis2-ui/loader" "9.2.0"
+    "@dhis2-ui/status-icon" "9.2.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
-    "@dhis2/ui-icons" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
+    "@dhis2/ui-icons" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/intersection-detector@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/intersection-detector/-/intersection-detector-8.14.0.tgz#8fde840ec164f6da270f5fae5b264d90b99496b8"
-  integrity sha512-J4lUqjcHVZBrCpUp/DVSbr3F2pp/LnXnc48CdQ04+vgS3kEt6mUtf7s7mQMshAI57Kcv7AZciHkQNYxWooqXBA==
+"@dhis2-ui/intersection-detector@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/intersection-detector/-/intersection-detector-9.2.0.tgz#31f19bfb8645ebda7d7af6f6e641b40fa1e57888"
+  integrity sha512-erBoDMhOPmua8eP8bKJNl4WIUUm+Fw3Jj9M0OxC+xia3/Fi8scLUyk0Yek1Y0lGdb4YHJEXqx475dLNjpmiLRQ==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/label@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/label/-/label-8.14.0.tgz#8354be4b02d242869e58aef4ccb20e3cb1d73e23"
-  integrity sha512-5tqs7+8Fu9zk4f/cQFAogUnOAsYm1RltSRhEuajGqHd/Glgsz5dU5jPu4ixUgqv43qdIrvkCpLZdjVDJRKriTQ==
+"@dhis2-ui/label@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/label/-/label-9.2.0.tgz#81ec2de2ea1b9bc7cf25eb8bb036d451d5b61748"
+  integrity sha512-k9Q4XyIbaNRvCn1+rLcEb/iDi479S3fOEJ2MCT6wsGxr1+Hys7yVw7Ggq0OQ9SLCEwElNQcvj+vWB4dZltXl5Q==
   dependencies:
-    "@dhis2-ui/required" "8.14.0"
+    "@dhis2-ui/required" "9.2.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/layer@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/layer/-/layer-8.14.0.tgz#eb2fdf2d4cf48b03186187950f4e066e71af3f8e"
-  integrity sha512-Qcek91Cb7S4FV3aGc4drbBF2KISD8QeUuKUKeorGsibL/iZo+0i1Ng9hJMj6VF4fi+6cItW9n9vrwi8TZyuu4A==
+"@dhis2-ui/layer@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/layer/-/layer-9.2.0.tgz#7afcb2ef8571eb9c839fc522eb76ead70e395dbc"
+  integrity sha512-95aFgQYxgJ7GmWY6AOSoAH4BH7wkIyUAioAIRUDwp0mmSJhJxG6P9b1PFqw4koX1zV4/RLoz+NiQ7Twv+03CLQ==
   dependencies:
-    "@dhis2-ui/portal" "8.14.0"
+    "@dhis2-ui/portal" "9.2.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/legend@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/legend/-/legend-8.14.0.tgz#171a42e671011095c8e61306f6cbdd7d867850c4"
-  integrity sha512-wQjdg718TZXBps1vJLMMveF/EEB9qg6pWuo4xELXjUTjVWBe7ej4BxMgMM/iLGZPef0ceFCHOj0JREd2tmgpJQ==
+"@dhis2-ui/legend@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/legend/-/legend-9.2.0.tgz#a051822fd67c1442b6986a86097aca94f3960dd2"
+  integrity sha512-IfJhu48eu//O9AlHt7IUdsv5E92XG7v/95laFfyQOaGhf1C4BQf11s6yXc3nTFoil/p55oAsZnWp5e7UXcgrhg==
   dependencies:
-    "@dhis2-ui/required" "8.14.0"
+    "@dhis2-ui/required" "9.2.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/loader@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/loader/-/loader-8.14.0.tgz#ecfb58523f8950d7da8bc472ceb3a379e8df1027"
-  integrity sha512-uF4QxUsSf7imnjxCSdLrLXtm979kBoypTxGKBg9Hl1ROQfxQX/vIyw5Mn2sE5Zi1MCyvet5kpmMxQFI3B84jzQ==
+"@dhis2-ui/loader@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/loader/-/loader-9.2.0.tgz#f45fdb19a37182351932cd3e11980d43b4895d40"
+  integrity sha512-M8tuLE5kgm7oHmIN6par8GfRDpmt+DXFU3cCSZdiYIUM6SQSD8G5LmA8AaIHR5h7l430d93vcw7RQL3eeE/svw==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/logo@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/logo/-/logo-8.14.0.tgz#c7488d8c8c5ccffa85cbb61f114e5444d66b4dbe"
-  integrity sha512-jPhHYLSN09j0yJONUjvE5ZqyU4btCmJ+OpQxZJUrVzQOj1XYq/xjqOZwaHFKPx15WAg1U+NyVDER0rS4+xnIow==
+"@dhis2-ui/logo@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/logo/-/logo-9.2.0.tgz#0452aadd8e92afc1c558869a08c8e5d1f14ff55f"
+  integrity sha512-OEFrSpDijeCIhLjJ8vipDGRdihTgj8+iLcPLDrOeRAurlgJZJZiicxBKSuY6uc6p1/9QPccqX2huJjM1uNqo2g==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/menu@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/menu/-/menu-8.14.0.tgz#633e3fa728808c21b7752d51be536853de7694fd"
-  integrity sha512-LAASOtWZtgs7eXRcS5Jld+6J2K/QDvA8bQDoShgsq9eKu22ucPXkS2BS2osI414u2CRKZBATodEsybnHy35gMA==
+"@dhis2-ui/menu@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/menu/-/menu-9.2.0.tgz#996729545b29def9366a099005a17c781bdca8f6"
+  integrity sha512-8k15qmoqBWKo1Afj+QXFnDAIoDyAqosvq3j8M/+xM+cSn0H+6e3Q7UOp0ByVQlumoY5DyrT9Z7NojULIjFUifQ==
   dependencies:
-    "@dhis2-ui/card" "8.14.0"
-    "@dhis2-ui/divider" "8.14.0"
-    "@dhis2-ui/layer" "8.14.0"
-    "@dhis2-ui/popper" "8.14.0"
-    "@dhis2-ui/portal" "8.14.0"
+    "@dhis2-ui/card" "9.2.0"
+    "@dhis2-ui/divider" "9.2.0"
+    "@dhis2-ui/layer" "9.2.0"
+    "@dhis2-ui/popper" "9.2.0"
+    "@dhis2-ui/portal" "9.2.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
-    "@dhis2/ui-icons" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
+    "@dhis2/ui-icons" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/modal@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/modal/-/modal-8.14.0.tgz#201b05a0448bf1ea1be6c33a5feb242e51e3b20b"
-  integrity sha512-hQSQb1kfiNqY+BlTA0UZ6mSuxJ0BjjJ1RrYmT0/3EZlmZ3SqgblKQ3Hs3RaKwqfE6OPV6zTIBi+zJkE/c1UgKA==
+"@dhis2-ui/modal@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/modal/-/modal-9.2.0.tgz#7815efe62be4f482b2e2224ffe92981068b1bae9"
+  integrity sha512-gp+gCTmtoiLVAhigo1i6msE598qIGnkW6To+dTkUecvxyvni+DZTAulTmL62UtTzzjPjYO0yOqNTWQztbpj1KQ==
   dependencies:
-    "@dhis2-ui/card" "8.14.0"
-    "@dhis2-ui/center" "8.14.0"
-    "@dhis2-ui/layer" "8.14.0"
-    "@dhis2-ui/portal" "8.14.0"
+    "@dhis2-ui/card" "9.2.0"
+    "@dhis2-ui/center" "9.2.0"
+    "@dhis2-ui/layer" "9.2.0"
+    "@dhis2-ui/portal" "9.2.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
-    "@dhis2/ui-icons" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
+    "@dhis2/ui-icons" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/node@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/node/-/node-8.14.0.tgz#20a1ec87419b5667a6ef0fba2d272629ba4f0dbe"
-  integrity sha512-4s9N2pR9WQ1VYRc4vFFVTY17bSBz6wbQR3y2ju83McZoNQdyUsMWFqVxmX7WbKg6Tlzkxs6/+liNja2rcHb4AQ==
+"@dhis2-ui/node@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/node/-/node-9.2.0.tgz#3560b3e7394d275c1bce3e800b2654cddcd2adb2"
+  integrity sha512-xx7P/6V7vq3JLXUUATKGGUCORHqQL74fsGYUd9a0izyUyq4h3pEHL9ZT6Cel+A0d5ODYn/j/Q6fHICZzg55FBQ==
   dependencies:
-    "@dhis2-ui/loader" "8.14.0"
+    "@dhis2-ui/loader" "9.2.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/notice-box@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/notice-box/-/notice-box-8.14.0.tgz#f4d290c186b0e8ad0969e1e4833e1cb7e37847d5"
-  integrity sha512-CG9UX9ywSW9E+5/qDJq4re9Wb1Vh5r6B/LZT3hMyg3Dx3QMWd3fZOTw+/utLRTCChx6/E67DM19qgYD+kFfXTg==
+"@dhis2-ui/notice-box@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/notice-box/-/notice-box-9.2.0.tgz#8c1fb4a2a780fea0fde4b8f9eaf8f73957187c99"
+  integrity sha512-DY3WYXj1hsOsiBHGaNrOeZ8h7SPaXox6iMCTzL/jLvnfmTrH7wy6SHRLQYWg0BMrDflhMJu9qhn0jtzhEXZNMQ==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
-    "@dhis2/ui-icons" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
+    "@dhis2/ui-icons" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/organisation-unit-tree@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/organisation-unit-tree/-/organisation-unit-tree-8.14.0.tgz#189b9b8f14d54a5ba749f337d44c8e22e1c31774"
-  integrity sha512-BvtrWCOqRuIXNNJe+oyFvuB2w3VMJexe3RXH4UiRrne5XddJGz2eVhDCHK3KAOkv2BnJJiXN0w51+8LAdg4Sgw==
+"@dhis2-ui/organisation-unit-tree@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/organisation-unit-tree/-/organisation-unit-tree-9.2.0.tgz#ce33d91361145d6574ddbef3866b56be06cee6cb"
+  integrity sha512-PHm908gNGPhq5D655BI4lrB+hMqfISKASjoFCWxG2f9FU64/pvQ+snZQQwQFMAJYMd6FKw4GOP1isKz0jTGNuA==
   dependencies:
-    "@dhis2-ui/checkbox" "8.14.0"
-    "@dhis2-ui/loader" "8.14.0"
-    "@dhis2-ui/node" "8.14.0"
+    "@dhis2-ui/checkbox" "9.2.0"
+    "@dhis2-ui/loader" "9.2.0"
+    "@dhis2-ui/node" "9.2.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/pagination@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/pagination/-/pagination-8.14.0.tgz#5d15df324a3f0f0adeefab8477d29e346e20651d"
-  integrity sha512-BlyY1yAI2lQFz1H8CD/tyR3SePoNO3ydhnShW34oChOqzPBIxunPUS4UPziHd6O9yuFtREKAp1HOWGuTIXoGLQ==
+"@dhis2-ui/pagination@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/pagination/-/pagination-9.2.0.tgz#f38d1ada2bc9f9795dae8f86c52d54f29889dd17"
+  integrity sha512-jXJNQ8JOPweeMFCsPXgAb8dAx8J/rNTnExL8WA6rfRDWujOojLp8Gu2MrH5jlHRpCBWIl+aJO1I/ZKHekQOeDg==
   dependencies:
-    "@dhis2-ui/button" "8.14.0"
-    "@dhis2-ui/select" "8.14.0"
+    "@dhis2-ui/button" "9.2.0"
+    "@dhis2-ui/select" "9.2.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
-    "@dhis2/ui-icons" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
+    "@dhis2/ui-icons" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/popover@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/popover/-/popover-8.14.0.tgz#02d1fc80dc242887365570852e4ca203538cadc6"
-  integrity sha512-Db6pxOw9+P1Ps7SQ8HuCb/HhflcrRIGh/gF7m5cHh7MqqP0z/l1a5xai7NjhZe7IUPxmsWnnOvb5qY99eqKpTA==
+"@dhis2-ui/popover@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/popover/-/popover-9.2.0.tgz#3eccd6abde1da72089aa5feda5669ce4d1aa6f7e"
+  integrity sha512-7g8AHPrzUuMuv2MXpX5HdwiyO+peSGoq7hg6rHN/VDasIUvGS7vbaV4Xbxfd32fNmpHceBV7gMga31hRNaKtgw==
   dependencies:
-    "@dhis2-ui/layer" "8.14.0"
-    "@dhis2-ui/popper" "8.14.0"
+    "@dhis2-ui/layer" "9.2.0"
+    "@dhis2-ui/popper" "9.2.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/popper@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/popper/-/popper-8.14.0.tgz#27ab6fb881224b70c69f857b4327e62208b7e0fe"
-  integrity sha512-lXoL6f6Z6A1atc/ivz2ixCOwy5EqFSeT3eP7pDhjLbsRb6gaEEiPjSSZMikNRAWnyFoyw7D2Cn7YWW+rCyk4iw==
+"@dhis2-ui/popper@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/popper/-/popper-9.2.0.tgz#6d17ca49d7f0496289e11315d414095d93d179b5"
+  integrity sha512-6xWNvUQaDu8VE4rCa+uYOheb/4BD/52Cs23w2yt4lLAVrym4kV+0cnpHtlEG1ZuuVrK/yHelMjrmYxn6yJE41Q==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
     "@popperjs/core" "^2.10.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
     react-popper "^2.2.5"
     resize-observer-polyfill "^1.5.1"
 
-"@dhis2-ui/portal@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/portal/-/portal-8.14.0.tgz#4f2cfd67cd5d2c3f5905ab593d4ddf14fb823dd6"
-  integrity sha512-GDu1gL4UxZR7Nnz2atEinhE9rea91BH1y2FVJyfH0D596vDbBkqVrZ/PbkJ4lozT9YH2HWIdhMJHFI2fXAZEPQ==
+"@dhis2-ui/portal@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/portal/-/portal-9.2.0.tgz#12435f3a8886de685fc9ee4540639810eabf0191"
+  integrity sha512-a5DqmTG+pn4y1aXZWr8wEGlK4xRqdvnOWJVqO/6aebEn4ZtcPJT6yyXouviAM2yoW7+fDj6TZhKrZo3vgMLHlA==
   dependencies:
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/radio@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/radio/-/radio-8.14.0.tgz#c484bc00132af186d09207fe3519e06eb674d2da"
-  integrity sha512-p/u/zlh3qDZF5FFrfzhaQz+/evpSdlXWONnMOq1DwO83s7M8/Rr/nnS0NO3f0Q8rHB+zix3NXZO2QwnOGbOGcw==
+"@dhis2-ui/radio@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/radio/-/radio-9.2.0.tgz#9223ada90fe2d0eae375e85e0d99e6eb81d5269a"
+  integrity sha512-rjcz05spFlvRL8fnkO/7/ckznY4agQLl5P7UKSFL3Kz0KxvnocmounTX1BDsm6iQhKKt2HqJCYShpzPhTXavSA==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/required@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/required/-/required-8.14.0.tgz#67ec4a725d98180fd14aceb3654dfa2c141f3b79"
-  integrity sha512-qqr92tk0hSeClWzevMTrflPw6GqBgBNO/00yLgOTUBdBPq//mnzHjNZV8n14tSwAGxogt0ybh0oqg5rB1GXHzg==
+"@dhis2-ui/required@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/required/-/required-9.2.0.tgz#8d76c914c3eb483958284c8ddf52ef7095cc2f42"
+  integrity sha512-cNoQct7gVbrAdzGDDFLnfBktmwmxAhD48oEZ6z4TE7IrPi2N+idqOiQCTEVKEWmuY7VGv9TV0I/1OLX6oiuSvA==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/segmented-control@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/segmented-control/-/segmented-control-8.14.0.tgz#450aad42bdd9b8d7e97dcc9137649d0afb48cff7"
-  integrity sha512-UG37XmkJUDlB3jjj/7EuvC8FURfxuVKN96XOaljEkRXUN4SRDUMkwqQYhKQuk0WP9ihz0ZJHwIbVMiz9KM+eLQ==
+"@dhis2-ui/segmented-control@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/segmented-control/-/segmented-control-9.2.0.tgz#2b230eea17e35194072544ebbfc68e2c896fb951"
+  integrity sha512-x4eDqGu4JFfFPQk06mg8YdUCjYeYyXCLmZ0gbGj1Zx03gxpMwb4/nVyGoAxZg31/IVkhBOeAwXlvt+ckNXovgw==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/select@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/select/-/select-8.14.0.tgz#06f0af5436646d70c1f5a13961fbf0e16071a62f"
-  integrity sha512-g8HBE/QqJ3U3IwKOh9UiVlbJ/TlPmQNO+Iby8uK+dcV/5H4lXo/6dwgRQxEwnxi5XIhpnpoh5FZ4axAGs6ZrWA==
+"@dhis2-ui/select@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/select/-/select-9.2.0.tgz#e854ecf6fd2580f9fb904301d1985923c1ade9cf"
+  integrity sha512-Hv0mRbpJNHJUa2lVivrWBt67iJ+4xTb7KxZkThISkmpQpzbWmhmJWlDbe0L+PdqOsaB2A70/N9HH4dhQyVP8vA==
   dependencies:
-    "@dhis2-ui/box" "8.14.0"
-    "@dhis2-ui/button" "8.14.0"
-    "@dhis2-ui/card" "8.14.0"
-    "@dhis2-ui/checkbox" "8.14.0"
-    "@dhis2-ui/chip" "8.14.0"
-    "@dhis2-ui/field" "8.14.0"
-    "@dhis2-ui/input" "8.14.0"
-    "@dhis2-ui/layer" "8.14.0"
-    "@dhis2-ui/loader" "8.14.0"
-    "@dhis2-ui/popper" "8.14.0"
-    "@dhis2-ui/status-icon" "8.14.0"
+    "@dhis2-ui/box" "9.2.0"
+    "@dhis2-ui/button" "9.2.0"
+    "@dhis2-ui/card" "9.2.0"
+    "@dhis2-ui/checkbox" "9.2.0"
+    "@dhis2-ui/chip" "9.2.0"
+    "@dhis2-ui/field" "9.2.0"
+    "@dhis2-ui/input" "9.2.0"
+    "@dhis2-ui/layer" "9.2.0"
+    "@dhis2-ui/loader" "9.2.0"
+    "@dhis2-ui/popper" "9.2.0"
+    "@dhis2-ui/status-icon" "9.2.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
-    "@dhis2/ui-icons" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
+    "@dhis2/ui-icons" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/selector-bar@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/selector-bar/-/selector-bar-8.14.0.tgz#6fefe936008f0ff9297eab2e596b3c1bd88127c3"
-  integrity sha512-eU1NtQfYNA28PQAD4Plfc4Ai9rIfr2sJUW5cZ8aQB6c5JO6kIq5F+oXsaL3uLz5oWyq2SbnhBCXlei1BOW/I5Q==
+"@dhis2-ui/selector-bar@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/selector-bar/-/selector-bar-9.2.0.tgz#23790f850bee1142e7bdffd711a2dea27dc78112"
+  integrity sha512-HDb/XKuUdD82vDh5mgz+OWIwpKjyiZEqek74y8g2r/AsMIl5Fe2rOyncOUPpGctxYeVp9u3gAlkFbIHd/qpv/w==
   dependencies:
-    "@dhis2-ui/button" "8.14.0"
-    "@dhis2-ui/card" "8.14.0"
-    "@dhis2-ui/layer" "8.14.0"
-    "@dhis2-ui/popper" "8.14.0"
-    "@dhis2/ui-constants" "8.14.0"
-    "@dhis2/ui-icons" "8.14.0"
+    "@dhis2-ui/button" "9.2.0"
+    "@dhis2-ui/card" "9.2.0"
+    "@dhis2-ui/layer" "9.2.0"
+    "@dhis2-ui/popper" "9.2.0"
+    "@dhis2/ui-constants" "9.2.0"
+    "@dhis2/ui-icons" "9.2.0"
     "@testing-library/react" "^12.1.2"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/sharing-dialog@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/sharing-dialog/-/sharing-dialog-8.14.0.tgz#4978f5c84be69b7b290ca28784f0eefa55deb58d"
-  integrity sha512-PyeWQD0rYypf7kjX/D/3K957rYiQMfRMli4Wb1Rk87KlUxV4DAl9wtliH2zQhmCoplPXMwdbfnf+hLA7yCiCKg==
+"@dhis2-ui/sharing-dialog@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/sharing-dialog/-/sharing-dialog-9.2.0.tgz#8818e5119c2113b3a54add3bd56dfe55ad2fc52a"
+  integrity sha512-h7chsY8XM2kw06r52pGRjS8ZknuwiEkRxuBTXD77G1Loni5TMm6xr0OFr9nSQHSsbcbxydbo2WPRPAu6WjVyfg==
   dependencies:
-    "@dhis2-ui/box" "8.14.0"
-    "@dhis2-ui/button" "8.14.0"
-    "@dhis2-ui/card" "8.14.0"
-    "@dhis2-ui/divider" "8.14.0"
-    "@dhis2-ui/input" "8.14.0"
-    "@dhis2-ui/layer" "8.14.0"
-    "@dhis2-ui/menu" "8.14.0"
-    "@dhis2-ui/modal" "8.14.0"
-    "@dhis2-ui/notice-box" "8.14.0"
-    "@dhis2-ui/popper" "8.14.0"
-    "@dhis2-ui/select" "8.14.0"
-    "@dhis2-ui/tab" "8.14.0"
-    "@dhis2-ui/tooltip" "8.14.0"
-    "@dhis2-ui/user-avatar" "8.14.0"
+    "@dhis2-ui/box" "9.2.0"
+    "@dhis2-ui/button" "9.2.0"
+    "@dhis2-ui/card" "9.2.0"
+    "@dhis2-ui/divider" "9.2.0"
+    "@dhis2-ui/input" "9.2.0"
+    "@dhis2-ui/layer" "9.2.0"
+    "@dhis2-ui/menu" "9.2.0"
+    "@dhis2-ui/modal" "9.2.0"
+    "@dhis2-ui/notice-box" "9.2.0"
+    "@dhis2-ui/popper" "9.2.0"
+    "@dhis2-ui/select" "9.2.0"
+    "@dhis2-ui/tab" "9.2.0"
+    "@dhis2-ui/tooltip" "9.2.0"
+    "@dhis2-ui/user-avatar" "9.2.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
-    "@dhis2/ui-icons" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
+    "@dhis2/ui-icons" "9.2.0"
     "@react-hook/size" "^2.1.2"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/status-icon@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/status-icon/-/status-icon-8.14.0.tgz#de4e2ca1eca34e9cdcd2e7cd12f1a7ec0ac48009"
-  integrity sha512-s/KgFzoAorBLf3XVmD3d3Zyobsbgv19UR+5dLRAKgKtV4aT3bm7UgDvJdzApl9fElmeLCv/Ic7aTS2Y6aRWseQ==
+"@dhis2-ui/status-icon@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/status-icon/-/status-icon-9.2.0.tgz#5686721ef7dc1b1cd1cca315b11136e0809e568f"
+  integrity sha512-oILHs38xICDU27C7CXgFAEttU4QJzg0wImKlX4XVJ5z1aGeq6qOW0RUVibF6JtyAppEi9XsYZ+AB1KLEGnDFJw==
   dependencies:
-    "@dhis2-ui/loader" "8.14.0"
+    "@dhis2-ui/loader" "9.2.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
-    "@dhis2/ui-icons" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
+    "@dhis2/ui-icons" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/switch@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/switch/-/switch-8.14.0.tgz#23f1b43fe8461d7bca8e287facab445233209129"
-  integrity sha512-jPSrsqcSkPXRs/EnyUgr0duBQAs0a2j75vJEfULUPXGx2RQUk71WjJy+WNh4iq89En8abvGu2DvEX15wX2uXNQ==
+"@dhis2-ui/switch@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/switch/-/switch-9.2.0.tgz#1fc9ed88546906da11aa19348b8ba8ff2e7c8414"
+  integrity sha512-IwVUiqxMKZmx7VtEJkyHqGzy4tvRNh4qbhmrFodaH6d9YrbycaFNECbphrT1OywrUBuci0Q2LovZhYKInkeIFg==
   dependencies:
-    "@dhis2-ui/field" "8.14.0"
-    "@dhis2-ui/required" "8.14.0"
+    "@dhis2-ui/field" "9.2.0"
+    "@dhis2-ui/required" "9.2.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/tab@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/tab/-/tab-8.14.0.tgz#4f79e2134ce6a83aeabae0843fd3d5389e535e60"
-  integrity sha512-y4Aktalr4ACTpoH115ohDI9Go7KDhZZf8bR5Scr0jh4mRtYj1+or+dk/M+uALzU4uxp4GMozh2PfwT4g133PYQ==
+"@dhis2-ui/tab@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/tab/-/tab-9.2.0.tgz#910223a907f8c007921924138306b53c2014f0fd"
+  integrity sha512-zVxwQ7WgjcrCGd+qWzLx+OtTWlGOIuC+AuSknHz0wpGgW3vawr1rMDA6j129l4O+ezzPs5bw8vN3xUQORbj0Bg==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
-    "@dhis2/ui-icons" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
+    "@dhis2/ui-icons" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/table@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/table/-/table-8.14.0.tgz#bf8602a64e485439643b42e20393cfaae4cc768c"
-  integrity sha512-uni9xTcl/YO5zXxslzey/5mlbaUYntmQU6CYLC9Jqx5HLCCeaOJyBPAgvoSVLIzwAt6HlQ1uvp7LMbuJYRRZTA==
+"@dhis2-ui/table@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/table/-/table-9.2.0.tgz#83d535e6c60ff9c9c3f436e592489a131caef772"
+  integrity sha512-wep8wPQKRg5vYPGg3HLAvsAEo+lUk3L7wO7axHyzx/XuHR40QXRirpv4tsFVn8VPpSFVq0w/BFGp8ijp3Y6RtA==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
-    "@dhis2/ui-icons" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
+    "@dhis2/ui-icons" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/tag@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/tag/-/tag-8.14.0.tgz#a30e9eb4a19794e12b376022c9d3852d9944bc81"
-  integrity sha512-sD/cB/nfUNBwZjWVRm5eS46Qy9H+fnkAOeYSZdbcf6xazPzjaDGqk6SR4rVd+p3qN/i13h4cMUEsCzFCVHLnvw==
+"@dhis2-ui/tag@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/tag/-/tag-9.2.0.tgz#c6a11fbdfc20151cc75c323e6a6b1470ef064e58"
+  integrity sha512-qt/FUIFPZkghfF/fhhLHr4oOl54d1Zwy4CKf4cZmO2DSd09h7E7cfIUxXaX/shRHsSmeUhrFP2Nv5LAvu8XVUg==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/text-area@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/text-area/-/text-area-8.14.0.tgz#f9a24ca838b579772aad70d32b947640f1ce36fd"
-  integrity sha512-YnnByLyDz5Nqiw/7pBCQgMZi7inp6x1xfZpiYOCV4P2EXzyM58Xivm1aXyKnjCQvhJ2fwqDpYQm47bXSx1FrJg==
+"@dhis2-ui/text-area@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/text-area/-/text-area-9.2.0.tgz#75f279281f1513801148f11c2693537a5e9beed7"
+  integrity sha512-KLBlerlO3OvBvzTVKKolfghaAMjDPUZkxFsyRvWEIPh1RRxS9ZprunXpBWRkNO2I6U6uwqN0DiBLTNbh/zrafg==
   dependencies:
-    "@dhis2-ui/box" "8.14.0"
-    "@dhis2-ui/field" "8.14.0"
-    "@dhis2-ui/loader" "8.14.0"
-    "@dhis2-ui/status-icon" "8.14.0"
+    "@dhis2-ui/box" "9.2.0"
+    "@dhis2-ui/field" "9.2.0"
+    "@dhis2-ui/loader" "9.2.0"
+    "@dhis2-ui/status-icon" "9.2.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
-    "@dhis2/ui-icons" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
+    "@dhis2/ui-icons" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/tooltip@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/tooltip/-/tooltip-8.14.0.tgz#8bc643ab290947e2c143f05cc3f1e887c102a337"
-  integrity sha512-K5F5y1CCVZagBagpK6Hn5xi06A1Qd/Fp5sNyyYHEyoIDD6/TMQpnZ4hMNKqwVNWUqbxj2KuMM8zE6IaZTm+ATA==
+"@dhis2-ui/tooltip@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/tooltip/-/tooltip-9.2.0.tgz#e7a0827d9ca6b30b69073916f7801d01fb7c9793"
+  integrity sha512-7Gb/Occ5/Bju95dnxUGzt/Q4129zqGWrxu1+S2uhc0YPRSx83JcG0MivPsVsr0BeU+p+8xwTVdGBOhMmqLpL9Q==
   dependencies:
-    "@dhis2-ui/popper" "8.14.0"
-    "@dhis2-ui/portal" "8.14.0"
+    "@dhis2-ui/popper" "9.2.0"
+    "@dhis2-ui/portal" "9.2.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/transfer@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/transfer/-/transfer-8.14.0.tgz#3b8f39afe9c77d88a903f334b1dbcb6be4f61a39"
-  integrity sha512-LjGUP1Q3jjMHryibJb8wZGUNsZ4rYROzEzho0Z9e+dtf2tTlng74DIuzYd+5RCD15Am+xqySaq/zJC0XQ9yFdA==
+"@dhis2-ui/transfer@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/transfer/-/transfer-9.2.0.tgz#3624d08100b72143da5639ce231b53d57706ffdc"
+  integrity sha512-1+SdfeCBr+iOLaXf4gkpNLlysaBsWLOmlVzBdGVqFt4I4SMJrhFrCMUTz4A1Nsw7GpKGds35vGClQUe5LcuVSw==
   dependencies:
-    "@dhis2-ui/button" "8.14.0"
-    "@dhis2-ui/field" "8.14.0"
-    "@dhis2-ui/input" "8.14.0"
-    "@dhis2-ui/intersection-detector" "8.14.0"
-    "@dhis2-ui/loader" "8.14.0"
+    "@dhis2-ui/button" "9.2.0"
+    "@dhis2-ui/field" "9.2.0"
+    "@dhis2-ui/input" "9.2.0"
+    "@dhis2-ui/intersection-detector" "9.2.0"
+    "@dhis2-ui/loader" "9.2.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/user-avatar@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/user-avatar/-/user-avatar-8.14.0.tgz#7fe40a33eb14391f532dca1ad0ad44fd6a32fbdb"
-  integrity sha512-nKXcpP4QjbI4WaI5H5KJzKg1cI9o49WAE0R5ddmHugGdCXkqeW8w5tjGT08D7wKFJc4jan4ejKn3DU5rf0GS8A==
+"@dhis2-ui/user-avatar@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/user-avatar/-/user-avatar-9.2.0.tgz#722b4bad239aff8eb2b639ca51bd6528a08da1e4"
+  integrity sha512-XRop5Mmc5q1GnrM3YgIEdjw0OX7/KA9ZdxRNS4AU7ifYMEjUNutYmq8a2bJ1M6eZfq2DrhRQui9/1E7MvK+Evw==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "8.14.0"
+    "@dhis2/ui-constants" "9.2.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
@@ -2521,91 +2521,91 @@
     workbox-routing "^6.1.5"
     workbox-strategies "^6.1.5"
 
-"@dhis2/ui-constants@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-constants/-/ui-constants-8.14.0.tgz#658a0b50ac3bf88754d19b6be372c1db4fcc81a0"
-  integrity sha512-tVEQGCYpdQs2eH1uiXE0PIcTFNlLC9fqGBi95bduXLXZ8G23VPgIHgGdPPLsK8goVZYr7jIpYnN6fTNbPhu66Q==
+"@dhis2/ui-constants@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-constants/-/ui-constants-9.2.0.tgz#47506acaec5e4ce28630519a630a05657d2d29f6"
+  integrity sha512-gMbnVJQJmCPoGJHnY09BoDe6Z1vukzFdUcm0HPYyijs8ZWnclLs+69iVamxhskOnNWgj8hEt/FVs4mfhMcW3Cg==
   dependencies:
     prop-types "^15.7.2"
 
-"@dhis2/ui-forms@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-forms/-/ui-forms-8.14.0.tgz#d918ef7a308d777a162c1ff4b644ffd12dc604a9"
-  integrity sha512-PhNeSoLSU1sQHy/G84CNi92JwpJGY1kFEJnww8o5/lMFClxbFvG978hd6kzA8CTzBNvrOzD0uY/TCL+cj1xshw==
+"@dhis2/ui-forms@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-forms/-/ui-forms-9.2.0.tgz#a5651dc5010a495c8a52ef5484e7d44b2583b715"
+  integrity sha512-eodiPW+ahR5wVsgrl/bFvj2zyeJD+DR9woqys4ZyoaHlKjOdeLqDNbJDnrS+AmHfte5uorF/aWzmEZr825LBVg==
   dependencies:
-    "@dhis2-ui/button" "8.14.0"
-    "@dhis2-ui/checkbox" "8.14.0"
-    "@dhis2-ui/field" "8.14.0"
-    "@dhis2-ui/file-input" "8.14.0"
-    "@dhis2-ui/input" "8.14.0"
-    "@dhis2-ui/radio" "8.14.0"
-    "@dhis2-ui/select" "8.14.0"
-    "@dhis2-ui/switch" "8.14.0"
-    "@dhis2-ui/text-area" "8.14.0"
+    "@dhis2-ui/button" "9.2.0"
+    "@dhis2-ui/checkbox" "9.2.0"
+    "@dhis2-ui/field" "9.2.0"
+    "@dhis2-ui/file-input" "9.2.0"
+    "@dhis2-ui/input" "9.2.0"
+    "@dhis2-ui/radio" "9.2.0"
+    "@dhis2-ui/select" "9.2.0"
+    "@dhis2-ui/switch" "9.2.0"
+    "@dhis2-ui/text-area" "9.2.0"
     "@dhis2/prop-types" "^3.1.2"
     classnames "^2.3.1"
     final-form "^4.20.2"
     prop-types "^15.7.2"
     react-final-form "^6.5.3"
 
-"@dhis2/ui-icons@8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-icons/-/ui-icons-8.14.0.tgz#35182305b56790b0263b2898580989c331e57ef5"
-  integrity sha512-EltpyicKR7hvk+j/FrXIogxcWIEzG+D7XdOXi9xwOWot+JnXio0wWObHsuR6xyMPjwnFjk5vLRtlIn2E3jtdYw==
+"@dhis2/ui-icons@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-icons/-/ui-icons-9.2.0.tgz#bddf5223cabec93c9499281b2181eb165346b639"
+  integrity sha512-g9993UGWVLwDcbV+wp3HqrK8AXFu49aped0GpZsQUlGbHIzEl1EgmjiII44N40VbXwVUnqIDmu99wBxpH5Gd+g==
 
-"@dhis2/ui@^8.12.3", "@dhis2/ui@^8.14.0":
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-8.14.0.tgz#3649e67c9d160f57b2c05691f4454fcd0df1156e"
-  integrity sha512-ewwdGDN5TW1l591OYsIc6AMa71B58XZtolZgC4GoOk+BYNNdq7UPJEuLH6SI4VZHeF248jFq0kRObU39oT59Mg==
+"@dhis2/ui@^8.12.3", "@dhis2/ui@^9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-9.2.0.tgz#33d474cbc7cd95f8a714e019d6c69e144f77f86b"
+  integrity sha512-nhKwW5bmIfQvt3L16PffFO2NsDk9BgYb91vHx06fPgM56UdwGYSejpax8eU29vE9urmHSkijSpnBqY4buZy6Ow==
   dependencies:
-    "@dhis2-ui/alert" "8.14.0"
-    "@dhis2-ui/box" "8.14.0"
-    "@dhis2-ui/button" "8.14.0"
-    "@dhis2-ui/calendar" "8.14.0"
-    "@dhis2-ui/card" "8.14.0"
-    "@dhis2-ui/center" "8.14.0"
-    "@dhis2-ui/checkbox" "8.14.0"
-    "@dhis2-ui/chip" "8.14.0"
-    "@dhis2-ui/cover" "8.14.0"
-    "@dhis2-ui/css" "8.14.0"
-    "@dhis2-ui/divider" "8.14.0"
-    "@dhis2-ui/field" "8.14.0"
-    "@dhis2-ui/file-input" "8.14.0"
-    "@dhis2-ui/header-bar" "8.14.0"
-    "@dhis2-ui/help" "8.14.0"
-    "@dhis2-ui/input" "8.14.0"
-    "@dhis2-ui/intersection-detector" "8.14.0"
-    "@dhis2-ui/label" "8.14.0"
-    "@dhis2-ui/layer" "8.14.0"
-    "@dhis2-ui/legend" "8.14.0"
-    "@dhis2-ui/loader" "8.14.0"
-    "@dhis2-ui/logo" "8.14.0"
-    "@dhis2-ui/menu" "8.14.0"
-    "@dhis2-ui/modal" "8.14.0"
-    "@dhis2-ui/node" "8.14.0"
-    "@dhis2-ui/notice-box" "8.14.0"
-    "@dhis2-ui/organisation-unit-tree" "8.14.0"
-    "@dhis2-ui/pagination" "8.14.0"
-    "@dhis2-ui/popover" "8.14.0"
-    "@dhis2-ui/popper" "8.14.0"
-    "@dhis2-ui/portal" "8.14.0"
-    "@dhis2-ui/radio" "8.14.0"
-    "@dhis2-ui/required" "8.14.0"
-    "@dhis2-ui/segmented-control" "8.14.0"
-    "@dhis2-ui/select" "8.14.0"
-    "@dhis2-ui/selector-bar" "8.14.0"
-    "@dhis2-ui/sharing-dialog" "8.14.0"
-    "@dhis2-ui/switch" "8.14.0"
-    "@dhis2-ui/tab" "8.14.0"
-    "@dhis2-ui/table" "8.14.0"
-    "@dhis2-ui/tag" "8.14.0"
-    "@dhis2-ui/text-area" "8.14.0"
-    "@dhis2-ui/tooltip" "8.14.0"
-    "@dhis2-ui/transfer" "8.14.0"
-    "@dhis2-ui/user-avatar" "8.14.0"
-    "@dhis2/ui-constants" "8.14.0"
-    "@dhis2/ui-forms" "8.14.0"
-    "@dhis2/ui-icons" "8.14.0"
+    "@dhis2-ui/alert" "9.2.0"
+    "@dhis2-ui/box" "9.2.0"
+    "@dhis2-ui/button" "9.2.0"
+    "@dhis2-ui/calendar" "9.2.0"
+    "@dhis2-ui/card" "9.2.0"
+    "@dhis2-ui/center" "9.2.0"
+    "@dhis2-ui/checkbox" "9.2.0"
+    "@dhis2-ui/chip" "9.2.0"
+    "@dhis2-ui/cover" "9.2.0"
+    "@dhis2-ui/css" "9.2.0"
+    "@dhis2-ui/divider" "9.2.0"
+    "@dhis2-ui/field" "9.2.0"
+    "@dhis2-ui/file-input" "9.2.0"
+    "@dhis2-ui/header-bar" "9.2.0"
+    "@dhis2-ui/help" "9.2.0"
+    "@dhis2-ui/input" "9.2.0"
+    "@dhis2-ui/intersection-detector" "9.2.0"
+    "@dhis2-ui/label" "9.2.0"
+    "@dhis2-ui/layer" "9.2.0"
+    "@dhis2-ui/legend" "9.2.0"
+    "@dhis2-ui/loader" "9.2.0"
+    "@dhis2-ui/logo" "9.2.0"
+    "@dhis2-ui/menu" "9.2.0"
+    "@dhis2-ui/modal" "9.2.0"
+    "@dhis2-ui/node" "9.2.0"
+    "@dhis2-ui/notice-box" "9.2.0"
+    "@dhis2-ui/organisation-unit-tree" "9.2.0"
+    "@dhis2-ui/pagination" "9.2.0"
+    "@dhis2-ui/popover" "9.2.0"
+    "@dhis2-ui/popper" "9.2.0"
+    "@dhis2-ui/portal" "9.2.0"
+    "@dhis2-ui/radio" "9.2.0"
+    "@dhis2-ui/required" "9.2.0"
+    "@dhis2-ui/segmented-control" "9.2.0"
+    "@dhis2-ui/select" "9.2.0"
+    "@dhis2-ui/selector-bar" "9.2.0"
+    "@dhis2-ui/sharing-dialog" "9.2.0"
+    "@dhis2-ui/switch" "9.2.0"
+    "@dhis2-ui/tab" "9.2.0"
+    "@dhis2-ui/table" "9.2.0"
+    "@dhis2-ui/tag" "9.2.0"
+    "@dhis2-ui/text-area" "9.2.0"
+    "@dhis2-ui/tooltip" "9.2.0"
+    "@dhis2-ui/transfer" "9.2.0"
+    "@dhis2-ui/user-avatar" "9.2.0"
+    "@dhis2/ui-constants" "9.2.0"
+    "@dhis2/ui-forms" "9.2.0"
+    "@dhis2/ui-icons" "9.2.0"
     prop-types "^15.7.2"
 
 "@dnd-kit/accessibility@^3.0.0":


### PR DESCRIPTION
Adds support for Outlier table DV items in dashboard [DHIS2-16751](https://dhis2.atlassian.net/browse/DHIS2-16751)

**Requires https://github.com/dhis2/analytics/pull/1598**

---

### Key features

1. Bump `analytics` for Outlier table vis type support
2. Bump `@dhis2/ui` for the Outlier table icon
3. Disable the "View as" options in the item's context menu
4. Revisit tooltip texts now that we have 2 types of "table" visualizations

---

### Description

Outlier table is a new DV vis type, the code required for displaying it it's therefore already in place, but the new vis type definition is in `analytics` so we need to bump the dependency.
Also, to avoid problems with having multiple versions of `@dhis2/ui` the dependency is also bumped.

---

### TODO

- [x] confirm what to do with the "View as" options in the context menu
- [ ] replace the alpha version of analytics with the correct one

---

### Screenshots

<img width="1498" alt="Screenshot 2024-02-16 at 11 42 49" src="https://github.com/dhis2/dashboard-app/assets/150978/8905f20c-345a-4b84-9c18-fc215cef8014">



[DHIS2-16751]: https://dhis2.atlassian.net/browse/DHIS2-16751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ