### PR TITLE
feat: add metadata support for TE (DHIS2-17242)

### DIFF
--- a/src/api/metadata.js
+++ b/src/api/metadata.js
@@ -22,6 +22,10 @@ export const getDimensionFields = ({ withItems, withRepetition }) =>
         'programStage',
         withItems ? `items[${getItemFields().join(',')}]` : ``,
         withRepetition ? 'repetition' : '',
+        'dimensionType',
+        'program[id]',
+        'optionSet[id]',
+        'valueType',
     ])
 
 // Axis


### PR DESCRIPTION
Fix for [DHIS2-17242](https://dhis2.atlassian.net/browse/DHIS2-17242)

Implements [DHIS2-16023](https://dhis2.atlassian.net/browse/DHIS2-16023)

Relates to https://github.com/dhis2/line-listing-app/pull/451

---

### Key features

1. Add metadata support for tracked entity line lists

---

### Description

Some `fields` were missing in dashboards when fetching line lists that was preventing tracked entity line lists to work properly (introduced in the LL PR here: https://github.com/dhis2/line-listing-app/pull/451)

---

### TODO

-   [x] Manual testing

---

### Screenshots

_supporting text_


[DHIS2-16023]: https://dhis2.atlassian.net/browse/DHIS2-16023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DHIS2-17242]: https://dhis2.atlassian.net/browse/DHIS2-17242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ