### PR TITLE
fix: ensure widgets work with global shell (DHIS2-19276)

### DIFF
--- a/src/components/Item/AppItem/__tests__/__snapshots__/Item.spec.js.snap
+++ b/src/components/Item/AppItem/__tests__/__snapshots__/Item.spec.js.snap
@@ -138,7 +138,7 @@ exports[`renders a valid widget AppItem 1`] = `
     class="content"
   >
     <iframe
-      src="https://iframe/app/widget/scorecard?dashboardItemId=applejack"
+      src="https://iframe/app/widget/scorecard?redirect=false&dashboardItemId=applejack"
       title="Scorecard"
     />
   </div>
@@ -163,7 +163,7 @@ exports[`renders a valid widget AppItem when in slideshow 1`] = `
     class="content"
   >
     <iframe
-      src="https://iframe/app/widget/scorecard?dashboardItemId=applejack"
+      src="https://iframe/app/widget/scorecard?redirect=false&dashboardItemId=applejack"
       title="Scorecard"
     />
   </div>
@@ -196,7 +196,7 @@ exports[`renders a valid widget AppItem with title in edit mode irrespective of 
     class="content"
   >
     <iframe
-      src="https://iframe/app/widget/scorecard?dashboardItemId=twilightsparkle"
+      src="https://iframe/app/widget/scorecard?redirect=false&dashboardItemId=twilightsparkle"
       title="Scorecard but hide the title"
     />
   </div>
@@ -219,7 +219,7 @@ exports[`renders a valid widget AppItem without title in view mode if specified 
     class="content hiddenTitle"
   >
     <iframe
-      src="https://iframe/app/widget/scorecard?dashboardItemId=twilightsparkle"
+      src="https://iframe/app/widget/scorecard?redirect=false&dashboardItemId=twilightsparkle"
       title="Scorecard but hide the title"
     />
   </div>

--- a/src/components/Item/AppItem/__tests__/getIframeSrc.spec.js
+++ b/src/components/Item/AppItem/__tests__/getIframeSrc.spec.js
@@ -2,7 +2,7 @@ import { getIframeSrc } from '../getIframeSrc.js'
 
 const appDetails = { launchUrl: 'debug/dev' }
 const dashboardItem = { id: 'rainbowdashitem' }
-const expectedSrc = `${appDetails.launchUrl}?dashboardItemId=${dashboardItem.id}`
+const expectedSrc = `${appDetails.launchUrl}?redirect=false&dashboardItemId=${dashboardItem.id}`
 
 describe('getIframeSrc', () => {
     it('no ou filter', () => {

--- a/src/components/Item/AppItem/getIframeSrc.js
+++ b/src/components/Item/AppItem/getIframeSrc.js
@@ -12,7 +12,7 @@ export const getIframeSrc = (item, itemFilters, appDetails = {}) => {
 
         return appDetails.pluginLaunchUrl
     } else {
-        let iframeSrc = `${appDetails.launchUrl}?dashboardItemId=${item.id}`
+        let iframeSrc = `${appDetails.launchUrl}?redirect=false&dashboardItemId=${item.id}`
 
         if (itemFilters[FILTER_ORG_UNIT]?.length) {
             const ouIds = itemFilters[FILTER_ORG_UNIT].map(({ id, path }) =>


### PR DESCRIPTION
Fixes [DHIS2-19276](https://dhis2.atlassian.net/browse/DHIS2-19276)

---

### Key features

1. ensure widgets work with global shell

---

### Description

`redirect=false` is needed for dashboard widgets in order to load correctly.
Without it the global shell redirects the `api/apps` URL to `apps` causing the iframe content to fail to load.

---

### Screenshots

Before:
<img width="400" alt="Screenshot 2025-03-28 at 15 35 42" src="https://github.com/user-attachments/assets/bdda22a7-de72-4ec8-acad-ee7b4409d581" />

After:
<img width="398" alt="Screenshot 2025-03-28 at 15 35 28" src="https://github.com/user-attachments/assets/dfa717e0-fddd-435c-a7df-37d559c0ee2d" />



[DHIS2-19276]: https://dhis2.atlassian.net/browse/DHIS2-19276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ