### PR TITLE
fix: separator for hundreds, thousands and millions is missing in the Pie charts (DHIS2-16172) v39

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "license": "BSD-3-Clause",
     "dependencies": {
-        "@dhis2/analytics": "^24",
+        "@dhis2/analytics": "^24.10.10",
         "@dhis2/app-runtime": "^3.9.3",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/d2-i18n": "^1.1.1",
@@ -13,7 +13,7 @@
         "@dhis2/d2-ui-interpretations": "^7.4.1",
         "@dhis2/d2-ui-mentions-wrapper": "^7.4.1",
         "@dhis2/d2-ui-rich-text": "^7.4.1",
-        "@dhis2/data-visualizer-plugin": "^39.2.33",
+        "@dhis2/data-visualizer-plugin": "^39.2.35",
         "@dhis2/ui": "^8.12.4",
         "@krakenjs/post-robot": "^11.0.0",
         "classnames": "^2.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2153,10 +2153,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^24":
-  version "24.10.9"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-24.10.9.tgz#9de0f16664693c0c45354d2522444c186606718e"
-  integrity sha512-6GpE1wHNzZ1XE0pBa/sbthFiNLnsA8NUxutUiip0mIlbqshJw8Da0JMszDz+CF4JYU1lg1lcSkrhBWSM4vpDBQ==
+"@dhis2/analytics@^24.10.10":
+  version "24.10.10"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-24.10.10.tgz#b9d35b9a86afb6634b688eab2f50004f0edeb492"
+  integrity sha512-YNfjUy64eZ9wfepSe/Dr53yYay0tFL8nS+mgwXvU1P2qZM41VDqlvutas5DCNhr2kufCZeD15LC1nQlYQn8Tcg==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^7.4.0"
     "@dhis2/multi-calendar-dates" "1.0.0"
@@ -2434,12 +2434,12 @@
     recompose "^0.26.0"
     rxjs "^5.5.7"
 
-"@dhis2/data-visualizer-plugin@^39.2.33":
-  version "39.2.33"
-  resolved "https://registry.yarnpkg.com/@dhis2/data-visualizer-plugin/-/data-visualizer-plugin-39.2.33.tgz#bfccc31c6331eda8a3ef878cf20fbe8305a18edc"
-  integrity sha512-yISbOR46VjuTYPhjzyxdo2IARUBf3fPbMcqFiptEGYWCRT0JjGXGpodoyXE1hQaj2dUPi0fyIoptHlW3vKzsfA==
+"@dhis2/data-visualizer-plugin@^39.2.35":
+  version "39.2.35"
+  resolved "https://registry.yarnpkg.com/@dhis2/data-visualizer-plugin/-/data-visualizer-plugin-39.2.35.tgz#eaf4b29dc40707b694c22fae7c258968c775746a"
+  integrity sha512-rfWET8rjzwAJp18mjEhnquKfL1UWAohieBqVpWtUnGWQedhagYU0pxdU725RBkOWvESibfLIu++ibv309pUCHQ==
   dependencies:
-    "@dhis2/analytics" "^24"
+    "@dhis2/analytics" "^24.10.10"
     "@dhis2/app-runtime" "^3.9.0"
     "@dhis2/d2-i18n" "^1.1.0"
     "@dhis2/ui" "^8.4.11"


### PR DESCRIPTION
Implements [DHIS2-16172](https://jira.dhis2.org/browse/DHIS2-16172)

Requires https://github.com/dhis2/analytics/pull/1679

Requires https://github.com/dhis2/data-visualizer-app/pull/3094

---

Backport to bump the analytics and dv plugin versions

[DHIS2-16172]: https://dhis2.atlassian.net/browse/DHIS2-16172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ