### PR TITLE
chore: add workflow for dependency-track

### DIFF
--- a/.github/workflows/generate-and-upload-bom.yml
+++ b/.github/workflows/generate-and-upload-bom.yml
@@ -1,0 +1,49 @@
+name: 'This workflow creates bill of material and uploads it to Dependency-Track each night'
+
+on:
+    schedule:
+        - cron: '0 0 * * *'
+    workflow_dispatch:
+
+concurrency:
+    group: ${{ github.workflow}}-${{ github.ref }}
+    cancel-in-progress: true
+
+defaults:
+    run:
+        shell: bash
+
+jobs:
+    create-bom:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 18.x
+
+            - name: Install
+              run: yarn install --frozen-lockfile
+
+            - name: Install CycloneDX CLI
+              run: |
+                  curl -s https://api.github.com/repos/CycloneDX/cyclonedx-cli/releases/latest | grep "browser_download_url.*linux.x64" | cut -d '"' -f 4 | wget -i -
+                  sudo mv cyclonedx-linux-x64 /usr/local/bin/
+                  sudo chmod +x /usr/local/bin/cyclonedx-linux-x64
+
+            - name: Generate BOMs
+              run: |
+                  npm install -g @cyclonedx/cdxgen
+                  cdxgen -o sbom.json
+
+            - name: Upload SBOM to DependencyTrack
+              env:
+                  DEPENDENCY_TRACK_API: 'https://dt.security.dhis2.org/api/v1/bom'
+              run: |
+                  curl -X POST "$DEPENDENCY_TRACK_API" \
+                      --fail-with-body \
+                      -H "Content-Type: multipart/form-data" \
+                      -H "X-Api-Key: ${{ secrets.DEPENDENCYTRACK_APIKEY }}" \
+                      -F "project=c0bd0f2d-d512-460a-81f9-e256e4fb1054" \
+                      -F "bom=@sbom.json"


### PR DESCRIPTION
Implements [SEC-60](https://dhis2.atlassian.net/browse/SEC-60)

---

### Key features

1. Integration of Static Analysis Security Scanning Tool: Dependency Track: https://dtrack.security.dhis2.org/projects
2. Running every night so it won't bother Developers 

---

### Description

Dependency Track will scan the created SBOM and analyze for CVEs and open vulnerabilities.
Those reports will be evaluated by the security team and will be brought back to the dev teams if something crucial pops up

---



[SEC-60]: https://dhis2.atlassian.net/browse/SEC-60?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ