### PR TITLE
fix: not possible to see more or search for App items when creating dashboard

### DIFF
--- a/src/modules/itemTypes.js
+++ b/src/modules/itemTypes.js
@@ -145,6 +145,7 @@ export const itemTypeMap = {
         supportsFullscreen: true,
     },
     [APP]: {
+        id: APP,
         endPointName: 'apps',
         propName: 'appKey',
         pluralTitle: i18n.t('Apps'),

--- a/src/pages/edit/ItemSelector/ItemSelector.js
+++ b/src/pages/edit/ItemSelector/ItemSelector.js
@@ -59,7 +59,7 @@ const ItemSelector = () => {
                 const itemCount = getDefaultItemCount(type)
                 const allItems = items[itemType.endPointName]
                 const hasMore = allItems.length > itemCount
-                const displayItems = maxOptions.has(itemType.id)
+                const displayItems = maxOptions.has(type)
                     ? allItems
                     : allItems.slice(0, itemCount)
 


### PR DESCRIPTION
Fixes [DHIS2-18835](https://dhis2.atlassian.net/browse/DHIS2-18835)

Fix: the Item selector list is populated based on the item type, but for some reason the code for setting which types should "Show more" was using itemType.id, which APP lacked. Now, it will consistently check the `type` rather than `id`. But also, the `id` property for APP was added to the `itemTypes` object, for code consistency.

- [ ] Test "Show More" and search for all types


https://github.com/user-attachments/assets/71cee91f-bdea-481b-a12f-8b3082a4e021


https://github.com/user-attachments/assets/545b837b-e33e-402e-a157-d19091df37bd



[DHIS2-18835]: https://dhis2.atlassian.net/browse/DHIS2-18835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ