### PR TITLE
chore: dependabot config and remove dev branch from workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,22 @@
 version: 2
 updates:
     - package-ecosystem: npm
-      directory: '/'
+      directory: /
       schedule:
           interval: weekly
-      open-pull-requests-limit: 10
+      open-pull-requests-limit: 5
       versioning-strategy: increase
+      groups:
+          security:
+              applies-to: security-updates
+              update-types:
+                  - minor
+                  - patch
+          dependencies:
+              applies-to: version-updates
+              update-types:
+                  - minor
+                  - patch
+              exclude-patterns:
+                  - '*@dhis2*'
+                  - '*i18next*'

--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -6,7 +6,6 @@ on:
     push:
         branches:
             - 'master'
-            - 'dev'
         tags:
             - '*'
 

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,4 +1,6 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn d2-style check --staged
+yarn d2-app-scripts i18n extract && \
+    git add i18n && \
+    yarn d2-style check --staged


### PR DESCRIPTION
Three changes:
1. do not run the git verify-app workflow on the 'dev' branch since it is no longer in use
2. configure dependabot to group together deps, reducing number of PRs and workflow runs.
3. add localization strings to commit in the pre-commit hook (this is how LL does it)

dhis2 dependencies will still come as separate PRs (like analytics, ui, cli-app-scripts...)