### PR TITLE
fix: ensure fields do not have undefined initial values

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
         "@semantic-release/git": "^10",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^12",
+        "@testing-library/react-hooks": "^8.0.1",
         "cypress": "^13.13.1",
         "cypress-real-events": "^1.13.0",
         "cypress-tags": "^1.2.2",

--- a/src/components/DashboardsBar/ConfigureSupersetDashboard/SupersetDashboardFields.js
+++ b/src/components/DashboardsBar/ConfigureSupersetDashboard/SupersetDashboardFields.js
@@ -25,6 +25,7 @@ export const SupersetDashboardFields = ({
             <InputField
                 initialFocus
                 label={i18n.t('Title')}
+                placeholder={i18n.t('Untitled dashboard')}
                 type="text"
                 onChange={onChange}
                 value={values.title}

--- a/src/modules/__tests__/useSupersetDashboardFieldsState.spec.js
+++ b/src/modules/__tests__/useSupersetDashboardFieldsState.spec.js
@@ -1,17 +1,10 @@
+import { renderHook, act } from '@testing-library/react-hooks'
 import {
-    createInitialState,
-    defaultInitialValues,
-    FIELD_CHANGE,
     FIELD_NAME_CODE,
-    FIELD_NAME_DESCRIPTION,
-    FIELD_NAME_EXPAND_FILTERS,
     FIELD_NAME_SHOW_CHART_CONTROLS,
     FIELD_NAME_SUPERSET_EMBED_ID,
     FIELD_NAME_TITLE,
-    isValidUuid,
-    reducer,
-    RESET_FIELD_STATE,
-    SUPERSET_FIELD_BLUR,
+    useSupersetDashboardFieldsState,
 } from '../useSupersetDashboardFieldsState.js'
 
 const INITIAL_TITLE = 'Initial title'
@@ -20,30 +13,45 @@ const UUID_V1 = 'dbb4cd86-e206-11ef-9cd2-0242ac120002'
 const UUID_V4 = '0394041b-8367-4fe2-9777-fe54b6d2da2f'
 const UUID_V7 = '0194cae2-92f9-7363-ab58-9a19b13084eb'
 const NILL_UUID = '00000000-0000-0000-0000-000000000000'
+const defaultInitialValues = {
+    title: '',
+    code: '',
+    description: '',
+    supersetEmbedId: '',
+    showChartControls: true,
+    expandFilters: false,
+}
 
-describe('superset embedded fields state reducer', () => {
-    describe('UUID validator', () => {
+describe('useSupersetDashboardFieldsState', () => {
+    describe('UUID validation', () => {
+        const getIsSupersetEmbedValidState = (uuid) => {
+            const { result } = renderHook(() =>
+                useSupersetDashboardFieldsState({ supersetEmbedId: uuid })
+            )
+            return result.current.isSupersetEmbedIdValid
+        }
         it('accepts valid UUID strings for common versions', () => {
-            expect(isValidUuid(UUID_V1)).toBe(true)
-            expect(isValidUuid(UUID_V4)).toBe(true)
-            expect(isValidUuid(UUID_V7)).toBe(true)
+            expect(getIsSupersetEmbedValidState(UUID_V1)).toBe(true)
+            expect(getIsSupersetEmbedValidState(UUID_V4)).toBe(true)
+            expect(getIsSupersetEmbedValidState(UUID_V7)).toBe(true)
         })
         it('rejects empty string, invalid string and nill UUID', () => {
-            expect(isValidUuid(NILL_UUID)).toBe(false)
-            expect(isValidUuid('')).toBe(false)
-            expect(isValidUuid('a random string')).toBe(false)
+            expect(getIsSupersetEmbedValidState(NILL_UUID)).toBe(false)
+            expect(getIsSupersetEmbedValidState('')).toBe(false)
+            expect(getIsSupersetEmbedValidState('a random string')).toBe(false)
         })
     })
     describe('initial state creation', () => {
         it('creates the expected initial state when not providing initial values', () => {
-            expect(createInitialState()).toEqual({
-                initialValues: defaultInitialValues,
-                values: defaultInitialValues,
-                isSupersetEmbedIdValid: false,
-                isCodeValid: true,
-                shouldShowSupersetEmbedIdError: false,
-                hasFieldChanges: false,
-            })
+            const { result } = renderHook(() =>
+                useSupersetDashboardFieldsState()
+            )
+            expect(result.current.initialValues).toEqual(defaultInitialValues)
+            expect(result.current.values).toEqual(defaultInitialValues)
+            expect(result.current.isSupersetEmbedIdValid).toBe(false)
+            expect(result.current.isCodeValid).toBe(true)
+            expect(result.current.shouldShowSupersetEmbedIdError).toBe(false)
+            expect(result.current.hasFieldChanges).toBe(false)
         })
         it('creates the expected initial state from provided initial values', () => {
             const initialValues = {
@@ -54,14 +62,15 @@ describe('superset embedded fields state reducer', () => {
                 showChartControls: false,
                 expandFilters: true,
             }
-            expect(createInitialState(initialValues)).toEqual({
-                initialValues: initialValues,
-                values: initialValues,
-                isSupersetEmbedIdValid: false,
-                isCodeValid: true,
-                shouldShowSupersetEmbedIdError: false,
-                hasFieldChanges: false,
-            })
+            const { result } = renderHook(() =>
+                useSupersetDashboardFieldsState(initialValues)
+            )
+            expect(result.current.initialValues).toEqual(initialValues)
+            expect(result.current.values).toEqual(initialValues)
+            expect(result.current.isSupersetEmbedIdValid).toBe(false)
+            expect(result.current.isCodeValid).toBe(true)
+            expect(result.current.shouldShowSupersetEmbedIdError).toBe(false)
+            expect(result.current.hasFieldChanges).toBe(false)
         })
         it('creates the expected initial state when some properties are undefined', () => {
             const initialValues = {
@@ -72,183 +81,213 @@ describe('superset embedded fields state reducer', () => {
                 showChartControls: undefined,
                 expandFilters: undefined,
             }
-            expect(createInitialState(initialValues)).toEqual({
-                initialValues: defaultInitialValues,
-                values: defaultInitialValues,
-                isSupersetEmbedIdValid: false,
-                isCodeValid: true,
-                shouldShowSupersetEmbedIdError: false,
-                hasFieldChanges: false,
-            })
+            const { result } = renderHook(() =>
+                useSupersetDashboardFieldsState(initialValues)
+            )
+            expect(result.current.initialValues).toEqual(defaultInitialValues)
+            expect(result.current.values).toEqual(defaultInitialValues)
+            expect(result.current.isSupersetEmbedIdValid).toBe(false)
+            expect(result.current.isCodeValid).toBe(true)
+            expect(result.current.shouldShowSupersetEmbedIdError).toBe(false)
+            expect(result.current.hasFieldChanges).toBe(false)
         })
         it('the initial state reports a valid superset embed ID if a valid UUID was provided', () => {
             const initialValues = {
                 ...defaultInitialValues,
                 supersetEmbedId: UUID_V4,
             }
-            expect(createInitialState(initialValues)).toEqual({
-                initialValues: initialValues,
-                values: initialValues,
-                isSupersetEmbedIdValid: true,
-                isCodeValid: true,
-                shouldShowSupersetEmbedIdError: false,
-                hasFieldChanges: false,
-            })
+            const { result } = renderHook(() =>
+                useSupersetDashboardFieldsState(initialValues)
+            )
+            expect(result.current.isSupersetEmbedIdValid).toBe(true)
+            expect(result.current.shouldShowSupersetEmbedIdError).toBe(false)
         })
-        it('the intial state reports that the superset embed ID error should be displayed if invalid UUID is provided', () => {
+        it('the intial state reports that the superset embed ID error should be displayed if an invalid UUID is provided', () => {
             const initialValues = {
                 ...defaultInitialValues,
                 supersetEmbedId: 'a-bad-value',
             }
-            expect(createInitialState(initialValues)).toEqual({
-                initialValues: initialValues,
-                values: initialValues,
-                isSupersetEmbedIdValid: false,
-                isCodeValid: true,
-                shouldShowSupersetEmbedIdError: true,
-                hasFieldChanges: false,
-            })
+            const { result } = renderHook(() =>
+                useSupersetDashboardFieldsState(initialValues)
+            )
+            expect(result.current.isSupersetEmbedIdValid).toBe(false)
+            expect(result.current.shouldShowSupersetEmbedIdError).toBe(true)
+        })
+        it('the intial state reports that no superset embed ID error should be displayed if UUID is empty', () => {
+            const initialValues = {
+                ...defaultInitialValues,
+                supersetEmbedId: '',
+            }
+            const { result } = renderHook(() =>
+                useSupersetDashboardFieldsState(initialValues)
+            )
+            expect(result.current.isSupersetEmbedIdValid).toBe(false)
+            expect(result.current.shouldShowSupersetEmbedIdError).toBe(false)
         })
     })
     describe('state updates due to field change action', () => {
         it('updates state for text fields', () => {
-            const initialState = createInitialState()
-            const expectedState = {
-                ...initialState,
-                values: {
-                    ...initialState.values,
-                    title: UPDATED_TITLE,
-                },
-                hasFieldChanges: true,
-            }
-            expect(
-                reducer(initialState, {
-                    type: FIELD_CHANGE,
-                    payload: { name: FIELD_NAME_TITLE, value: UPDATED_TITLE },
+            const { result } = renderHook(() =>
+                useSupersetDashboardFieldsState()
+            )
+            act(() => {
+                result.current.onChange({
+                    name: FIELD_NAME_TITLE,
+                    value: UPDATED_TITLE,
                 })
-            ).toEqual(expectedState)
+            })
+            expect(result.current.values.title).toBe(UPDATED_TITLE)
+            expect(result.current.hasFieldChanges).toBe(true)
         })
         it('updates state for boolean fields', () => {
-            const initialState = createInitialState()
-            const expectedState = {
-                ...initialState,
-                values: {
-                    ...initialState.values,
-                    showChartControls: false,
-                },
-                hasFieldChanges: true,
-            }
-            expect(
-                reducer(initialState, {
-                    type: FIELD_CHANGE,
-                    payload: {
-                        name: FIELD_NAME_SHOW_CHART_CONTROLS,
-                        checked: false,
-                    },
+            const { result } = renderHook(() =>
+                useSupersetDashboardFieldsState()
+            )
+            act(() => {
+                result.current.onChange({
+                    name: FIELD_NAME_SHOW_CHART_CONTROLS,
+                    checked: false,
                 })
-            ).toEqual(expectedState)
+            })
+            expect(result.current.values.showChartControls).toBe(false)
+            expect(result.current.hasFieldChanges).toBe(true)
         })
         it('detects when an code field is invalid', () => {
             const invalidCode =
                 '0123456789-0123456789-0123456789-0123456789-0123456789-'
-            const initialState = createInitialState()
-            const expectedState = {
-                ...initialState,
-                values: {
-                    ...initialState.values,
-                    code: invalidCode,
-                },
-                hasFieldChanges: true,
-                isCodeValid: false,
-            }
-            expect(
-                reducer(initialState, {
-                    type: FIELD_CHANGE,
-                    payload: {
-                        name: FIELD_NAME_CODE,
-                        value: invalidCode,
-                    },
+            const { result } = renderHook(() =>
+                useSupersetDashboardFieldsState()
+            )
+            act(() => {
+                result.current.onChange({
+                    name: FIELD_NAME_CODE,
+                    value: invalidCode,
                 })
-            ).toEqual(expectedState)
+            })
+            expect(result.current.values.code).toBe(invalidCode)
+            expect(result.current.hasFieldChanges).toBe(true)
+            expect(result.current.isCodeValid).toBe(false)
         })
         it('reports no field changes if values are changed back to initial values', () => {
-            const initialState = createInitialState({
-                ...defaultInitialValues,
-                title: INITIAL_TITLE,
+            const { result } = renderHook(() =>
+                useSupersetDashboardFieldsState({ title: INITIAL_TITLE })
+            )
+            act(() => {
+                result.current.onChange({
+                    name: FIELD_NAME_TITLE,
+                    value: UPDATED_TITLE,
+                })
             })
-            const stateAfterTitleChange = reducer(initialState, {
-                type: FIELD_CHANGE,
-                payload: { name: FIELD_NAME_TITLE, value: UPDATED_TITLE },
+            expect(result.current.values.title).toBe(UPDATED_TITLE)
+            expect(result.current.hasFieldChanges).toBe(true)
+
+            act(() => {
+                result.current.resetFieldsStateWithNewValues({
+                    title: INITIAL_TITLE,
+                })
             })
 
-            expect(stateAfterTitleChange.values.title).toBe(UPDATED_TITLE)
-            expect(stateAfterTitleChange.hasFieldChanges).toBe(true)
-
-            const stateAfterTitleReset = reducer(stateAfterTitleChange, {
-                type: FIELD_CHANGE,
-                payload: { name: FIELD_NAME_TITLE, value: INITIAL_TITLE },
-            })
-
-            expect(stateAfterTitleReset.values.title).toBe(INITIAL_TITLE)
-            expect(stateAfterTitleReset.hasFieldChanges).toBe(false)
+            expect(result.current.values.title).toBe(INITIAL_TITLE)
+            expect(result.current.hasFieldChanges).toBe(false)
         })
-        it('reports superset embed ID is valid if the field is changed to a valid value', () => {
-            const stateAfterEmbedIdChange = reducer(createInitialState(), {
-                type: FIELD_CHANGE,
-                payload: { name: FIELD_NAME_SUPERSET_EMBED_ID, value: UUID_V1 },
+        it('reports superset embed ID validity state changes correctly', () => {
+            const { result } = renderHook(() =>
+                useSupersetDashboardFieldsState()
+            )
+            act(() => {
+                result.current.onChange({
+                    name: FIELD_NAME_SUPERSET_EMBED_ID,
+                    value: UUID_V1,
+                })
             })
-
-            expect(stateAfterEmbedIdChange.values.supersetEmbedId).toBe(UUID_V1)
-            expect(stateAfterEmbedIdChange.isSupersetEmbedIdValid).toBe(true)
+            expect(result.current.values.supersetEmbedId).toBe(UUID_V1)
+            expect(result.current.isSupersetEmbedIdValid).toBe(true)
+            expect(result.current.shouldShowSupersetEmbedIdError).toBe(false)
+            act(() => {
+                result.current.onChange({
+                    name: FIELD_NAME_SUPERSET_EMBED_ID,
+                    value: NILL_UUID,
+                })
+            })
+            expect(result.current.values.supersetEmbedId).toBe(NILL_UUID)
+            expect(result.current.isSupersetEmbedIdValid).toBe(false)
+            expect(result.current.shouldShowSupersetEmbedIdError).toBe(true)
+            act(() => {
+                result.current.onChange({
+                    name: FIELD_NAME_SUPERSET_EMBED_ID,
+                    value: UUID_V7,
+                })
+            })
+            expect(result.current.values.supersetEmbedId).toBe(UUID_V7)
+            expect(result.current.isSupersetEmbedIdValid).toBe(true)
+            expect(result.current.shouldShowSupersetEmbedIdError).toBe(false)
         })
     })
     describe('state updates due to superset field blur action', () => {
         it('sets superset embed ID field touched to true', () => {
-            const initialState = createInitialState()
-            expect(
-                reducer(initialState, { type: SUPERSET_FIELD_BLUR })
-            ).toEqual({ ...initialState, shouldShowSupersetEmbedIdError: true })
+            const { result } = renderHook(() =>
+                useSupersetDashboardFieldsState()
+            )
+            act(() => {
+                result.current.onChange({
+                    name: FIELD_NAME_SUPERSET_EMBED_ID,
+                    value: NILL_UUID,
+                })
+            })
+            // Not showing error because started empty and changed to invalid without field blur
+            expect(result.current.values.supersetEmbedId).toBe(NILL_UUID)
+            expect(result.current.isSupersetEmbedIdValid).toBe(false)
+            expect(result.current.shouldShowSupersetEmbedIdError).toBe(false)
+            // Now field blurs and error should show
+            act(() => {
+                result.current.onSupersetEmbedIdFieldBlur()
+            })
+            expect(result.current.values.supersetEmbedId).toBe(NILL_UUID)
+            expect(result.current.isSupersetEmbedIdValid).toBe(false)
+            expect(result.current.shouldShowSupersetEmbedIdError).toBe(true)
         })
     })
     describe('state updates due to reset field state action', () => {
         it('resets the state using the initial values in the payload', () => {
-            let state = createInitialState()
-            // Make various state changes
-            state = reducer(state, { type: SUPERSET_FIELD_BLUR })
-            state = reducer(state, {
-                type: FIELD_CHANGE,
-                payload: { name: FIELD_NAME_TITLE, value: INITIAL_TITLE },
+            const { result } = renderHook(() =>
+                useSupersetDashboardFieldsState()
+            )
+            // Trigger some state changes
+            act(() => {
+                result.current.onChange({
+                    name: FIELD_NAME_TITLE,
+                    value: INITIAL_TITLE,
+                })
             })
-            state = reducer(state, {
-                type: FIELD_CHANGE,
-                payload: { name: FIELD_NAME_SUPERSET_EMBED_ID, value: UUID_V1 },
+            act(() => {
+                result.current.onChange({
+                    name: FIELD_NAME_SUPERSET_EMBED_ID,
+                    value: UUID_V1,
+                })
             })
-            expect(state.values.title).toBe(INITIAL_TITLE)
-            expect(state.values.supersetEmbedId).toBe(UUID_V1)
-            expect(state.shouldShowSupersetEmbedIdError).toBe(false)
-            expect(state.isSupersetEmbedIdValid).toBe(true)
-            expect(state.hasFieldChanges).toBe(true)
 
-            // Dispatch reset action
+            expect(result.current.values).not.toEqual(
+                result.current.initialValues
+            )
+            expect(result.current.hasFieldChanges).toBe(true)
+
             const newValues = {
-                [FIELD_NAME_TITLE]: UPDATED_TITLE,
-                [FIELD_NAME_CODE]: 'SOME_CODE',
-                [FIELD_NAME_DESCRIPTION]: 'A description text',
-                [FIELD_NAME_SUPERSET_EMBED_ID]: NILL_UUID,
-                [FIELD_NAME_SHOW_CHART_CONTROLS]: false,
-                [FIELD_NAME_EXPAND_FILTERS]: true,
+                title: UPDATED_TITLE,
+                code: 'SOME_CODE',
+                description: 'A description text',
+                supersetEmbedId: NILL_UUID,
+                showChartControls: false,
+                expandFilters: true,
             }
-            state = reducer(state, {
-                type: RESET_FIELD_STATE,
-                payload: newValues,
+
+            act(() => {
+                result.current.resetFieldsStateWithNewValues(newValues)
             })
 
-            expect(state.initialValues).toEqual(newValues)
-            expect(state.values).toEqual(newValues)
-            expect(state.isSupersetEmbedIdValid).toBe(false)
-            expect(state.shouldShowSupersetEmbedIdError).toBe(true)
-            // Note that this is by design, the initalValues are also reset
-            expect(state.hasFieldChanges).toBe(false)
+            // initalValues are reset, so hasFieldChanges is false
+            expect(result.current.initialValues).toEqual(newValues)
+            expect(result.current.values).toEqual(result.current.initialValues)
+            expect(result.current.hasFieldChanges).toBe(false)
         })
     })
 })

--- a/src/modules/__tests__/useSupersetDashboardFieldsState.spec.js
+++ b/src/modules/__tests__/useSupersetDashboardFieldsState.spec.js
@@ -63,6 +63,24 @@ describe('superset embedded fields state reducer', () => {
                 hasFieldChanges: false,
             })
         })
+        it('creates the expected initial state when some properties are undefined', () => {
+            const initialValues = {
+                title: undefined,
+                code: undefined,
+                description: undefined,
+                supersetEmbedId: undefined,
+                showChartControls: undefined,
+                expandFilters: undefined,
+            }
+            expect(createInitialState(initialValues)).toEqual({
+                initialValues: defaultInitialValues,
+                values: defaultInitialValues,
+                isSupersetEmbedIdValid: false,
+                isCodeValid: true,
+                shouldShowSupersetEmbedIdError: false,
+                hasFieldChanges: false,
+            })
+        })
         it('the initial state reports a valid superset embed ID if a valid UUID was provided', () => {
             const initialValues = {
                 ...defaultInitialValues,

--- a/src/modules/useSupersetDashboardFieldsState.js
+++ b/src/modules/useSupersetDashboardFieldsState.js
@@ -23,7 +23,23 @@ const UUID_PATTERN =
     /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 export const isValidUuid = (string) => UUID_PATTERN.test(string)
 const isFiftyCharsOrLess = (string) => string.length <= 50
-export const createInitialState = (initialValues = defaultInitialValues) => {
+export const createInitialState = (
+    providedInitialValues = defaultInitialValues
+) => {
+    // Prevent undefined values
+    const initialValues = Object.entries(providedInitialValues).reduce(
+        (acc, [key, value]) => {
+            acc[key] =
+                typeof value === 'undefined' ? defaultInitialValues[key] : value
+            return acc
+        },
+        {}
+    )
+    for (const key in initialValues) {
+        if (typeof initialValues[key] === 'undefined') {
+            initialValues[key] = defaultInitialValues[key]
+        }
+    }
     const isSupersetEmbedIdValid = isValidUuid(initialValues.supersetEmbedId)
 
     return {

--- a/src/modules/useSupersetDashboardFieldsState.js
+++ b/src/modules/useSupersetDashboardFieldsState.js
@@ -7,7 +7,7 @@ export const FIELD_NAME_SUPERSET_EMBED_ID = 'supersetEmbedId'
 export const FIELD_NAME_SHOW_CHART_CONTROLS = 'showChartControls'
 export const FIELD_NAME_EXPAND_FILTERS = 'expandFilters'
 
-export const defaultInitialValues = {
+const defaultInitialValues = {
     [FIELD_NAME_TITLE]: '',
     [FIELD_NAME_CODE]: '',
     [FIELD_NAME_DESCRIPTION]: '',
@@ -15,17 +15,15 @@ export const defaultInitialValues = {
     [FIELD_NAME_SHOW_CHART_CONTROLS]: true,
     [FIELD_NAME_EXPAND_FILTERS]: false,
 }
-export const FIELD_CHANGE = 'FIELD_CHANGE'
-export const SUPERSET_FIELD_BLUR = 'SUPERSET_FIELD_BLUR'
-export const RESET_FIELD_STATE = 'RESET_FIELD_STATE'
+const FIELD_CHANGE = 'FIELD_CHANGE'
+const SUPERSET_FIELD_BLUR = 'SUPERSET_FIELD_BLUR'
+const RESET_FIELD_STATE = 'RESET_FIELD_STATE'
 // Adapted from :https://github.com/uuidjs/uuid/blob/main/src/regex.ts
 const UUID_PATTERN =
     /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
-export const isValidUuid = (string) => UUID_PATTERN.test(string)
+const isValidUuid = (string) => UUID_PATTERN.test(string)
 const isFiftyCharsOrLess = (string) => string.length <= 50
-export const createInitialState = (
-    providedInitialValues = defaultInitialValues
-) => {
+const createInitialState = (providedInitialValues = defaultInitialValues) => {
     // Prevent undefined values
     const initialValues = Object.entries(providedInitialValues).reduce(
         (acc, [key, value]) => {
@@ -48,7 +46,7 @@ export const createInitialState = (
     }
 }
 
-export const reducer = (state, { type, payload }) => {
+const reducer = (state, { type, payload }) => {
     switch (type) {
         case FIELD_CHANGE: {
             const values = {

--- a/src/modules/useSupersetDashboardFieldsState.js
+++ b/src/modules/useSupersetDashboardFieldsState.js
@@ -25,10 +25,12 @@ const isValidUuid = (string) => UUID_PATTERN.test(string)
 const isFiftyCharsOrLess = (string) => string.length <= 50
 const createInitialState = (providedInitialValues = defaultInitialValues) => {
     // Prevent undefined values
-    const initialValues = Object.entries(providedInitialValues).reduce(
-        (acc, [key, value]) => {
+    const initialValues = Object.entries(defaultInitialValues).reduce(
+        (acc, [key, defaultValue]) => {
             acc[key] =
-                typeof value === 'undefined' ? defaultInitialValues[key] : value
+                typeof providedInitialValues[key] === 'undefined'
+                    ? defaultValue
+                    : providedInitialValues[key]
             return acc
         },
         {}

--- a/src/modules/useSupersetDashboardFieldsState.js
+++ b/src/modules/useSupersetDashboardFieldsState.js
@@ -35,11 +35,6 @@ export const createInitialState = (
         },
         {}
     )
-    for (const key in initialValues) {
-        if (typeof initialValues[key] === 'undefined') {
-            initialValues[key] = defaultInitialValues[key]
-        }
-    }
     const isSupersetEmbedIdValid = isValidUuid(initialValues.supersetEmbedId)
 
     return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4001,6 +4001,14 @@
     lodash "^4.17.21"
     redent "^3.0.0"
 
+"@testing-library/react-hooks@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
+  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    react-error-boundary "^3.1.0"
+
 "@testing-library/react@^12":
   version "12.1.5"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.5.tgz#bb248f72f02a5ac9d949dea07279095fa577963b"
@@ -15411,6 +15419,13 @@ react-draggable@^4.0.0, react-draggable@^4.0.3:
   dependencies:
     clsx "^1.1.1"
     prop-types "^15.8.1"
+
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-error-overlay@^6.0.11:
   version "6.0.11"


### PR DESCRIPTION
Implements [DHIS2-19266](https://dhis2.atlassian.net/browse/DHIS2-19266)

---

### Key features

1. When creating the initial state, ensure the `values` and `initialValues` do not contain properties that are `undefined`

---

### Description

The error we were seeing when opening the modal was caused by the fact that a dashboard did not have a code. So the `initialValues` object provided to `createInitialState` was not undefined itself, but one of its properties did have a value of `undefined`. The validation logic was assuming each property would default to the value defined in the `defaultInitialValues` object, but this was the case.

In this fix I chose to implement a generic fix that scans all `initialValues` properties and if an `undefined` value is encountered, it falls back to the default. IMO this preferable over making the validation logic more flexible, or implementing a fix specific to the `code` field. 

---


[DHIS2-19266]: https://dhis2.atlassian.net/browse/DHIS2-19266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ