### PR TITLE
fix: short name was not being shown in charts [v39]

### DIFF
--- a/src/components/Item/VisualizationItem/Visualization/DataVisualizerPlugin.js
+++ b/src/components/Item/VisualizationItem/Visualization/DataVisualizerPlugin.js
@@ -53,7 +53,6 @@ const DataVisualizerPlugin = ({
                     visualization={visualization}
                     forDashboard={true}
                     userSettings={userSettings}
-                    displayProperty={userSettings.displayProperty}
                     style={style}
                     onLoadingComplete={onLoadingComplete}
                     onError={onError}

--- a/src/components/Item/VisualizationItem/Visualization/DataVisualizerPlugin.js
+++ b/src/components/Item/VisualizationItem/Visualization/DataVisualizerPlugin.js
@@ -52,6 +52,7 @@ const DataVisualizerPlugin = ({
                 <VisualizationPlugin
                     visualization={visualization}
                     forDashboard={true}
+                    userSettings={userSettings}
                     displayProperty={userSettings.displayProperty}
                     style={style}
                     onLoadingComplete={onLoadingComplete}

--- a/src/components/Item/VisualizationItem/Visualization/DataVisualizerPlugin.js
+++ b/src/components/Item/VisualizationItem/Visualization/DataVisualizerPlugin.js
@@ -52,7 +52,7 @@ const DataVisualizerPlugin = ({
                 <VisualizationPlugin
                     visualization={visualization}
                     forDashboard={true}
-                    displayProperty={userSettings.keyAnalysisDisplayProperty}
+                    displayProperty={userSettings.displayProperty}
                     style={style}
                     onLoadingComplete={onLoadingComplete}
                     onError={onError}

--- a/src/components/Item/VisualizationItem/Visualization/DataVisualizerPlugin.js
+++ b/src/components/Item/VisualizationItem/Visualization/DataVisualizerPlugin.js
@@ -52,7 +52,7 @@ const DataVisualizerPlugin = ({
                 <VisualizationPlugin
                     visualization={visualization}
                     forDashboard={true}
-                    userSettings={userSettings}
+                    displayProperty={userSettings.keyAnalysisDisplayProperty}
                     style={style}
                     onLoadingComplete={onLoadingComplete}
                     onError={onError}

--- a/src/components/Item/VisualizationItem/Visualization/IframePlugin.js
+++ b/src/components/Item/VisualizationItem/Visualization/IframePlugin.js
@@ -53,7 +53,7 @@ const IframePlugin = ({
         () => ({
             isVisualizationLoaded: true,
             forDashboard: true,
-            displayProperty: userSettings.displayProperty,
+            displayProperty: userSettings.keyAnalysisDisplayProperty,
             visualization,
             onError,
 

--- a/src/components/UserSettingsProvider.js
+++ b/src/components/UserSettingsProvider.js
@@ -17,11 +17,14 @@ const UserSettingsProvider = ({ children }) => {
 
             setSettings({
                 ...userSettings,
-                displayProperty: userSettings.keyAnalysisDisplayProperty,
+                displayProperty:
+                    userSettings.keyAnalysisDisplayProperty === 'name'
+                        ? 'displayName'
+                        : 'displayShortName',
             })
         }
         fetchData()
-    }, [])
+    }, [engine])
 
     return (
         <UserSettingsCtx.Provider

--- a/src/modules/useDimensions.js
+++ b/src/modules/useDimensions.js
@@ -17,7 +17,7 @@ const useDimensions = (doFetch) => {
             try {
                 const unfilteredDimensions = await apiFetchDimensions(
                     dataEngine,
-                    userSettings.keyAnalysisDisplayProperty
+                    userSettings.displayProperty
                 )
 
                 dispatch(
@@ -28,14 +28,16 @@ const useDimensions = (doFetch) => {
             }
         }
 
-        if (
-            !dimensions.length &&
-            doFetch &&
-            userSettings.keyAnalysisDisplayProperty
-        ) {
+        if (!dimensions.length && doFetch && userSettings.displayProperty) {
             fetchDimensions()
         }
-    }, [dimensions, doFetch, userSettings.keyAnalysisDisplayProperty])
+    }, [
+        dimensions,
+        doFetch,
+        userSettings.displayProperty,
+        dataEngine,
+        dispatch,
+    ])
 
     return dimensions
 }

--- a/src/pages/view/TitleBar/FilterDialog.js
+++ b/src/pages/view/TitleBar/FilterDialog.js
@@ -119,9 +119,7 @@ const FilterDialog = ({
                         dimensionId={dimension.id}
                         onSelect={onSelectItems}
                         dimensionTitle={dimension.name}
-                        displayNameProp={
-                            userSettings.keyAnalysisDisplayProperty
-                        }
+                        displayNameProp={userSettings.displayProperty}
                     />
                 )
         }


### PR DESCRIPTION
Fixes: https://dhis2.atlassian.net/browse/DHIS2-12499

DV plugin fix: the plugin does not accept a `userSettings` prop. It expects a `displayProperty` of either `displayName` or `displayShortName`.

LL plugin (IFramePlugin): expects `displayProperty` of `name` or `shortName`.

The FIlterDialog and useDimensions expect `displayName` or `displayShortName`.

<img width="500" alt="image" src="https://github.com/dhis2/dashboard-app/assets/6113918/5db89dae-ddfc-4d42-bd32-9d3483c173cc">

