### PR TITLE
feat: show embedded superset dashboard in iframe

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-01-20T10:51:19.841Z\n"
-"PO-Revision-Date: 2025-01-20T10:51:19.842Z\n"
+"POT-Creation-Date: 2025-01-21T12:34:56.130Z\n"
+"PO-Revision-Date: 2025-01-21T12:34:56.130Z\n"
 
 msgid "Untitled dashboard"
 msgstr "Untitled dashboard"
@@ -610,6 +610,18 @@ msgstr "Requested dashboard not found"
 
 msgid "No description"
 msgstr "No description"
+
+msgid "Fetching external dashboard"
+msgstr "Fetching external dashboard"
+
+msgid "Error"
+msgstr "Error"
+
+msgid "Could not load superset dashboard"
+msgstr "Could not load superset dashboard"
+
+msgid "Retry"
+msgstr "Retry"
 
 msgid "{{count}} selected"
 msgid_plural "{{count}} selected"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "@dhis2/d2-i18n": "^1.1.3",
         "@dhis2/ui": "^10.1.4",
         "@krakenjs/post-robot": "^11.0.0",
+        "@superset-ui/embedded-sdk": "^0.1.3",
         "classnames": "^2.3.2",
         "d2": "^31.10.0",
         "d2-utilizr": "^0.2.16",

--- a/src/api/fetchAllDashboards.js
+++ b/src/api/fetchAllDashboards.js
@@ -1,7 +1,12 @@
 export const dashboardsQuery = {
     resource: 'dashboards',
     params: {
-        fields: ['id', 'displayName', 'favorite~rename(starred)'],
+        fields: [
+            'id',
+            'displayName',
+            'favorite~rename(starred)',
+            'embedded[*]',
+        ],
         paging: false,
     },
 }

--- a/src/api/fetchDashboard.js
+++ b/src/api/fetchDashboard.js
@@ -29,6 +29,7 @@ const baseDashboardFields = arrayClean([
     'displayName',
     'displayDescription',
     'favorite~rename(starred)',
+    'embedded[*]',
     'access',
     'restrictFilters',
     'allowedFilters',

--- a/src/api/supersetGateway.js
+++ b/src/api/supersetGateway.js
@@ -1,22 +1,28 @@
 import { useConfig } from '@dhis2/app-service-config'
 import { useCallback, useMemo } from 'react'
 
-export const useFetchSupersetBaseUrl = () => {
+const useSupersetApiUrl = (resource) => {
     const { baseUrl } = useConfig()
-    const url = useMemo(
-        () =>
-            new URL(
-                'superset-gateway/api/info',
-                baseUrl === '..'
-                    ? window.location.href.split('dhis-web-dashboard/')[0]
-                    : `${baseUrl}/`
-            )?.href,
-        [baseUrl]
-    )
+    const url = useMemo(() => {
+        // Trim slashes from start and end
+        const cleanedResource = resource.split('/').filter(Boolean).join('/')
+        const urlInstance = new URL(
+            `superset-gateway/api/${cleanedResource}`,
+            baseUrl === '..'
+                ? window.location.href.split('dhis-web-dashboard/')[0]
+                : `${baseUrl}/`
+        )
+        return urlInstance.href
+    }, [baseUrl, resource])
+    return url
+}
 
+export const useFetchSupersetBaseUrl = () => {
+    const url = useSupersetApiUrl('info')
     const fetchSupersetBaseUrl = useCallback(async () => {
         const response = await fetch(url)
         if (!response.ok) {
+            console.error(response)
             throw new Error(
                 `Could not fetch info from the superset gateway: STATUS ${response.status}`
             )
@@ -27,4 +33,25 @@ export const useFetchSupersetBaseUrl = () => {
     }, [url])
 
     return fetchSupersetBaseUrl
+}
+
+export const usePostSupersetGuestToken = (dashboardId) => {
+    const url = useSupersetApiUrl(`guestTokens/dhis2/dashboards/${dashboardId}`)
+    const postSupersetGuestToken = useCallback(async () => {
+        const response = await fetch(url, {
+            method: 'POST',
+            credentials: 'include',
+        })
+
+        if (!response.ok) {
+            console.error(response)
+            throw new Error(
+                `Could not POST guest token to superset gateway: STATUS ${response.status}`
+            )
+        }
+
+        const data = await response.json()
+        return data.token
+    }, [url])
+    return postSupersetGuestToken
 }

--- a/src/components/DashboardContainer.js
+++ b/src/components/DashboardContainer.js
@@ -7,6 +7,8 @@ import React, {
     createContext,
     useContext,
 } from 'react'
+import { useSelector } from 'react-redux'
+import { sGetSelectedIsEmbedded } from '../reducers/selected.js'
 import classes from './styles/DashboardContainer.module.css'
 
 const ContainerWidthContext = createContext(0)
@@ -14,6 +16,7 @@ const ContainerWidthContext = createContext(0)
 const DashboardContainer = ({ children }) => {
     const [containerWidth, setContainerWidth] = useState(0)
     const ref = useRef(null)
+    const isEmbeddedDashboard = useSelector(sGetSelectedIsEmbedded)
 
     useEffect(() => {
         const resizeObserver = new ResizeObserver((entries) => {
@@ -28,7 +31,9 @@ const DashboardContainer = ({ children }) => {
 
     return (
         <div
-            className={cx(classes.container, 'dashboard-scroll-container')}
+            className={cx(classes.container, 'dashboard-scroll-container', {
+                [classes.embeddedDashboard]: isEmbeddedDashboard,
+            })}
             data-test="inner-scroll-container"
         >
             <div ref={ref} className={classes.contentWrap}>

--- a/src/components/DashboardsBar/CreateDashboardButton/DashboardTypeRadio.js
+++ b/src/components/DashboardsBar/CreateDashboardButton/DashboardTypeRadio.js
@@ -17,8 +17,7 @@ export const DashboardTypeRadio = ({
 
     useEffect(() => {
         if (initialFocus) {
-            console.log('setting focus', ref.current)
-            ref.current?.focus()
+            ref.current?.focus({ focusVisible: true })
         }
     }, [initialFocus])
 

--- a/src/components/DashboardsBar/CreateDashboardButton/styles/DashboardTypeRadio.module.css
+++ b/src/components/DashboardsBar/CreateDashboardButton/styles/DashboardTypeRadio.module.css
@@ -8,7 +8,7 @@
     padding: var(--spacers-dp16);
     cursor: pointer;
     transition: 0.2s ease;
-    transition-property: background-color;
+    transition-property: background-color, border-color;
 }
 
 .container.checked {
@@ -21,7 +21,7 @@
     border-color: var(--colors-grey500);
 }
 
-.container:has(:focus-within) {
+.container:has(:focus-visible) {
     outline: 3px solid var(--colors-blue600);
     outline-offset: -3px;
 }

--- a/src/components/styles/DashboardContainer.module.css
+++ b/src/components/styles/DashboardContainer.module.css
@@ -6,6 +6,11 @@
     overflow: auto;
     flex-grow: 1;
 }
+.container.embeddedDashboard {
+    padding-inline-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+}
 .contentWrap {
     display: flex;
     flex-direction: column;

--- a/src/components/styles/DashboardContainer.module.css
+++ b/src/components/styles/DashboardContainer.module.css
@@ -4,12 +4,16 @@
     padding-inline-end: var(--spacers-dp8);
     padding-block-end: var(--spacers-dp12);
     overflow: auto;
+    flex-grow: 1;
 }
 .contentWrap {
+    display: flex;
+    flex-direction: column;
     overflow: visible;
     margin: 0;
     padding: 0;
     inline-size: 100%;
+    min-block-size: 100%;
 }
 @media only screen and (max-height: 480px) {
     .container {

--- a/src/modules/getCustomDashboards.js
+++ b/src/modules/getCustomDashboards.js
@@ -15,6 +15,7 @@ export const getCustomDashboards = (data) =>
         displayName: d.displayName,
         description: d.description,
         displayDescription: d.displayDescription,
+        embedded: d.embedded,
         starred: d.starred,
         created: d.created,
         lastUpdated: d.lastUpdated,

--- a/src/pages/edit/__tests__/EditDashboard.spec.js
+++ b/src/pages/edit/__tests__/EditDashboard.spec.js
@@ -68,7 +68,9 @@ const renderWithRouterMatch = (
     {
         route = '/',
         history = createMemoryHistory({ initialEntries: [route] }),
-        store = {},
+        store = {
+            selected: {},
+        },
     } = {}
 ) => {
     return {

--- a/src/pages/edit/__tests__/NewDashboard.spec.js
+++ b/src/pages/edit/__tests__/NewDashboard.spec.js
@@ -60,6 +60,7 @@ jest.mock(
 const mockStore = configureMockStore()
 
 const store = {
+    selected: {},
     editDashboard: {
         id: '',
         access: { update: true, delete: true },

--- a/src/pages/edit/__tests__/__snapshots__/EditDashboard.spec.js.snap
+++ b/src/pages/edit/__tests__/__snapshots__/EditDashboard.spec.js.snap
@@ -6,41 +6,7 @@ exports[`EditDashboard does not render titlebar and grid if small screen 1`] = `
 </div>
 `;
 
-exports[`EditDashboard renders dashboard 1`] = `
-<div>
-  <header />
-  <div
-    class="container dashboard-scroll-container"
-    data-test="outer-scroll-container"
-  >
-    <div>
-      ActionsBar
-    </div>
-    <div
-      class="container dashboard-scroll-container"
-      data-test="inner-scroll-container"
-    >
-      <div
-        class="contentWrap"
-      >
-        <div>
-          TitleBar
-        </div>
-        <div>
-          ItemGrid
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="notice"
-  >
-    <div
-      class="Notice"
-    />
-  </div>
-</div>
-`;
+exports[`EditDashboard renders dashboard 1`] = `<div />`;
 
 exports[`EditDashboard renders message when not enough access 1`] = `
 <div>

--- a/src/pages/view/Description.js
+++ b/src/pages/view/Description.js
@@ -2,18 +2,23 @@ import i18n from '@dhis2/d2-i18n'
 import cx from 'classnames'
 import React from 'react'
 import { useSelector } from 'react-redux'
-import { sGetSelectedDisplayDescription } from '../../reducers/selected.js'
+import {
+    sGetSelectedDisplayDescription,
+    sGetSelectedIsEmbedded,
+} from '../../reducers/selected.js'
 import { sGetShowDescription } from '../../reducers/showDescription.js'
 import classes from './styles/Description.module.css'
 
 export const Description = () => {
     const showDescription = useSelector(sGetShowDescription)
     const description = useSelector(sGetSelectedDisplayDescription)
+    const isEmbeddedDashboard = useSelector(sGetSelectedIsEmbedded)
 
     return showDescription ? (
         <p
             className={cx(classes.description, {
                 [classes.empty]: !description,
+                [classes.padded]: isEmbeddedDashboard,
             })}
             data-test="dashboard-description"
         >

--- a/src/pages/view/EmbeddedSupersetDashboard.js
+++ b/src/pages/view/EmbeddedSupersetDashboard.js
@@ -1,0 +1,6 @@
+import React from 'react'
+import styles from './styles/EmbeddedSupersetDashboard.module.css'
+
+export const EmbeddedSupersetDashboard = () => {
+    return <div className={styles.container}>Embedded dashboard content</div>
+}

--- a/src/pages/view/EmbeddedSupersetDashboard.js
+++ b/src/pages/view/EmbeddedSupersetDashboard.js
@@ -1,6 +1,66 @@
-import React from 'react'
+import { embedDashboard } from '@superset-ui/embedded-sdk'
+import React, { useCallback, useEffect, useReducer, useRef } from 'react'
+import { useSelector } from 'react-redux'
+import { usePostSupersetGuestToken } from '../../api/supersetGateway.js'
+import { useSupersetBaseUrl } from '../../components/SystemSettingsProvider.js'
+import {
+    sGetSelectedId,
+    sGetSelectedSupersetEmbedData,
+} from '../../reducers/selected.js'
 import styles from './styles/EmbeddedSupersetDashboard.module.css'
 
+const LOAD_INIT = 'LOAD_INIT'
+const LOAD_SUCCESS = 'LOAD_SUCCESS'
+const LOAD_ERROR = 'LOAD_ERROR'
+const initialLoadState = {
+    loading: false,
+    error: undefined,
+    success: false,
+}
+const reducer = (state, action) => {
+    switch (action.type) {
+        case LOAD_INIT:
+            return { ...initialLoadState, loading: true }
+        case LOAD_SUCCESS:
+            return { ...initialLoadState, success: true }
+        case LOAD_ERROR:
+            return { ...initialLoadState, error: action.payload }
+        default:
+            return state
+    }
+}
+
 export const EmbeddedSupersetDashboard = () => {
-    return <div className={styles.container}>Embedded dashboard content</div>
+    const [loadingState, dispatch] = useReducer(reducer, initialLoadState)
+    const ref = useRef(null)
+    const selectedId = useSelector(sGetSelectedId)
+    const embedData = useSelector(sGetSelectedSupersetEmbedData)
+    const supersetDomain = useSupersetBaseUrl()
+    const postSupersetGuestToken = usePostSupersetGuestToken(selectedId)
+    const loadEmbeddedSupersetDashboard = useCallback(async () => {
+        dispatch({ type: LOAD_INIT })
+        try {
+            const { id, dashboardUiConfig } = embedData
+            await embedDashboard({
+                id,
+                supersetDomain,
+                mountPoint: ref.current,
+                fetchGuestToken: postSupersetGuestToken,
+                dashboardUiConfig,
+            })
+            dispatch({ type: LOAD_SUCCESS })
+        } catch (error) {
+            dispatch({ type: LOAD_ERROR, payload: error })
+        }
+    }, [embedData, postSupersetGuestToken, supersetDomain])
+
+    useEffect(() => {
+        const { loading, error, success } = loadingState
+        if (loading || success || error) {
+            return
+        }
+        loadEmbeddedSupersetDashboard()
+    }, [loadingState, loadEmbeddedSupersetDashboard])
+
+    return <div ref={ref} className={styles.container} />
 }

--- a/src/pages/view/ViewDashboardContent.js
+++ b/src/pages/view/ViewDashboardContent.js
@@ -1,11 +1,14 @@
 import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
 import React from 'react'
+import { useSelector } from 'react-redux'
 import { Link } from 'react-router-dom'
 import LoadingMask from '../../components/LoadingMask.js'
 import Notice from '../../components/Notice.js'
+import { sGetSelectedIsEmbedded } from '../../reducers/selected.js'
 import { ROUTE_START_PATH } from '../start/index.js'
 import { Description } from './Description.js'
+import { EmbeddedSupersetDashboard } from './EmbeddedSupersetDashboard.js'
 import FilterBar from './FilterBar/FilterBar.js'
 import ItemGrid from './ItemGrid.js'
 import classes from './styles/ViewDashboard.module.css'
@@ -16,6 +19,8 @@ export const ViewDashboardContent = ({
     loadFailed,
     isCached,
 }) => {
+    const isEmbeddedDashboard = useSelector(sGetSelectedIsEmbedded)
+
     if (loading) {
         return <LoadingMask />
     }
@@ -35,8 +40,12 @@ export const ViewDashboardContent = ({
         return (
             <>
                 <Description />
-                <FilterBar />
-                <ItemGrid dashboardIsCached={isCached} />
+                {!isEmbeddedDashboard && <FilterBar />}
+                {isEmbeddedDashboard ? (
+                    <EmbeddedSupersetDashboard />
+                ) : (
+                    <ItemGrid dashboardIsCached={isCached} />
+                )}
             </>
         )
     }

--- a/src/pages/view/styles/Description.module.css
+++ b/src/pages/view/styles/Description.module.css
@@ -9,3 +9,7 @@
     color: var(--colors-grey600);
     font-style: italic;
 }
+
+.padded {
+    padding-inline: var(--spacers-dp8);
+}

--- a/src/pages/view/styles/EmbeddedSupersetDashboard.module.css
+++ b/src/pages/view/styles/EmbeddedSupersetDashboard.module.css
@@ -1,5 +1,12 @@
 .container {
-    border: 1px solid red;
     block-size: 100%;
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+.container :global(iframe) {
+    all: unset;
+    inline-size: 100%;
     flex-grow: 1;
 }

--- a/src/pages/view/styles/EmbeddedSupersetDashboard.module.css
+++ b/src/pages/view/styles/EmbeddedSupersetDashboard.module.css
@@ -1,0 +1,5 @@
+.container {
+    border: 1px solid red;
+    block-size: 100%;
+    flex-grow: 1;
+}

--- a/src/pages/view/styles/EmbeddedSupersetDashboard.module.css
+++ b/src/pages/view/styles/EmbeddedSupersetDashboard.module.css
@@ -1,12 +1,66 @@
-.container {
+.container,
+.iframeHost {
     block-size: 100%;
     flex-grow: 1;
     display: flex;
     flex-direction: column;
 }
+.container {
+    position: relative;
+}
 
-.container :global(iframe) {
+.iframeHost {
+    opacity: 1;
+    transition: opacity 120ms ease-in;
+}
+.iframeHost :global(iframe) {
     all: unset;
     inline-size: 100%;
     flex-grow: 1;
+}
+.iframeHost.opaque {
+    opacity: 0;
+}
+
+.contentOverlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.contentOverlay > :global(.error) {
+    align-self: baseline;
+    min-inline-size: 400px;
+    margin-block-start: var(--spacers-dp24);
+}
+.errorText {
+    margin-block-start: 0;
+    margin-block-end: var(--spacers-dp8);
+}
+
+.loaderContainer {
+    display: flex;
+    gap: var(--spacers-dp8);
+    animation: showLoader;
+    animation-duration: 120ms;
+    animation-delay: 400ms;
+    animation-fill-mode: forwards;
+    opacity: 0;
+}
+.loaderContainer > p {
+    all: unset;
+    color: var(--colors-grey600);
+}
+@keyframes showLoader {
+    0% {
+        opacity: 0;
+    }
+    50% {
+        opacity: 0.5;
+    }
+    100% {
+        opacity: 1;
+    }
 }

--- a/src/reducers/selected.js
+++ b/src/reducers/selected.js
@@ -40,6 +40,22 @@ export const sGetSelectedId = (state) => sGetSelected(state).id
 
 export const sGetSelectedIsEmbedded = (state) => !!sGetSelected(state).embedded
 
+export const sGetSelectedSupersetEmbedData = (state) => {
+    const embedData = sGetSelected(state).embedded
+    return {
+        id: embedData.id,
+        dashboardUiConfig: {
+            hideTitle: true,
+            hideTab: true,
+            hideChartControls: embedData.options.hideChartControls,
+            filters: {
+                visible: embedData.options.filters.visible,
+                expanded: false,
+            },
+        },
+    }
+}
+
 export const sGetSelectedDisplayName = (state) =>
     sGetSelected(state).displayName
 

--- a/src/reducers/selected.js
+++ b/src/reducers/selected.js
@@ -12,6 +12,7 @@ const SELECTED_PROPERTIES = {
     dashboardItems: [],
     layout: [],
     itemConfig: {},
+    embedded: undefined,
 }
 
 export default (state = DEFAULT_SELECTED_STATE, action) => {
@@ -36,6 +37,8 @@ export default (state = DEFAULT_SELECTED_STATE, action) => {
 export const sGetSelected = (state) => state.selected
 
 export const sGetSelectedId = (state) => sGetSelected(state).id
+
+export const sGetSelectedIsEmbedded = (state) => !!sGetSelected(state).embedded
 
 export const sGetSelectedDisplayName = (state) =>
     sGetSelected(state).displayName

--- a/yarn.lock
+++ b/yarn.lock
@@ -3908,6 +3908,19 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@superset-ui/embedded-sdk@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@superset-ui/embedded-sdk/-/embedded-sdk-0.1.3.tgz#32279aff9ae5479a73f70ac1ec41b0b15c24381c"
+  integrity sha512-7NJMTx+rWzOzY0CHTFkh+iZjxsvz9ga8HJxpAN/LaY+uM6jBObbzo8KXah6qcX6no2wEfOQYdSazDPfWOrnHQw==
+  dependencies:
+    "@superset-ui/switchboard" "^0.20.3"
+    jwt-decode "^4.0.0"
+
+"@superset-ui/switchboard@^0.20.3":
+  version "0.20.3"
+  resolved "https://registry.yarnpkg.com/@superset-ui/switchboard/-/switchboard-0.20.3.tgz#9037c64408dfb6b0291671fa0a136fb32b9511db"
+  integrity sha512-qEMXFwdRLfXug4gXXdBEGpFtBWZoxdZkCJLBVxj1IR8cQvSqjkWAQOzSSYYdcIeREWqi8iP+iK6apNV1ZQCKcA==
+
 "@surma/rollup-plugin-off-main-thread@^2.2.3":
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz#ee34985952ca21558ab0d952f00298ad2190c053"
@@ -11263,6 +11276,11 @@ just-diff@^5.0.1:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/just-diff/-/just-diff-5.2.0.tgz#60dca55891cf24cd4a094e33504660692348a241"
   integrity sha512-6ufhP9SHjb7jibNFrNxyFZ6od3g+An6Ai9mhGRvcYe8UJlH0prseN64M+6ZBBUoKYHZsitDP42gAJ8+eVWr3lw==
+
+jwt-decode@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-4.0.0.tgz#2270352425fd413785b2faf11f6e755c5151bd4b"
+  integrity sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==
 
 keyv@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
In this PR I've added support for showing a superset dashboard in the dashboard-app. Some notes:
- We assume embedded superset dashboards come with their own whitespace around the dashboard. This is the default setting in superset. And as such we remove padding from the dashboard-container and add it to the description when the dashboard is embedded.
- Loading the dashboard goes in three stages. :
    1. We show this loader-overlay with translucent backdrop that comes with an AlertBar if loading takes long. 
    2. We show an "Fetching external dashboard" loader. This loader comes with a "show animation" which is called after a 400ms delay. The result of this is that on quick connections this loader is effectively skipped, which is better than showing 3 different loaders in quick succession.
    3. Finally superset has its own internal loading UI. It was not possible to work out when superset has completely loaded the dashboard so hiding the dashboard until then was not feasible.
- There is currently a [known issue](https://github.com/apache/superset/issues/24195#issuecomment-2143900192) in the superSetEmbeddedSdk which is preventing the side-filter-ui to be hidden. We will take no action but simply wait until this is fixed upstream.

And this PR also includes a small unrelated change: the dashboard-type-radio now only gets a focus outline when the user starts using keyboard navigation. We are still discussing wether or not this is better than the previous solution, so this may be subject to change later on. I woulnd't pay too much notices to the changes in `src/components/DashboardsBar/CreateDashboardButton/styles/DashboardTypeRadio.module.css`

<img width="1203" alt="Screenshot 2025-01-21 at 14 17 04" src="https://github.com/user-attachments/assets/400311c4-6dba-4691-96ff-eb455fb31a33" />

