### PR TITLE
fix: reload plugin only when visualization changes

### DIFF
--- a/src/components/Item/VisualizationItem/Visualization/LegacyPlugin.js
+++ b/src/components/Item/VisualizationItem/Visualization/LegacyPlugin.js
@@ -8,7 +8,6 @@ import { load, unmount } from './plugin.js'
 const LegacyPlugin = ({
     item,
     activeType,
-    filterVersion,
     visualization,
     options,
     style,
@@ -18,7 +17,7 @@ const LegacyPlugin = ({
     const { baseUrl } = useConfig()
     const prevItem = useRef()
     const prevActiveType = useRef()
-    const prevFilterVersion = useRef()
+    const prevVisualization = useRef()
 
     useEffect(() => {
         const el = document.querySelector(
@@ -37,8 +36,8 @@ const LegacyPlugin = ({
         if (
             !prevItem.current ||
             (prevItem.current === item &&
-                (prevActiveType.current !== activeType ||
-                    prevFilterVersion.current !== filterVersion))
+                prevActiveType.current !== activeType) ||
+            prevVisualization.current !== visualization
         ) {
             // Initial load, or active type or filter has changed
             load(item, visualization, {
@@ -53,17 +52,16 @@ const LegacyPlugin = ({
 
         prevItem.current = item
         prevActiveType.current = activeType
-        prevFilterVersion.current = filterVersion
+        prevVisualization.current = visualization
 
         return () => unmount(item, item.type || activeType)
-    }, [item, visualization, activeType, filterVersion, baseUrl, options, d2])
+    }, [item, visualization, activeType, baseUrl, options, d2])
 
     return <div id={getVisualizationContainerDomId(item.id)} style={style} />
 }
 
 LegacyPlugin.propTypes = {
     activeType: PropTypes.string,
-    filterVersion: PropTypes.string,
     gridWidth: PropTypes.number,
     item: PropTypes.object,
     options: PropTypes.object,

--- a/src/components/Item/VisualizationItem/Visualization/Visualization.js
+++ b/src/components/Item/VisualizationItem/Visualization/Visualization.js
@@ -2,9 +2,8 @@ import { useCachedDataQuery } from '@dhis2/analytics'
 import { useDhis2ConnectionStatus } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import { Button, Cover, IconInfo24, colors } from '@dhis2/ui'
-import uniqueId from 'lodash/uniqueId.js'
 import PropTypes from 'prop-types'
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import {
     isDVVersionCompatible,
@@ -54,7 +53,6 @@ const Visualization = ({
         mapsAppVersion,
         apps,
     } = useCachedDataQuery()
-    const [filterVersion, setFilterVersion] = useState(null)
 
     const visualizationConfig = useMemo(() => {
         if (originalType === EVENT_VISUALIZATION) {
@@ -66,10 +64,6 @@ const Visualization = ({
             itemFilters
         )
     }, [visualization, activeType, originalType, itemFilters])
-
-    useEffect(() => {
-        setFilterVersion(uniqueId())
-    }, [itemFilters])
 
     const iFramePluginProps = useMemo(
         () => ({
@@ -204,7 +198,6 @@ const Visualization = ({
                     item={item}
                     activeType={activeType}
                     visualization={visualizationConfig}
-                    filterVersion={filterVersion}
                     style={style}
                     gridWidth={gridWidth}
                     {...rest}

--- a/src/components/Item/VisualizationItem/Visualization/Visualization.js
+++ b/src/components/Item/VisualizationItem/Visualization/Visualization.js
@@ -4,7 +4,7 @@ import i18n from '@dhis2/d2-i18n'
 import { Button, Cover, IconInfo24, colors } from '@dhis2/ui'
 import uniqueId from 'lodash/uniqueId.js'
 import PropTypes from 'prop-types'
-import React, { useCallback, useMemo } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { useSelector } from 'react-redux'
 import {
     isDVVersionCompatible,
@@ -54,6 +54,7 @@ const Visualization = ({
         mapsAppVersion,
         apps,
     } = useCachedDataQuery()
+    const [filterVersion, setFilterVersion] = useState(null)
 
     const visualizationConfig = useMemo(() => {
         if (originalType === EVENT_VISUALIZATION) {
@@ -66,7 +67,9 @@ const Visualization = ({
         )
     }, [visualization, activeType, originalType, itemFilters])
 
-    const filterVersion = useCallback(() => uniqueId(), [])
+    useEffect(() => {
+        setFilterVersion(uniqueId())
+    }, [itemFilters])
 
     const iFramePluginProps = useMemo(
         () => ({
@@ -201,7 +204,7 @@ const Visualization = ({
                     item={item}
                     activeType={activeType}
                     visualization={visualizationConfig}
-                    filterVersion={filterVersion()}
+                    filterVersion={filterVersion}
                     style={style}
                     gridWidth={gridWidth}
                     {...rest}


### PR DESCRIPTION
### Key features

1. remove `filterVersion` and use `visualization` instead to trigger a plugin reload

---

### Description

This avoids unnecessary re-renders of LegacyPlugin items (EV/ER) which cause EV visualizations to flash and extra analytics requests to fire.
Before `filterVersion` was changing at every render.
Now `visualization` is used to determine when to reload the plugin.

---

### Screenshots

Before:
https://github.com/user-attachments/assets/b206f422-6765-44c8-b033-53def739bea3

After:
https://github.com/user-attachments/assets/93be967d-50ec-45f9-8f24-564f5961bcbd


