### PR TITLE
fix: show tag/tooltip only when a filter other than ou/pe is used

### DIFF
--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -1,4 +1,8 @@
-import { VIS_TYPE_OUTLIER_TABLE } from '@dhis2/analytics'
+import {
+    VIS_TYPE_OUTLIER_TABLE,
+    DIMENSION_ID_PERIOD,
+    DIMENSION_ID_ORGUNIT,
+} from '@dhis2/analytics'
 import i18n from '@dhis2/d2-i18n'
 import { Tag, Tooltip } from '@dhis2/ui'
 import PropTypes from 'prop-types'
@@ -225,7 +229,14 @@ class Item extends Component {
                     case CHART:
                     case VISUALIZATION: {
                         return item.visualization.type ===
-                            VIS_TYPE_OUTLIER_TABLE ? (
+                            VIS_TYPE_OUTLIER_TABLE &&
+                            Object.keys(itemFilters).some(
+                                (filter) =>
+                                    ![
+                                        DIMENSION_ID_ORGUNIT,
+                                        DIMENSION_ID_PERIOD,
+                                    ].includes(filter)
+                            ) ? (
                             <Tooltip
                                 content={i18n.t(
                                     'Only Period and Organisation unit filters can be applied to this item'


### PR DESCRIPTION
Part of [DHIS2-16751](https://dhis2.atlassian.net/browse/DHIS2-16751)

---

### Key features

1. do not show tag/tooltip when the only filters are pe/ou

---

### Description

The tag with tooltip explaining how the filters are applied for Outlier table should only appear if there is a least one filter other than period or org unit.

---

### Screenshots

Before:
![image (9)](https://github.com/dhis2/dashboard-app/assets/150978/6ad666b4-2b38-45eb-a7bb-768d5acc2ad0)

After:
<img width="543" alt="Screenshot 2024-03-20 at 16 23 13" src="https://github.com/dhis2/dashboard-app/assets/150978/c02e3835-0e4a-451e-906d-942fc24fdfa6">



[DHIS2-16751]: https://dhis2.atlassian.net/browse/DHIS2-16751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ