### PR TITLE
fix: not possible to see more or search for App items when creating dashboard [v39]

### DIFF
--- a/src/modules/itemTypes.js
+++ b/src/modules/itemTypes.js
@@ -137,6 +137,7 @@ export const itemTypeMap = {
         appKey: 'line-listing',
     },
     [APP]: {
+        id: APP,
         endPointName: 'apps',
         propName: 'appKey',
         pluralTitle: i18n.t('Apps'),

--- a/src/pages/edit/ItemSelector/ItemSelector.js
+++ b/src/pages/edit/ItemSelector/ItemSelector.js
@@ -59,7 +59,7 @@ const ItemSelector = () => {
                 const itemCount = getDefaultItemCount(type)
                 const allItems = items[itemType.endPointName]
                 const hasMore = allItems.length > itemCount
-                const displayItems = maxOptions.has(itemType.id)
+                const displayItems = maxOptions.has(type)
                     ? allItems
                     : allItems.slice(0, itemCount)
 


### PR DESCRIPTION
Fixes [DHIS2-18835](https://dhis2.atlassian.net/browse/DHIS2-18835)

Backport of https://github.com/dhis2/dashboard-app/pull/3186


[DHIS2-18835]: https://dhis2.atlassian.net/browse/DHIS2-18835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ