### PR TITLE
fix: show user's search text in the No dashboards found message [v39]

### DIFF
--- a/src/components/DashboardsBar/Content.js
+++ b/src/components/DashboardsBar/Content.js
@@ -39,8 +39,20 @@ const Content = ({
         }
     }
 
-    const getChips = () =>
-        getFilteredDashboards(dashboards, filterText).map((dashboard) => (
+    const getChips = () => {
+        const filteredList = getFilteredDashboards(dashboards, filterText)
+
+        if (filteredList.length === 0) {
+            return (
+                <span className={classes.noDashboardsMessage}>
+                    {i18n.t('No dashboards found for "{{filterText}}"', {
+                        filterText,
+                    })}
+                </span>
+            )
+        }
+
+        return filteredList.map((dashboard) => (
             <Chip
                 key={dashboard.id}
                 label={dashboard.displayName}
@@ -50,6 +62,7 @@ const Content = ({
                 onClick={onChipClicked}
             />
         ))
+    }
 
     const getControlsSmall = () => (
         <div className={classes.controlsSmall}>

--- a/src/components/DashboardsBar/styles/Content.module.css
+++ b/src/components/DashboardsBar/styles/Content.module.css
@@ -26,6 +26,17 @@
     min-height: 40px;
 }
 
+.noDashboardsMessage {
+    padding-left: 6px;
+    color: #4A5768;
+    font-size: 12px;
+    display: inline-flex;
+    -webkit-box-align: center;
+    align-items: center;
+    height: 32px;
+    line-height: 16px;
+    user-select: none;
+}
 @media only screen and (max-width: 480px) {
     .newLink {
         display: none;


### PR DESCRIPTION
Implements [DHIS2-6647](https://dhis2.atlassian.net/browse/DHIS2-6647)

Include the search text in the "No dashboards found" message to better inform the user.

![image](https://github.com/user-attachments/assets/9d9d2dca-105c-409b-9850-43d4e723ec4b)


[DHIS2-6647]: https://dhis2.atlassian.net/browse/DHIS2-6647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ