### PR TITLE
chore: accept both 201 and 204 http status codes in response

### DIFF
--- a/cypress/e2e_cucumber/dashboard_filter/create_dashboard.js
+++ b/cypress/e2e_cucumber/dashboard_filter/create_dashboard.js
@@ -19,7 +19,7 @@ When('I add items and save', () => {
     // first install a custom app
     cy.request('POST', `${getApiBaseUrl()}/api/appHub/${customApp.id}`).then(
         (response) => {
-            expect(response.status).to.eq(204)
+            expect(response.status).to.be.oneOf([204, 201])
 
             //add the dashboard title
             cy.get('[data-test="dashboard-title-input"]').type(


### PR DESCRIPTION
The behaviour of the `/appHub` resource has changed in v42, and as a result one of our tests started to fail consistently. I am now accepting both `201` and `204` as a valid http status code in the response.