### PR TITLE
fix: fetch repetition data for LL to show in plugin v38

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+Implements [DHIS2-XXXX](https://dhis2.atlassian.net/browse/DHIS2-XXXX)
+
+**Requires https://github.com/dhis2/analytics/pull/XXX**
+
+---
+
+### Key features
+
+1. _feature_
+
+---
+
+### Description
+
+_text_
+
+---
+
+### TODO
+
+-   [ ] _task_
+
+---
+
+### Known issues
+
+-   [ ] _issue_
+
+---
+
+### Screenshots
+
+_supporting text_

--- a/src/api/fetchVisualization.js
+++ b/src/api/fetchVisualization.js
@@ -1,7 +1,11 @@
 import { getInstance } from 'd2'
-import { getVisualizationId } from '../modules/item'
-import { getEndPointName, MAP } from '../modules/itemTypes'
-import { getMapFields, getFavoriteFields } from './metadata'
+import { getVisualizationId } from '../modules/item.js'
+import {
+    getEndPointName,
+    MAP,
+    EVENT_VISUALIZATION,
+} from '../modules/itemTypes.js'
+import { getMapFields, getFavoriteFields } from './metadata.js'
 
 export const apiFetchVisualization = async item => {
     const id = getVisualizationId(item)
@@ -11,6 +15,7 @@ export const apiFetchVisualization = async item => {
             : getFavoriteFields({
                   withDimensions: true,
                   withOptions: true,
+                  withRepetition: item.type === EVENT_VISUALIZATION,
               })
 
     const d2 = await getInstance()

--- a/src/api/metadata.js
+++ b/src/api/metadata.js
@@ -14,29 +14,36 @@ export const getItemFields = () => [
 ]
 
 // Dimension
-export const getDimensionFields = ({ withItems }) =>
+export const getDimensionFields = ({ withItems, withRepetition }) =>
     arrayClean([
         'dimension',
         'legendSet[id]',
         'filter',
         'programStage',
         withItems ? `items[${getItemFields().join(',')}]` : ``,
+        withRepetition ? 'repetition' : '',
     ])
 
 // Axis
-export const getAxesFields = ({ withItems }) => [
-    `columns[${getDimensionFields({ withItems }).join(',')}]`,
-    `rows[${getDimensionFields({ withItems }).join(',')}]`,
-    `filters[${getDimensionFields({ withItems }).join(',')}]`,
+export const getAxesFields = ({ withItems, withRepetition }) => [
+    `columns[${getDimensionFields({ withItems, withRepetition }).join(',')}]`,
+    `rows[${getDimensionFields({ withItems, withRepetition }).join(',')}]`,
+    `filters[${getDimensionFields({ withItems, withRepetition }).join(',')}]`,
 ]
 
 // Favorite
-export const getFavoriteFields = ({ withDimensions, withOptions }) => {
+export const getFavoriteFields = ({
+    withDimensions,
+    withOptions,
+    withRepetition,
+}) => {
     return arrayClean([
         `${getIdNameFields({ rename: true }).join(',')}`,
         'type',
         'displayDescription~rename(description)',
-        withDimensions ? `${getAxesFields({ withItems: true }).join(',')}` : ``,
+        withDimensions
+            ? `${getAxesFields({ withItems: true, withRepetition }).join(',')}`
+            : ``,
         withOptions
             ? [
                   '*',


### PR DESCRIPTION
Backport of #2271 .
(cherry picked from commit 25378ce65effdf6e0670f95a927d97aa7164643a)

### Key features

1. fetch `repetition` data for LL

---

### Description

If a repeatable event was saved in a LL AO, it didn't show up in the plugin on dashboard.
The reason was because dashboard didn't fetch the `repetition` data with the rest of the fields passed to the plugin.

---

### Screenshots

Before:
<img width="304" alt="Screenshot 2023-03-22 at 14 56 54" src="https://user-images.githubusercontent.com/150978/227168267-d01471bb-e5d6-4921-9177-cf78bc84617c.png">

After:
<img width="495" alt="Screenshot 2023-03-23 at 10 59 11" src="https://user-images.githubusercontent.com/150978/227168395-1b155811-b917-49d1-ae63-b97bf31ce731.png">


