### PR TITLE
chore: support both '2.41' and '41' when parsing version string to in…

### DIFF
--- a/cypress/e2e/superset_dashboard.cy.js
+++ b/cypress/e2e/superset_dashboard.cy.js
@@ -28,12 +28,10 @@ const getInputByLabelText = (labelText, inputTag = 'input') =>
 describe('Creating, viewing, editing and deleting an embedded superset dashboard', function () {
     before(function () {
         // Skip this test if the DHIS2 Core version is below 42
-        console.log(
-            'AAAAAAAAAAAAAAAA',
-            Cypress.env('dhis2InstanceVersion'),
-            typeof Cypress.env('dhis2InstanceVersion')
-        )
-        console.log('BBBBBBBBBBBBBBBB', Cypress.env())
+        const versionString = Cypress.env('dhis2InstanceVersion')
+        expect(typeof versionString).to.be('string')
+        expect(versionString).to.be('2.41')
+        expect(typeof versionString.split).to.be('function')
         const version = parseInt(
             // Support both '2.41' and '41'
             Cypress.env('dhis2InstanceVersion').split('.').pop()

--- a/cypress/e2e/superset_dashboard.cy.js
+++ b/cypress/e2e/superset_dashboard.cy.js
@@ -29,9 +29,9 @@ describe('Creating, viewing, editing and deleting an embedded superset dashboard
     before(function () {
         // Skip this test if the DHIS2 Core version is below 42
         const versionString = Cypress.env('dhis2InstanceVersion')
-        expect(typeof versionString).to.be('string')
-        expect(versionString).to.be('2.41')
-        expect(typeof versionString.split).to.be('function')
+        expect(typeof versionString).to.equal('string')
+        expect(versionString).to.equal('2.41')
+        expect(typeof versionString.split).to.equal('function')
         const version = parseInt(
             // Support both '2.41' and '41'
             Cypress.env('dhis2InstanceVersion').split('.').pop()

--- a/cypress/e2e/superset_dashboard.cy.js
+++ b/cypress/e2e/superset_dashboard.cy.js
@@ -28,7 +28,10 @@ const getInputByLabelText = (labelText, inputTag = 'input') =>
 describe('Creating, viewing, editing and deleting an embedded superset dashboard', function () {
     before(function () {
         // Skip this test if the DHIS2 Core version is below 42
-        const version = parseInt(Cypress.env('dhis2InstanceVersion'))
+        const version = parseInt(
+            // Support both '2.41' and '41'
+            Cypress.env('dhis2InstanceVersion').split('.').pop()
+        )
         if (version < 42) {
             this.skip()
         }

--- a/cypress/e2e/superset_dashboard.cy.js
+++ b/cypress/e2e/superset_dashboard.cy.js
@@ -1,5 +1,5 @@
 import { newButtonSel } from '../elements/viewDashboard.js'
-import { EXTENDED_TIMEOUT } from '../support/utils.js'
+import { EXTENDED_TIMEOUT, parseVersionFromEnvToInt } from '../support/utils.js'
 
 const SUPERSET_BASE_URL = 'https://superset-test.dhis2.org'
 const NAME = 'My new dashboard'
@@ -28,14 +28,12 @@ const getInputByLabelText = (labelText, inputTag = 'input') =>
 describe('Creating, viewing, editing and deleting an embedded superset dashboard', function () {
     before(function () {
         // Skip this test if the DHIS2 Core version is below 42
-        const versionString = Cypress.env('dhis2InstanceVersion')
-        expect(typeof versionString).to.equal('string')
-        expect(versionString).to.equal('2.41')
-        expect(typeof versionString.split).to.equal('function')
-        const version = parseInt(
-            // Support both '2.41' and '41'
-            Cypress.env('dhis2InstanceVersion').split('.').pop()
-        )
+        const version = parseVersionFromEnvToInt()
+
+        expect(typeof version).to.equal('number')
+        expect(Number.isInteger(version)).to.equal(true)
+        expect(version).to.be.within(39, 100)
+
         if (version < 42) {
             this.skip()
         }

--- a/cypress/e2e/superset_dashboard.cy.js
+++ b/cypress/e2e/superset_dashboard.cy.js
@@ -28,6 +28,12 @@ const getInputByLabelText = (labelText, inputTag = 'input') =>
 describe('Creating, viewing, editing and deleting an embedded superset dashboard', function () {
     before(function () {
         // Skip this test if the DHIS2 Core version is below 42
+        console.log(
+            'AAAAAAAAAAAAAAAA',
+            Cypress.env('dhis2InstanceVersion'),
+            typeof Cypress.env('dhis2InstanceVersion')
+        )
+        console.log('BBBBBBBBBBBBBBBB', Cypress.env())
         const version = parseInt(
             // Support both '2.41' and '41'
             Cypress.env('dhis2InstanceVersion').split('.').pop()

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -56,3 +56,14 @@ export const goOnline = () => {
 export const createDashboardTitle = (prefix) => {
     return prefix + new Date().toUTCString().slice(-12, -4)
 }
+
+export const parseVersionFromEnvToInt = () => {
+    // could be '2.41', '41', 2.41 or 41
+    const numberOrString = Cypress.env('dhis2InstanceVersion')
+    // could be '2.41' or '41'
+    const str = String(numberOrString)
+    // '41'
+    const minor = str.split('.').pop()
+    // 41
+    return parseInt(minor)
+}


### PR DESCRIPTION
*No issue available*

It turned out that the embedded dashboards e2e test was not running despite of the fact that we are now testing against v42. The reason for this was that the `dhis2InstanceVersion` env variable had a different value than expected. The initial logic was too naive, it assumed it would always be the string representation of an integer. We quickly realised that a common case would be the a `'2.xx'` formatted string. And further along the line we realised that somewhere along the line the text from a `.yml` file was also being interpreted as a number.

---

### Key features

1. Now correctly handles various formats of `dhis2InstanceVersion`: `'#.##'`, `'##'`, `#.##` and `##` are all supported via a reusable helper
2. Since this variable is used to conditionally skip a set of tests it is important that it has been interpreted correctly. And for this I have added some additional assertions.

---

### Note

The reason we are using this "custom logic" to skip tests for particular versions is ultimately because of the fact that the Cypress Cucumber and the Tagify plugin don't get along. Once the test suite has been ported to "plain Cypress" we should simply use the version tags feature we use elsewhere to skip these tests for lower versions.

---

### TODO

- [x] Tests added (Cypress and/or Jest) (yes the assertions)
- [x] Docs added (N/A)
- [x] Tested with and without the global shell (N/A)
- [x] d2-ci dependency replaced (N/A)

---

### Screenshots

_Before: execution time 0s, all remain pending_
![image](https://github.com/user-attachments/assets/568afa55-8e97-4ae2-bba2-7ef6db52aa00)


_After: tests have passed and took 20 seconds to complete_
<img width="743" alt="Screenshot 2025-04-14 at 17 23 03" src="https://github.com/user-attachments/assets/42d2ebef-84de-4d99-92f5-d8fd6b3f79fd" />
