### PR TITLE
feat: fetch superset base url with system settings

### DIFF
--- a/src/api/superSetGateway.js
+++ b/src/api/superSetGateway.js
@@ -1,15 +1,20 @@
 import { useConfig } from '@dhis2/app-service-config'
+import { useCallback, useMemo } from 'react'
 
 export const useFetchSuperSetBaseUrl = () => {
     const { baseUrl } = useConfig()
-    const url = new URL(
-        'superset-gateway/api/info',
-        baseUrl === '..'
-            ? window.location.href.split('dhis-web-dashboard/')[0]
-            : `${baseUrl}/`
-    )?.href
+    const url = useMemo(
+        () =>
+            new URL(
+                'superset-gateway/api/info',
+                baseUrl === '..'
+                    ? window.location.href.split('dhis-web-dashboard/')[0]
+                    : `${baseUrl}/`
+            )?.href,
+        [baseUrl]
+    )
 
-    return async () => {
+    const fetchSuperSetBaseUrl = useCallback(async () => {
         const response = await fetch(url)
         if (!response.ok) {
             throw new Error(`Response status: ${response.status}`)
@@ -17,5 +22,7 @@ export const useFetchSuperSetBaseUrl = () => {
 
         const data = await response.json()
         return data.supersetBaseUrl
-    }
+    }, [url])
+
+    return fetchSuperSetBaseUrl
 }

--- a/src/api/superSetGateway.js
+++ b/src/api/superSetGateway.js
@@ -1,0 +1,21 @@
+import { useConfig } from '@dhis2/app-service-config'
+
+export const useFetchSuperSetBaseUrl = () => {
+    const { baseUrl } = useConfig()
+    const url = new URL(
+        'superset-gateway/api/info',
+        baseUrl === '..'
+            ? window.location.href.split('dhis-web-dashboard/')[0]
+            : `${baseUrl}/`
+    )?.href
+
+    return async () => {
+        const response = await fetch(url)
+        if (!response.ok) {
+            throw new Error(`Response status: ${response.status}`)
+        }
+
+        const data = await response.json()
+        return data.supersetBaseUrl
+    }
+}

--- a/src/api/supersetGateway.js
+++ b/src/api/supersetGateway.js
@@ -17,7 +17,9 @@ export const useFetchSupersetBaseUrl = () => {
     const fetchSupersetBaseUrl = useCallback(async () => {
         const response = await fetch(url)
         if (!response.ok) {
-            throw new Error(`Response status: ${response.status}`)
+            throw new Error(
+                `Could not fetch info from the superset gateway: STATUS ${response.status}`
+            )
         }
 
         const data = await response.json()

--- a/src/api/supersetGateway.js
+++ b/src/api/supersetGateway.js
@@ -1,7 +1,7 @@
 import { useConfig } from '@dhis2/app-service-config'
 import { useCallback, useMemo } from 'react'
 
-export const useFetchSuperSetBaseUrl = () => {
+export const useFetchSupersetBaseUrl = () => {
     const { baseUrl } = useConfig()
     const url = useMemo(
         () =>
@@ -14,7 +14,7 @@ export const useFetchSuperSetBaseUrl = () => {
         [baseUrl]
     )
 
-    const fetchSuperSetBaseUrl = useCallback(async () => {
+    const fetchSupersetBaseUrl = useCallback(async () => {
         const response = await fetch(url)
         if (!response.ok) {
             throw new Error(`Response status: ${response.status}`)
@@ -24,5 +24,5 @@ export const useFetchSuperSetBaseUrl = () => {
         return data.supersetBaseUrl
     }, [url])
 
-    return fetchSuperSetBaseUrl
+    return fetchSupersetBaseUrl
 }

--- a/src/api/systemSettings.js
+++ b/src/api/systemSettings.js
@@ -19,6 +19,7 @@ const SYSTEM_SETTINGS = [
     'keyHideWeeklyPeriods',
     'keyHideBiWeeklyPeriods',
     'startModuleEnableLightweight',
+    'keyEmbeddedDashboardsEnabled',
 ]
 
 const SYSTEM_SETTINGS_REMAPPINGS = {
@@ -32,6 +33,7 @@ const SYSTEM_SETTINGS_REMAPPINGS = {
     keyHideMonthlyPeriods: 'hideMonthlyPeriods',
     keyHideWeeklyPeriods: 'hideWeeklyPeriods',
     keyHideBiWeeklyPeriods: 'hideBiWeeklyPeriods',
+    keyEmbeddedDashboardsEnabled: 'embeddedDashboardsEnabled',
 }
 
 export const renameSystemSettings = (settings) => {

--- a/src/components/SystemSettingsProvider.js
+++ b/src/components/SystemSettingsProvider.js
@@ -1,6 +1,7 @@
 import { useDataEngine } from '@dhis2/app-runtime'
 import PropTypes from 'prop-types'
 import React, { useContext, useState, useEffect, createContext } from 'react'
+import { useFetchSuperSetBaseUrl } from '../api/superSetGateway.js'
 import {
     systemSettingsQuery,
     renameSystemSettings,
@@ -12,6 +13,7 @@ export const SystemSettingsCtx = createContext({})
 const SystemSettingsProvider = ({ children }) => {
     const [settings, setSettings] = useState(null)
     const engine = useDataEngine()
+    const fetchSuperSetBaseUrl = useFetchSuperSetBaseUrl()
 
     useEffect(() => {
         async function fetchData() {
@@ -26,14 +28,16 @@ const SystemSettingsProvider = ({ children }) => {
                     },
                 }
             )
+            const resolvedSystemSettings = {
+                ...renameSystemSettings(DEFAULT_SETTINGS),
+                ...renameSystemSettings(systemSettings),
+            }
+            if (resolvedSystemSettings.embeddedDashboardsEnabled) {
+                resolvedSystemSettings.supersetBaseUrl =
+                    await fetchSuperSetBaseUrl()
+            }
 
-            setSettings(
-                Object.assign(
-                    {},
-                    renameSystemSettings(DEFAULT_SETTINGS),
-                    renameSystemSettings(systemSettings)
-                )
-            )
+            setSettings(resolvedSystemSettings)
         }
         fetchData()
     }, [])

--- a/src/components/SystemSettingsProvider.js
+++ b/src/components/SystemSettingsProvider.js
@@ -40,7 +40,7 @@ const SystemSettingsProvider = ({ children }) => {
             setSettings(resolvedSystemSettings)
         }
         fetchData()
-    }, [])
+    }, [engine, fetchSuperSetBaseUrl])
 
     return (
         <SystemSettingsCtx.Provider

--- a/src/components/SystemSettingsProvider.js
+++ b/src/components/SystemSettingsProvider.js
@@ -1,7 +1,7 @@
 import { useDataEngine } from '@dhis2/app-runtime'
 import PropTypes from 'prop-types'
 import React, { useContext, useState, useEffect, createContext } from 'react'
-import { useFetchSuperSetBaseUrl } from '../api/superSetGateway.js'
+import { useFetchSupersetBaseUrl } from '../api/supersetGateway.js'
 import {
     systemSettingsQuery,
     renameSystemSettings,
@@ -13,7 +13,7 @@ export const SystemSettingsCtx = createContext({})
 const SystemSettingsProvider = ({ children }) => {
     const [settings, setSettings] = useState(null)
     const engine = useDataEngine()
-    const fetchSuperSetBaseUrl = useFetchSuperSetBaseUrl()
+    const fetchSupersetBaseUrl = useFetchSupersetBaseUrl()
 
     useEffect(() => {
         async function fetchData() {
@@ -34,13 +34,13 @@ const SystemSettingsProvider = ({ children }) => {
             }
             if (resolvedSystemSettings.embeddedDashboardsEnabled) {
                 resolvedSystemSettings.supersetBaseUrl =
-                    await fetchSuperSetBaseUrl()
+                    await fetchSupersetBaseUrl()
             }
 
             setSettings(resolvedSystemSettings)
         }
         fetchData()
-    }, [engine, fetchSuperSetBaseUrl])
+    }, [engine, fetchSupersetBaseUrl])
 
     return (
         <SystemSettingsCtx.Provider
@@ -60,7 +60,7 @@ SystemSettingsProvider.propTypes = {
 export default SystemSettingsProvider
 
 export const useSystemSettings = () => useContext(SystemSettingsCtx)
-export const useHasSuperSetSupport = () => {
+export const useHasSupersetSupport = () => {
     const { embeddedDashboardsEnabled, supersetBaseUrl } = useSystemSettings()
     return embeddedDashboardsEnabled && !!supersetBaseUrl
 }

--- a/src/components/SystemSettingsProvider.js
+++ b/src/components/SystemSettingsProvider.js
@@ -60,3 +60,11 @@ SystemSettingsProvider.propTypes = {
 export default SystemSettingsProvider
 
 export const useSystemSettings = () => useContext(SystemSettingsCtx)
+export const useHasSuperSetSupport = () => {
+    const { embeddedDashboardsEnabled, supersetBaseUrl } = useSystemSettings()
+    return embeddedDashboardsEnabled && !!supersetBaseUrl
+}
+export const useSupersetBaseUrl = () => {
+    const { supersetBaseUrl } = useSystemSettings()
+    return supersetBaseUrl ?? null
+}


### PR DESCRIPTION
In this PR I fetch `keyEmbeddedDashboardsEnabled` when I fetch the system settings and if `true` I also proceed to fetch the `supersetBaseUrl`. I'm doing so using a regular fetch and take into account that in production `baseUrl` could be `..`, which I think could be problematic for the `fetch()`.