### PR TITLE
fix: fetch visualization always when caching (DHIS2-17509)

### DIFF
--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -114,6 +114,15 @@ class Item extends Component {
         this.setState({ configLoaded: true })
     }
 
+    componentDidUpdate(prevProps) {
+        if (
+            this.props.isRecording &&
+            this.props.isRecording !== prevProps.isRecording
+        ) {
+            apiFetchVisualization(this.props.item)
+        }
+    }
+
     isFullscreenSupported = () => {
         const el = getGridItemElement(this.props.item.id)
         return !!(el?.requestFullscreen || el?.webkitRequestFullscreen)
@@ -322,6 +331,7 @@ Item.propTypes = {
     dashboardMode: PropTypes.string,
     gridWidth: PropTypes.number,
     isEditing: PropTypes.bool,
+    isRecording: PropTypes.bool,
     item: PropTypes.object,
     itemFilters: PropTypes.object,
     setActiveType: PropTypes.func,

--- a/src/pages/view/ItemGrid.js
+++ b/src/pages/view/ItemGrid.js
@@ -109,6 +109,7 @@ const ResponsiveItemGrid = ({ dashboardId, dashboardItems }) => {
                     item={item}
                     gridWidth={gridWidth}
                     dashboardMode={VIEW}
+                    isRecording={forceLoad}
                     onToggleItemExpanded={onToggleItemExpanded}
                 />
             </ProgressiveLoadingContainer>


### PR DESCRIPTION
Implements [DHIS2-17509](https://dhis2.atlassian.net/browse/DHIS2-17509)

---

### Key features

1. fix regression with offline caching

---

### Description

A [previous fix](https://github.com/dhis2/dashboard-app/pull/2935/commits/d4b3f4ddca037bedff9c1f459fd0fcddb7624cc8) for an item flashing issue caused the offline cache to lack the request for the visualization.
The fix looks at the recording state and triggers a fetch that can be recorded.
The affected version of Dashboard app is [v100.2.2](https://github.com/dhis2/dashboard-app/compare/v100.2.1...v100.2.2).

---

### Screenshots

Before, the cache is missing the request for `visualizations`:

<img width="1007" alt="Screenshot 2024-05-31 at 15 59 21" src="https://github.com/dhis2/dashboard-app/assets/150978/a2c5abea-6240-45d1-bbd7-52ccb33d37f8">

After the cache has an entry for the `visualizations` request:

<img width="1019" alt="Screenshot 2024-05-31 at 15 57 02" src="https://github.com/dhis2/dashboard-app/assets/150978/fdb88720-3eaa-4d20-9a3e-2cb9d42f828b">


[DHIS2-17509]: https://dhis2.atlassian.net/browse/DHIS2-17509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ