### PR TITLE
docs: fix typo in dashboard plugin docs

### DIFF
--- a/docs/developer/implement-a-dashboard-plugin.md
+++ b/docs/developer/implement-a-dashboard-plugin.md
@@ -100,7 +100,7 @@ The props from the Dashboard app are passed as React props to the component that
 ```js title="src/Plugin.tsx"
 const DashboardPlugin = ({
     dashboardItemId,
-    dashboardItemFilter,
+    dashboardItemFilters,
     dashboardMode,
     setDashboardItemDetails,
 }) => {


### PR DESCRIPTION
The prop name referenced in this example should be plural, not singular