### PR TITLE
fix: use correct icon for Line List items in item selector (DHIS2-18470)

### DIFF
--- a/src/modules/itemTypes.js
+++ b/src/modules/itemTypes.js
@@ -5,6 +5,7 @@ import {
     IconEmptyFrame24,
     IconFileDocument24,
     IconLink24,
+    IconVisualizationLinelist24,
     IconMail24,
     IconQuestion24,
     IconTable24,
@@ -248,8 +249,9 @@ export const getItemIcon = (type) => {
             return IconFileDocument24
         case CHART:
         case EVENT_CHART:
-        case EVENT_VISUALIZATION:
             return IconVisualizationColumn24
+        case EVENT_VISUALIZATION:
+            return IconVisualizationLinelist24
         case MAP:
             return IconWorld24
         case APP:


### PR DESCRIPTION
Implements [DHIS2-18470](https://dhis2.atlassian.net/browse/DHIS2-18470)

---

### Key features

1. use correct icon for LL items in item selector

---

### Description

The icon used for LL items in the dashboard's item selector was wrong.

---

### TODO

- [ ] Tests added (Cypress and/or Jest) N/A
- [ ] Docs added N/A
- [ ] d2-ci dependency replaced N/A
- [x] Tester approved (Jennifer)

---

### Screenshots

Before:
<img width="713" alt="Screenshot 2025-04-22 at 15 49 56" src="https://github.com/user-attachments/assets/1251d048-8d26-4852-8b7c-f76cb20a4b60" />

After:
<img width="705" alt="Screenshot 2025-04-22 at 15 50 36" src="https://github.com/user-attachments/assets/b0ed9ef1-d392-468f-a9d0-cec12d2036f7" />



[DHIS2-18470]: https://dhis2.atlassian.net/browse/DHIS2-18470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ