### PR TITLE
fix: use data output period types (DHIS2-21128)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "license": "BSD-3-Clause",
     "dependencies": {
-        "@dhis2/analytics": "29.0.2",
+        "@dhis2/analytics": "^29.3.2",
         "@dhis2/app-runtime": "^3.14.4",
         "@dhis2/d2-i18n": "^1.1.3",
         "@dhis2/ui": "^10.7.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1919,10 +1919,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@29.0.2":
-  version "29.0.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-29.0.2.tgz#15cf773d9d9291097442a6f290b89815cd319bf6"
-  integrity sha512-+kCsaufJMcto0zbaEkyGFd/KK6unCKsEd33bRTFtA3h3mhxu83/yL+6GkYeWAJfGhG/mOjIBDD2anzOUrwlZkw==
+"@dhis2/analytics@^29.3.2":
+  version "29.3.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-29.3.2.tgz#9cd598d5542a7c2885e58506059566d884476818"
+  integrity sha512-EKZ2uHxpaDsore+fYsswclTLhOgn2iJUDZ05hSGNg8LxW53dqECN2JWgFsG54FVeZ9+lYFJkrFxpsc7mcjdkfg==
   dependencies:
     "@dhis2/multi-calendar-dates" "^1.2.2"
     "@dnd-kit/core" "^6.0.7"


### PR DESCRIPTION
Implements [DHIS2-21128](https://dhis2.atlassian.net/browse/DHIS2-21128)

Use the latest period selector from analytics which supports data output period types and custom labels.

### Screenshots

<img width="1024" height="719" alt="Screenshot_2026-03-14_17-49-32" src="https://github.com/user-attachments/assets/94f69777-f47a-4082-a8e4-bbaf0b7514cd" />

<img width="970" height="538" alt="Screenshot_2026-03-14_17-53-27" src="https://github.com/user-attachments/assets/c8f90060-7653-414d-9c56-263f4ad5e526" />

[DHIS2-21128]: https://dhis2.atlassian.net/browse/DHIS2-21128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ