### PR TITLE
chore: run the release step on both master and dev branches

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -125,7 +125,8 @@ jobs:
         needs: e2e-prod
         if: |
             !github.event.push.repository.fork &&
-            github.actor != 'dependabot[bot]'
+            github.actor != 'dependabot[bot]' &&
+            (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev')
         steps:
             - uses: actions/checkout@v3
               with:

--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -125,8 +125,7 @@ jobs:
         needs: e2e-prod
         if: |
             !github.event.push.repository.fork &&
-            github.actor != 'dependabot[bot]' &&
-            github.ref == 'refs/heads/master'
+            github.actor != 'dependabot[bot]'
         steps:
             - uses: actions/checkout@v3
               with:


### PR DESCRIPTION
For the 41 soft freeze period, the app bundle needs to be deployed to d2-ci. Since it will be built from the 'dev' branch, we need to run the deploy build step on 'dev'