### PR TITLE
chore: check tasklist without posting commit status

### DIFF
--- a/.github/workflows/check-tasklist.yml
+++ b/.github/workflows/check-tasklist.yml
@@ -9,6 +9,11 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check for incomplete task list items
-              uses: Shopify/task-list-checker@main
-              with:
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
+              env:
+                  PR_BODY: ${{ github.event.pull_request.body }}
+              run: |
+                  if printf '%s' "$PR_BODY" | grep -nE '^[[:space:]]*[-*+] \[ \]'; then
+                      echo "::error::The pull request description contains unchecked task list items (see above). Complete them, or remove the items that do not apply."
+                      exit 1
+                  fi
+                  echo "No unchecked task list items found."


### PR DESCRIPTION
## Problem

`.github/workflows/check-tasklist.yml` used `Shopify/task-list-checker@main`, which reports its result by posting a **commit status**. That needs `statuses: write`, but `GITHUB_TOKEN` is forced read-only for `pull_request` events from forks, so the job failed on every fork PR (e.g. #3340):

```
RequestError [HttpError]: Resource not accessible by integration
status: 403
url: .../repos/dhis2/dashboard-app/statuses/3a4a3e84...
'x-accepted-github-permissions': 'statuses=write'
```

Adding `permissions: { statuses: write }` would only fix same-repo PRs — a fork's token cannot be granted write access.

## Change

Replaced the action with an inline step that reads `github.event.pull_request.body` and `exit 1`s if it contains unchecked checklist items (`- [ ]`). The job status itself is the signal, so no write permissions are needed and forks behave identically.

- The body is passed via an `env:` var rather than interpolated into the script, to avoid shell injection from PR descriptions.
- `- `, `* ` and `+ ` list markers are all matched, at any indentation.
- Unchecked items are printed with line numbers, plus an `::error::` annotation.
- `if: github.actor != 'dependabot[bot]'` kept as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)