### PR TITLE
fix: avoid re-rendering an item when adding the same again (DHIS2-17016) v38

### DIFF
--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -78,9 +78,13 @@ class Item extends Component {
     }
 
     async componentDidMount() {
-        this.props.setVisualization(
-            await apiFetchVisualization(this.props.item)
-        )
+        // Avoid refetching the visualization already in the Redux store
+        // when the same dashboard item is added again.
+        // This also solves a flashing of all the "duplicated" dashboard items.
+        !this.props.visualization.id &&
+            this.props.setVisualization(
+                await apiFetchVisualization(this.props.item)
+            )
 
         try {
             if (


### PR DESCRIPTION
Backport, cherry picked from commit d4b3f4ddca037bedff9c1f459fd0fcddb7624cc8

**Fixes: https://dhis2.atlassian.net/browse/DHIS2-17016**

### Key features

1. avoid re-render plugin when the same item is added multiple times

---

### Description

It is possible to add the same dashboard item to a dashboard multiple times.
Probably not a scenario that happens often, but nothing prevents it.
The bug caused a re-render of all the previously added items for the same visualization when in edit mode.
