### PR TITLE
chore: adjust e2e dev workflow so that it works

### DIFF
--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -8,7 +8,6 @@ env:
     CI: true
     DEV_URL: 'https://test.e2e.dhis2.org/analytics-dev'
     API_VERSION: 42
-    SHOULD_RUN: ${{ contains(github.event.pull_request.labels.*.name, 'e2e dev') }}
     SHOULD_RECORD: ${{ contains(github.event.pull_request.labels.*.name, 'e2e record') }}
 
 concurrency:
@@ -21,7 +20,7 @@ defaults:
 
 jobs:
     setup-matrix:
-        if: ${{ env.SHOULD_RUN }}
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'e2e dev') }}
         runs-on: ubuntu-latest
         outputs:
             matrix: ${{ steps.set-matrix.outputs.specs }}
@@ -33,7 +32,7 @@ jobs:
 
     e2e-dev:
         needs: setup-matrix
-        if: ${{ env.SHOULD_RUN }}
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'e2e dev') }}
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false

--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -7,6 +7,9 @@ on:
 env:
     CI: true
     DEV_URL: 'https://test.e2e.dhis2.org/analytics-dev'
+    API_VERSION: 42
+    SHOULD_RUN: ${{ contains(github.event.pull_request.labels.*.name, 'e2e dev') }}
+    SHOULD_RECORD: ${{ contains(github.event.pull_request.labels.*.name, 'e2e record') }}
 
 concurrency:
     group: ${{ github.workflow}}-${{ github.ref }}
@@ -17,28 +20,25 @@ defaults:
         shell: bash
 
 jobs:
-    compute-dev-version:
-        if: contains(github.event.pull_request.labels.*.name, 'e2e dev')
+    setup-matrix:
+        if: ${{ env.SHOULD_RUN }}
         runs-on: ubuntu-latest
         outputs:
-            version: ${{ steps.instance-version.outputs.version }}
+            matrix: ${{ steps.set-matrix.outputs.specs }}
         steps:
-            - name: Output dev version
-              id: instance-version
-              uses: dhis2/action-instance-version@v1
-              with:
-                  instance-url: ${{ env.DEV_URL }}
-                  username: ${{ secrets.CYPRESS_DHIS2_USERNAME }}
-                  password: ${{ secrets.CYPRESS_DHIS2_PASSWORD }}
+            - uses: actions/checkout@v4
+            - name: Generate Test matrix
+              id: set-matrix
+              run: echo "::set-output name=specs::$(node cypress/support/generateTestMatrix.js)"
 
     e2e-dev:
-        needs: compute-dev-version
-        if: contains(github.event.pull_request.labels.*.name, 'e2e dev')
+        needs: setup-matrix
+        if: ${{ env.SHOULD_RUN }}
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false
             matrix:
-                containers: [1, 2, 3, 4]
+                spec-group: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
         steps:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v4
@@ -56,17 +56,18 @@ jobs:
                   start: yarn d2-app-scripts start
                   wait-on: 'http://localhost:3000'
                   wait-on-timeout: 300
-                  record: ${{ contains(github.event.pull_request.labels.*.name, 'e2e record') }}
-                  parallel: ${{ contains(github.event.pull_request.labels.*.name, 'e2e record') }}
+                  record: ${{ env.SHOULD_RECORD }}
+                  parallel: ${{ env.SHOULD_RECORD }}
                   browser: chrome
-                  group: E2E Suite against Dev container ${{ matrix.containers }}
-                  ci-build-id: ${{ inputs.should_record && github.run_id || '' }}
+                  spec: ${{ join(matrix.spec-group.tests, ',') }}
+                  group: ${{ env.SHOULD_RECORD && format('e2e-chrome-parallel-{0}', matrix.spec-group.id) || '' }}
+                  ci-build-id: ${{ env.SHOULD_RECORD && github.run_id || '' }}
               env:
                   CI: true
                   BROWSER: none
                   CYPRESS_RECORD_KEY: ${{ secrets.recordkey }}
                   CYPRESS_dhis2BaseUrl: ${{ env.DEV_URL }}
-                  CYPRESS_dhis2InstanceVersion: ${{ needs.compute-dev-version.outputs.version }}
+                  CYPRESS_dhis2InstanceVersion: ${{ env.API_VERSION }}
                   CYPRESS_dhis2Username: ${{ secrets.CYPRESS_DHIS2_USERNAME }}
                   CYPRESS_dhis2Password: ${{ secrets.CYPRESS_DHIS2_PASSWORD }}
                   CYPRESS_networkMode: live

--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -1,4 +1,4 @@
-name: 'E2E - Development'
+name: 'e2e development'
 
 on:
     pull_request:

--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -49,12 +49,6 @@ jobs:
             - name: Generate translations
               run: yarn d2-app-scripts i18n generate
 
-            - name: Debug Cypress arguments
-              run: |
-                  echo "env.SHOULD_RECORD: ${{ env.SHOULD_RECORD }}"
-                  echo "Group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-{0}', matrix.spec-group.id) || '' }}"
-                  echo "CI Build ID: ${{ env.SHOULD_RECORD == 'true'&& github.run_id || '' }}"
-
             - name: Run e2e tests
               uses: cypress-io/github-action@v5
               with:

--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -49,6 +49,12 @@ jobs:
             - name: Generate translations
               run: yarn d2-app-scripts i18n generate
 
+            - name: Debug Cypress arguments
+              run: |
+                  echo "env.SHOULD_RECORD: ${{ env.SHOULD_RECORD }}"
+                  echo "Group: ${{ env.SHOULD_RECORD && format('e2e-chrome-parallel-{0}', matrix.spec-group.id) || '' }}"
+                  echo "CI Build ID: ${{ env.SHOULD_RECORD && github.run_id || '' }}"
+
             - name: Run e2e tests
               uses: cypress-io/github-action@v5
               with:

--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -50,10 +50,13 @@ jobs:
               run: yarn d2-app-scripts i18n generate
 
             - name: Debug Cypress arguments
+              env:
+                  GROUP: env.SHOULD_RECORD && ${{ format('e2e-chrome-parallel-{0}', matrix.spec-group.id) }} || ''
+                  CI_BUILD_ID: env.SHOULD_RECORD && ${{ github.run_id }} || ''
               run: |
                   echo "env.SHOULD_RECORD: ${{ env.SHOULD_RECORD }}"
-                  echo "Group: ${{ env.SHOULD_RECORD && format('e2e-chrome-parallel-{0}', matrix.spec-group.id) || '' }}"
-                  echo "CI Build ID: ${{ env.SHOULD_RECORD && github.run_id || '' }}"
+                  echo "Group: ${{ env.GROUP }}"
+                  echo "CI Build ID: ${{ env.CI_BUILD_ID }}"
 
             - name: Run e2e tests
               uses: cypress-io/github-action@v5
@@ -65,8 +68,8 @@ jobs:
                   parallel: ${{ env.SHOULD_RECORD }}
                   browser: chrome
                   spec: ${{ join(matrix.spec-group.tests, ',') }}
-                  group: ${{ env.SHOULD_RECORD && format('e2e-chrome-parallel-{0}', matrix.spec-group.id) || '' }}
-                  ci-build-id: ${{ env.SHOULD_RECORD && github.run_id || '' }}
+                  group: env.SHOULD_RECORD && ${{ format('e2e-chrome-parallel-{0}', matrix.spec-group.id) }} || ''
+                  ci-build-id: env.SHOULD_RECORD && ${{ github.run_id }} || ''
               env:
                   CI: true
                   BROWSER: none

--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -50,13 +50,10 @@ jobs:
               run: yarn d2-app-scripts i18n generate
 
             - name: Debug Cypress arguments
-              env:
-                  GROUP: env.SHOULD_RECORD && ${{ format('e2e-chrome-parallel-{0}', matrix.spec-group.id) }} || ''
-                  CI_BUILD_ID: env.SHOULD_RECORD && ${{ github.run_id }} || ''
               run: |
                   echo "env.SHOULD_RECORD: ${{ env.SHOULD_RECORD }}"
-                  echo "Group: ${{ env.GROUP }}"
-                  echo "CI Build ID: ${{ env.CI_BUILD_ID }}"
+                  echo "Group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-{0}', matrix.spec-group.id) || '' }}"
+                  echo "CI Build ID: ${{ env.SHOULD_RECORD == 'true'&& github.run_id || '' }}"
 
             - name: Run e2e tests
               uses: cypress-io/github-action@v5
@@ -64,12 +61,12 @@ jobs:
                   start: yarn d2-app-scripts start
                   wait-on: 'http://localhost:3000'
                   wait-on-timeout: 300
-                  record: ${{ env.SHOULD_RECORD }}
-                  parallel: ${{ env.SHOULD_RECORD }}
+                  record: ${{ env.SHOULD_RECORD  == 'true' }}
+                  parallel: ${{ env.SHOULD_RECORD == 'true' }}
                   browser: chrome
                   spec: ${{ join(matrix.spec-group.tests, ',') }}
-                  group: env.SHOULD_RECORD && ${{ format('e2e-chrome-parallel-{0}', matrix.spec-group.id) }} || ''
-                  ci-build-id: env.SHOULD_RECORD && ${{ github.run_id }} || ''
+                  group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-{0}', matrix.spec-group.id) || '' }}
+                  ci-build-id: ${{ env.SHOULD_RECORD == 'true' && github.run_id || '' }}
               env:
                   CI: true
                   BROWSER: none


### PR DESCRIPTION
Changes in this PR:
- We simply hardcode the dev API version to avoid complexity
- We compute the test matrix manually so we can execute the test in parallel, also without using the cypress dashboard
- We store `SHOULD_RECORD` in an env var to make the conditional logic less complex*

[*] Note that the env var is a string, so you see `== 'true'`. Also note that I could not do the same for `SHOULD_RUN` because env variables are not available in job-conditions (`if` properties of a job block).

I have checked and the parallelisation seems to be working fine.

I will also check if the `e2e record` label affects this new workflow as intended.