### PR TITLE
fix: avoid reading from undefined error (DHIS2-17334)

### DIFF
--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -232,8 +232,9 @@ class Item extends Component {
                     }
                     case CHART:
                     case VISUALIZATION: {
-                        return item.visualization.type ===
-                            VIS_TYPE_OUTLIER_TABLE &&
+                        return item.type === VISUALIZATION &&
+                            item.visualization.type ===
+                                VIS_TYPE_OUTLIER_TABLE &&
                             Object.keys(itemFilters).some(
                                 (filter) =>
                                     ![


### PR DESCRIPTION
Fixes [DHIS2-17334](https://dhis2.atlassian.net/browse/DHIS2-17334)

---

### Key features

1. fix read from undefined crash

---

### Description

This happened when using "View as" from Map to DV with some filters applied.
The reason is that `item` in that case is the Map item, and does not have the `visualization` key.
The tag part only make sense when rendering an Outlier table visualization type.
The fix makes sure the `item` is of type `VISUALIZATION` and then checks if the visualization type is an Outlier table one.

---

### Screenshots

Before:
<img width="941" alt="Screenshot 2024-05-03 at 15 26 00" src="https://github.com/dhis2/dashboard-app/assets/150978/7c16f153-7cdc-41da-9566-3494c92b311e">

After:
the leftmost item is a Map one, and can be viewed as Chart even with filters applied
<img width="930" alt="Screenshot 2024-05-03 at 15 26 26" src="https://github.com/dhis2/dashboard-app/assets/150978/119c2309-c516-49f3-b060-8a1bfe028532">

the rightmost item is a Visualization of type Outlier table and should render a tag informing about some filters not applied (Area in the example)
<img width="929" alt="Screenshot 2024-05-03 at 15 26 38" src="https://github.com/dhis2/dashboard-app/assets/150978/3e1e4c74-c8a6-43b5-bac9-467974b1f7ad">



[DHIS2-17334]: https://dhis2.atlassian.net/browse/DHIS2-17334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ