### PR TITLE
fix: fetch visualization always when caching (DHIS2-175009) v39

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "license": "BSD-3-Clause",
     "dependencies": {
-        "@dhis2/analytics": "^26.0.16",
+        "@dhis2/analytics": "^24",
         "@dhis2/app-runtime": "^3.9.3",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/d2-i18n": "^1.1.1",
@@ -13,7 +13,7 @@
         "@dhis2/d2-ui-interpretations": "^7.4.1",
         "@dhis2/d2-ui-mentions-wrapper": "^7.4.1",
         "@dhis2/d2-ui-rich-text": "^7.4.1",
-        "@dhis2/data-visualizer-plugin": "^39.2.29",
+        "@dhis2/data-visualizer-plugin": "^39.2.33",
         "@dhis2/ui": "^8.12.4",
         "@krakenjs/post-robot": "^11.0.0",
         "classnames": "^2.3.2",

--- a/src/components/Item/VisualizationItem/Item.js
+++ b/src/components/Item/VisualizationItem/Item.js
@@ -107,6 +107,15 @@ class Item extends Component {
         this.setState({ configLoaded: true })
     }
 
+    componentDidUpdate(prevProps) {
+        if (
+            this.props.isRecording &&
+            this.props.isRecording !== prevProps.isRecording
+        ) {
+            apiFetchVisualization(this.props.item)
+        }
+    }
+
     isFullscreenSupported = () => {
         const el = getGridItemElement(this.props.item.id)
         return !!(el?.requestFullscreen || el?.webkitRequestFullscreen)
@@ -284,6 +293,7 @@ Item.propTypes = {
     dashboardMode: PropTypes.string,
     gridWidth: PropTypes.number,
     isEditing: PropTypes.bool,
+    isRecording: PropTypes.bool,
     item: PropTypes.object,
     itemFilters: PropTypes.object,
     setActiveType: PropTypes.func,

--- a/src/pages/view/ItemGrid.js
+++ b/src/pages/view/ItemGrid.js
@@ -109,6 +109,7 @@ const ResponsiveItemGrid = ({ dashboardId, dashboardItems }) => {
                     item={item}
                     gridWidth={gridWidth}
                     dashboardMode={VIEW}
+                    isRecording={forceLoad}
                     onToggleItemExpanded={onToggleItemExpanded}
                 />
             </ProgressiveLoadingContainer>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2153,35 +2153,14 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^24.10.8":
-  version "24.10.8"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-24.10.8.tgz#7339f1fd565a0fe503c6c49643e20b9b4b40c860"
-  integrity sha512-6Bk9LrTC2urHZqJBVyNWgNY9QgImJ4G8IsYNPHVo59zWPbuCJ/363l1DCL+MZU0PxcIafTGAjUImvK6EDGMYkg==
+"@dhis2/analytics@^24":
+  version "24.10.9"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-24.10.9.tgz#9de0f16664693c0c45354d2522444c186606718e"
+  integrity sha512-6GpE1wHNzZ1XE0pBa/sbthFiNLnsA8NUxutUiip0mIlbqshJw8Da0JMszDz+CF4JYU1lg1lcSkrhBWSM4vpDBQ==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^7.4.0"
     "@dhis2/multi-calendar-dates" "1.0.0"
     classnames "^2.3.1"
-    d2-utilizr "^0.2.16"
-    d3-color "^1.2.3"
-    highcharts "^10.3.3"
-    lodash "^4.17.21"
-    mathjs "^9.4.2"
-    react-beautiful-dnd "^10.1.1"
-    resize-observer-polyfill "^1.5.1"
-
-"@dhis2/analytics@^26.0.16":
-  version "26.0.16"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-26.0.16.tgz#e283edd13797af2a3d5303ae7995a462f8b8af49"
-  integrity sha512-d5+VORl564sl4erdbf5tCyjnqqvDaI7SuNoiqUAqKdaCn+9N74nGOZQU45G6h8UEPA1AAYZbcRdNHNXUHN07gQ==
-  dependencies:
-    "@dhis2/d2-ui-rich-text" "^7.4.1"
-    "@dhis2/multi-calendar-dates" "1.0.0"
-    "@dnd-kit/core" "^6.0.7"
-    "@dnd-kit/sortable" "^7.0.2"
-    "@dnd-kit/utilities" "^3.2.1"
-    "@react-hook/debounce" "^4.0.0"
-    classnames "^2.3.1"
-    crypto-js "^4.1.1"
     d2-utilizr "^0.2.16"
     d3-color "^1.2.3"
     highcharts "^10.3.3"
@@ -2455,12 +2434,12 @@
     recompose "^0.26.0"
     rxjs "^5.5.7"
 
-"@dhis2/data-visualizer-plugin@^39.2.29":
-  version "39.2.29"
-  resolved "https://registry.yarnpkg.com/@dhis2/data-visualizer-plugin/-/data-visualizer-plugin-39.2.29.tgz#77c7068e89dc94afc5426cadd83a91689ed018eb"
-  integrity sha512-K70P9qElfVI7EFJLOVJXfduOeOMYtMPRyuVJisTtsGoQxko+2FRs5q21QF+1CmaRc2fUEcGwUw0IBE0YequkQg==
+"@dhis2/data-visualizer-plugin@^39.2.33":
+  version "39.2.33"
+  resolved "https://registry.yarnpkg.com/@dhis2/data-visualizer-plugin/-/data-visualizer-plugin-39.2.33.tgz#bfccc31c6331eda8a3ef878cf20fbe8305a18edc"
+  integrity sha512-yISbOR46VjuTYPhjzyxdo2IARUBf3fPbMcqFiptEGYWCRT0JjGXGpodoyXE1hQaj2dUPi0fyIoptHlW3vKzsfA==
   dependencies:
-    "@dhis2/analytics" "^24.10.8"
+    "@dhis2/analytics" "^24"
     "@dhis2/app-runtime" "^3.9.0"
     "@dhis2/d2-i18n" "^1.1.0"
     "@dhis2/ui" "^8.4.11"
@@ -2585,37 +2564,6 @@
     "@dhis2/ui-forms" "8.13.0"
     "@dhis2/ui-icons" "8.13.0"
     prop-types "^15.7.2"
-
-"@dnd-kit/accessibility@^3.0.0":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@dnd-kit/accessibility/-/accessibility-3.0.1.tgz#3ccbefdfca595b0a23a5dc57d3de96bc6935641c"
-  integrity sha512-HXRrwS9YUYQO9lFRc/49uO/VICbM+O+ZRpFDe9Pd1rwVv2PCNkRiTZRdxrDgng/UkvdC3Re9r2vwPpXXrWeFzg==
-  dependencies:
-    tslib "^2.0.0"
-
-"@dnd-kit/core@^6.0.7":
-  version "6.0.8"
-  resolved "https://registry.yarnpkg.com/@dnd-kit/core/-/core-6.0.8.tgz#040ae13fea9787ee078e5f0361f3b49b07f3f005"
-  integrity sha512-lYaoP8yHTQSLlZe6Rr9qogouGUz9oRUj4AHhDQGQzq/hqaJRpFo65X+JKsdHf8oUFBzx5A+SJPUvxAwTF2OabA==
-  dependencies:
-    "@dnd-kit/accessibility" "^3.0.0"
-    "@dnd-kit/utilities" "^3.2.1"
-    tslib "^2.0.0"
-
-"@dnd-kit/sortable@^7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@dnd-kit/sortable/-/sortable-7.0.2.tgz#791d550872457f3f3c843e00d159b640f982011c"
-  integrity sha512-wDkBHHf9iCi1veM834Gbk1429bd4lHX4RpAwT0y2cHLf246GAvU2sVw/oxWNpPKQNQRQaeGXhAVgrOl1IT+iyA==
-  dependencies:
-    "@dnd-kit/utilities" "^3.2.0"
-    tslib "^2.0.0"
-
-"@dnd-kit/utilities@^3.2.0", "@dnd-kit/utilities@^3.2.1":
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/@dnd-kit/utilities/-/utilities-3.2.1.tgz#53f9e2016fd2506ec49e404c289392cfff30332a"
-  integrity sha512-OOXqISfvBw/1REtkSK2N3Fi2EQiLMlWUlqnOK/UpOISqBZPWpE6TqL+jcPtMOkE8TqYGiURvRdPSI9hltNUjEA==
-  dependencies:
-    tslib "^2.0.0"
 
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
@@ -3154,13 +3102,6 @@
   version "2.11.6"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
   integrity sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==
-
-"@react-hook/debounce@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@react-hook/debounce/-/debounce-4.0.0.tgz#5da87e7bfa158cfe2830ffc997dc1b755e261379"
-  integrity sha512-706Xcg+KKWHk9BuZQUQ0ZQKp9zhv3/MbqFenWVfHcynYpSGRVwQTzJRGvPxvsdtXxJv+HfgKTY/O/hEejakwmA==
-  dependencies:
-    "@react-hook/latest" "^1.0.2"
 
 "@react-hook/latest@^1.0.2":
   version "1.0.3"
@@ -6263,11 +6204,6 @@ crypto-browserify@^3.0.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
     randomfill "^1.0.3"
-
-crypto-js@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.1.1.tgz#9e485bcf03521041bd85844786b83fb7619736cf"
-  integrity sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==
 
 crypto-random-string@^1.0.0:
   version "1.0.0"
@@ -15593,11 +15529,6 @@ tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tslib@^2.0.0:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
-  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
 tslib@^2.0.1, tslib@^2.0.3, tslib@^2.3.1:
   version "2.5.0"


### PR DESCRIPTION
Fixes [DHIS2-17509](https://dhis2.atlassian.net/browse/DHIS2-17509)

---

### Key features

1. backport of #2986 
2. backport fix for misaligned numbers in PT (DHIS2-16900)

---

### Description

A previous fix for an item flashing issue caused the offline cache to lack the request for the visualizations.
The fix looks at the recording state and triggers a fetch that can be recorded.

(cherry picked from commit c1201fa46dfbb8ee524dbc1087bad9f45bc22c65)

[DHIS2-17509]: https://dhis2.atlassian.net/browse/DHIS2-17509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ